### PR TITLE
Explicit Acrylic Resource Destruction

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicBlurFeature.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicBlurFeature.cs
@@ -68,6 +68,11 @@ namespace Microsoft.MixedReality.GraphicsTools
             blurFilter = _blurFilter;
         }
 
+        public AcrylicFilterDual GetBlurMethod()
+        {
+            return blurFilter;
+        }
+
         public override void Create()
         {
             pass = new AcrylicBlurRenderPass(name, downSample, blur, blurMaterial, textureName, applyBlur, providedTexture, blurFilter);

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicFilterDual.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicFilterDual.cs
@@ -32,11 +32,6 @@ namespace Microsoft.MixedReality.GraphicsTools
             buffers = new List<RenderTexture>();
         }
 
-        ~AcrylicFilterDual()
-        {
-            FreeBuffers();
-        }
-
         public void QueueBlur(CommandBuffer cmd, RenderTexture image, int iterations)
         {
             if (image.width != lastWidth || image.height != lastHeight || iterations != lastIterations)
@@ -79,6 +74,14 @@ namespace Microsoft.MixedReality.GraphicsTools
             Graphics.ExecuteCommandBuffer(cmd);
             Profiler.EndSample();
         }
+        public void FreeBuffers()
+        {
+            for (int i = 0; i < buffers.Count; i++)
+            {
+                Object.Destroy(buffers[i]);
+            }
+            buffers.Clear();
+        }
 
         private void InitBuffers(int width, int height, int iterations)
         {
@@ -90,15 +93,6 @@ namespace Microsoft.MixedReality.GraphicsTools
                 nextWidth = (nextWidth + 1) / 2;
                 nextHeight = (nextHeight + 1) / 2;
             }
-        }
-
-        private void FreeBuffers()
-        {
-            for (int i = 0; i < buffers.Count; i++)
-            {
-                Object.Destroy(buffers[i]);
-            }
-            buffers.Clear();
         }
 
         private void LocalBlit(CommandBuffer cmd, RenderTexture source, RenderTexture target, Material material, int pass)

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicLayer.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicLayer.cs
@@ -166,26 +166,36 @@ namespace Microsoft.MixedReality.GraphicsTools
         public void RemoveLayerRendererFeatures(ForwardRendererData rendererData)
 #endif
         {
-            if (rendererData == null) return;
-
-            rendererData.rendererFeatures.Remove(blur);
-
-            if (renderOpaque != null)
+            if (blur != null)
             {
-                LayerMask opaqueMask = rendererData.opaqueLayerMask;
-                rendererData.rendererFeatures.Remove(renderOpaque);
-                opaqueMask |= settings.renderLayers;
-                rendererData.opaqueLayerMask = opaqueMask;
-            }
-            if (renderTransparent != null)
-            {
-                LayerMask transparentMask = rendererData.transparentLayerMask;
-                rendererData.rendererFeatures.Remove(renderTransparent);
-                transparentMask |= settings.renderLayers;
-                rendererData.transparentLayerMask = transparentMask;
+                AcrylicFilterDual blurMethod = blur.GetBlurMethod();
+                if (blurMethod != null)
+                {
+                    blurMethod.FreeBuffers();
+                }
             }
 
-            rendererData.SetDirty();
+            if (rendererData != null)
+            {
+                rendererData.rendererFeatures.Remove(blur);
+
+                if (renderOpaque != null)
+                {
+                    LayerMask opaqueMask = rendererData.opaqueLayerMask;
+                    rendererData.rendererFeatures.Remove(renderOpaque);
+                    opaqueMask |= settings.renderLayers;
+                    rendererData.opaqueLayerMask = opaqueMask;
+                }
+                if (renderTransparent != null)
+                {
+                    LayerMask transparentMask = rendererData.transparentLayerMask;
+                    rendererData.rendererFeatures.Remove(renderTransparent);
+                    transparentMask |= settings.renderLayers;
+                    rendererData.transparentLayerMask = transparentMask;
+                }
+
+                rendererData.SetDirty();
+            }
         }
 
         public void SwapRenderTargets()


### PR DESCRIPTION
## Overview
Removes the AcrylicFilterDual destructor. Destructors should not be used to clean-up Unity objects. FreeBuffers is now public and called when render features are removed from the acrylic layer system.

## Changes
- Fixes the below exception from Microsoft.MixedReality.GraphicsTools.AcrylicFilterDual.Finalize:
`Unhandled log message: '[Exception] UnityException: Destroy can only be called from the main thread.\r\nConstructors and field initializers will be executed from the loading thread when loading a scene.\r\nDon't use this function in the constructor or field initializers, instead move initialization code to the Awake or Start function.`


## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
