### PR TITLE
Fixing potential artifacts in edge anti-aliasing method

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsCommon.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsCommon.hlsl
@@ -131,8 +131,9 @@ inline float GTPointVsRoundedBox(in float2 position, in float2 cornerCircleDista
 
 inline float FilterDistance(in float distance)
 {
-    float filterWidth = fwidth(distance);
-    return smoothstep(filterWidth, -filterWidth, distance);
+    float2 filterWidth = length(float2(ddx(distance), ddy(distance)));
+    float pixelDistance = distance / length(filterWidth);
+    return saturate(0.5 - pixelDistance);
 }
 
 inline float GTRoundCornersSmooth(in float2 position, in float2 cornerCircleDistance, in float cornerCircleRadius, in float smoothingValue)


### PR DESCRIPTION
## Overview
On certain platforms the `FilterDistance` method could result in "holes" at the center of SDF shapes when using automatic edge smoothing. This is now fixed.

## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
