### PR TITLE
Handling when Light isn't set

### DIFF
--- a/Assets/Runtime/CanvasShadow.cs
+++ b/Assets/Runtime/CanvasShadow.cs
@@ -47,11 +47,18 @@ public class CanvasShadow : MonoBehaviour
     {
         _casterRectTransform = transform.parent.gameObject.GetComponent<RectTransform>();
         _shadowRectTransform = GetComponent<RectTransform>();
-        _lightTransform = Light.transform;
+
+        if (Light != null)
+        {
+            _lightTransform = Light.transform;
+        }
     }
 
     private void UpdateShadow()
     {
+        if (_lightTransform == null)
+            return;
+
         Vector3 shadowLocalPosition = _casterRectTransform.localPosition;
         shadowLocalPosition.z = -_casterRectTransform.localPosition.z + BackingOffset;
         _shadowRectTransform.localPosition = shadowLocalPosition;


### PR DESCRIPTION
Since Light is only used for realtime or manual shadow updates it often doesn't need to be set for static shadows (especially in prefab instances)