### PR TITLE
Adding configurable alpha channel blending options

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/BaseShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/BaseShaderGUI.cs
@@ -48,6 +48,8 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             public static string customRenderingModeName = "_CustomMode";
             public static string sourceBlendName = "_SrcBlend";
             public static string destinationBlendName = "_DstBlend";
+            public static string sourceBlendAlphaName = "_SrcBlendAlpha";
+            public static string destinationBlendAlphaName = "_DstBlendAlpha";
             public static string blendOperationName = "_BlendOp";
             public static string depthTestName = "_ZTest";
             public static string depthWriteName = "_ZWrite";
@@ -68,8 +70,10 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             public static readonly string[] blendModeNames = Enum.GetNames(typeof(BlendMode));
             public static readonly string[] depthTestNames = Enum.GetNames(typeof(CompareFunction));
             public static readonly string[] depthWriteNames = Enum.GetNames(typeof(DepthWrite));
-            public static GUIContent sourceBlend = new GUIContent("Source Blend", "Blend Mode of Newly Calculated Color");
-            public static GUIContent destinationBlend = new GUIContent("Destination Blend", "Blend Mode of Existing Color");
+            public static GUIContent sourceBlend = new GUIContent("Source Blend", "Blend Mode of Newly Calculated Color (RGB)");
+            public static GUIContent destinationBlend = new GUIContent("Destination Blend", "Blend Mode of Existing Color (RGB)");
+            public static GUIContent sourceBlendAlpha = new GUIContent("Source Blend Alpha", "Blend Mode of Newly Calculated Alpha Channel (A)");
+            public static GUIContent destinationBlendAlpha = new GUIContent("Destination Blend Alpha", "Blend Mode of Existing Alpha Channel (A)");
             public static GUIContent blendOperation = new GUIContent("Blend Operation", "Operation for Blending New Color With Existing Color");
             public static GUIContent depthTest = new GUIContent("Depth Test", "How Should Depth Testing Be Performed.");
             public static GUIContent depthWrite = new GUIContent("Depth Write", "Controls Whether Pixels From This Material Are Written to the Depth Buffer");
@@ -86,6 +90,8 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         protected MaterialProperty customRenderingMode;
         protected MaterialProperty sourceBlend;
         protected MaterialProperty destinationBlend;
+        protected MaterialProperty sourceBlendAlpha;
+        protected MaterialProperty destinationBlendAlpha;
         protected MaterialProperty blendOperation;
         protected MaterialProperty depthTest;
         protected MaterialProperty depthWrite;
@@ -124,6 +130,8 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             customRenderingMode = FindProperty(BaseStyles.customRenderingModeName, props);
             sourceBlend = FindProperty(BaseStyles.sourceBlendName, props);
             destinationBlend = FindProperty(BaseStyles.destinationBlendName, props);
+            sourceBlendAlpha = FindProperty(BaseStyles.sourceBlendAlphaName, props);
+            destinationBlendAlpha = FindProperty(BaseStyles.destinationBlendAlphaName, props);
             blendOperation = FindProperty(BaseStyles.blendOperationName, props);
             depthTest = FindProperty(BaseStyles.depthTestName, props, false);
             depthWrite = FindProperty(BaseStyles.depthWriteName, props);
@@ -195,6 +203,8 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                 customRenderingMode.floatValue = EditorGUILayout.Popup(customRenderingMode.displayName, (int)customRenderingMode.floatValue, BaseStyles.renderingModeNames);
                 materialEditor.ShaderProperty(sourceBlend, BaseStyles.sourceBlend);
                 materialEditor.ShaderProperty(destinationBlend, BaseStyles.destinationBlend);
+                materialEditor.ShaderProperty(sourceBlendAlpha, BaseStyles.sourceBlendAlpha);
+                materialEditor.ShaderProperty(destinationBlendAlpha, BaseStyles.destinationBlendAlpha);
                 materialEditor.ShaderProperty(blendOperation, BaseStyles.blendOperation);
                 materialEditor.ShaderProperty(depthTest, BaseStyles.depthTest);
                 depthWrite.floatValue = EditorGUILayout.Popup(depthWrite.displayName, (int)depthWrite.floatValue, BaseStyles.depthWriteNames);

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/TextMeshProShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/TextMeshProShaderGUI.cs
@@ -49,6 +49,20 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                 {
                     destinationBlend.floatValue = EditorGUILayout.Popup(destinationBlend.displayName, (int)destinationBlend.floatValue, BaseShaderGUI.BaseStyles.blendModeNames);
                 }
+
+                var sourceBlendAlpha = FindProperty(BaseShaderGUI.BaseStyles.sourceBlendAlphaName, m_Properties, false);
+
+                if (sourceBlendAlpha != null)
+                {
+                    sourceBlendAlpha.floatValue = EditorGUILayout.Popup(sourceBlendAlpha.displayName, (int)sourceBlendAlpha.floatValue, BaseShaderGUI.BaseStyles.blendModeNames);
+                }
+
+                var destinationBlendAlpha = FindProperty(BaseShaderGUI.BaseStyles.destinationBlendAlphaName, m_Properties, false);
+
+                if (destinationBlendAlpha != null)
+                {
+                    destinationBlendAlpha.floatValue = EditorGUILayout.Popup(destinationBlendAlpha.displayName, (int)destinationBlendAlpha.floatValue, BaseShaderGUI.BaseStyles.blendModeNames);
+                }
             }
             GUI.enabled = true;
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Shaders/CanvasBackplateAcrylic.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Shaders/CanvasBackplateAcrylic.shader
@@ -70,6 +70,8 @@ Properties {
     [Header(Blending)]
         [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
         [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0  // "Zero"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
 
     [Header(Stencil)]
         _StencilReference("Stencil Reference", Range(0, 255)) = 0
@@ -87,7 +89,7 @@ Properties {
 
 SubShader {
     Tags{ "RenderType" = "Opaque" }
-    Blend[_SrcBlend][_DstBlend]
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
     Tags {"DisableBatching" = "True"}
     Stencil
     {

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBackplate.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBackplate.shader
@@ -55,6 +55,8 @@ Properties {
     [Header(Blending)]
         [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
         [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0  // "Zero"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
 
     [Header(Stencil)]
         _StencilReference("Stencil Reference", Range(0, 255)) = 0
@@ -72,7 +74,7 @@ Properties {
 
 SubShader {
     Tags{ "RenderType" = "Opaque" }
-    Blend[_SrcBlend][_DstBlend]
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
     Tags {"DisableBatching" = "True"}
     Stencil
     {

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasProgressBar.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasProgressBar.shader
@@ -28,6 +28,8 @@ Properties {
     [Header(Blending)]
         [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
         [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 10  // "OneMinusSrcAlpha"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
 
     [Header(Stencil)]
         _StencilReference("Stencil Reference", Range(0, 255)) = 0
@@ -45,7 +47,7 @@ Properties {
 
 SubShader {
     Tags { "RenderType" = "Transparent" "Queue" = "Transparent" }
-    Blend[_SrcBlend][_DstBlend]
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
     ZWrite[_ZWrite]
     ZTest[_ZTest]
     Tags {"DisableBatching" = "True"}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasQuadGlow.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasQuadGlow.shader
@@ -23,6 +23,8 @@ Properties {
     [Header(Blending)]
         [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
         [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 10  // "OneMinusSrcAlpha"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
 
     [Header(Stencil)]
         _StencilReference("Stencil Reference", Range(0, 255)) = 0
@@ -40,7 +42,7 @@ Properties {
 
 SubShader {
     Tags{ "RenderType" = "AlphaTest" "Queue" = "AlphaTest"}
-    Blend[_SrcBlend][_DstBlend]
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
     ZWrite[_ZWrite]
     ZTest[_ZTest]
     Tags {"DisableBatching" = "True"}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasRadialSpinner.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasRadialSpinner.shader
@@ -31,6 +31,8 @@ Properties {
     [Header(Blending)]
         [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
         [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 10  // "OneMinusSrcAlpha"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
 
     [Header(Stencil)]
         _StencilReference("Stencil Reference", Range(0, 255)) = 0
@@ -48,7 +50,7 @@ Properties {
 
 SubShader {
     Tags { "RenderType" = "Transparent" "Queue" = "Transparent" }
-    Blend[_SrcBlend][_DstBlend]
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
     ZWrite[_ZWrite]
     ZTest[_ZTest]
     Tags {"DisableBatching" = "True"}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
@@ -115,6 +115,8 @@ Shader "Graphics Tools/Standard"
         [Enum(RenderingMode)] _CustomMode("Mode", Float) = 0                                         // "Opaque"
         [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                 // "One"
         [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0            // "Zero"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
         [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0                 // "Add"
         [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4                // "LessEqual"
         [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 1                                         // "On"
@@ -154,7 +156,7 @@ Shader "Graphics Tools/Standard"
             Name "Main"
             Tags{ "LightMode" = "UniversalForward" }
             LOD 100
-            Blend[_SrcBlend][_DstBlend]
+            Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
             BlendOp[_BlendOp]
             ZTest[_ZTest]
             ZWrite[_ZWrite]
@@ -219,7 +221,7 @@ Shader "Graphics Tools/Standard"
             Name "Main"
             Tags{ "LightMode" = "ForwardBase" }
             LOD 100
-            Blend[_SrcBlend][_DstBlend]
+            Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
             BlendOp[_BlendOp]
             ZTest[_ZTest]
             ZWrite[_ZWrite]

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvas.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvas.shader
@@ -115,6 +115,8 @@ Shader "Graphics Tools/Standard Canvas"
         [Enum(RenderingMode)] _CustomMode("Mode", Float) = 2                                      // "Fade"
         [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1              // "One"
         [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 10        // "OneMinusSrcAlpha"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
         [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0              // "Add"
         [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4             // "LessEqual"
         [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 0                                      // "Off"
@@ -160,7 +162,7 @@ Shader "Graphics Tools/Standard Canvas"
             Name "Main"
             Tags{ "LightMode" = "UniversalForward" }
             LOD 100
-            Blend[_SrcBlend][_DstBlend]
+            Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
             BlendOp[_BlendOp]
             ZTest[_ZTest]
             ZWrite[_ZWrite]
@@ -212,7 +214,7 @@ Shader "Graphics Tools/Standard Canvas"
             Name "Main"
             Tags{ "LightMode" = "ForwardBase" }
             LOD 100
-            Blend[_SrcBlend][_DstBlend]
+            Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
             BlendOp[_BlendOp]
             ZTest[_ZTest]
             ZWrite[_ZWrite]

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsTextMeshPro.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsTextMeshPro.shader
@@ -68,8 +68,10 @@ Properties {
     [Enum(DepthWrite)] _ZWrite                          ("Depth Write", Float) = 0     // Off
     [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4      // "LessEqual"
 
-    [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
-    [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 10 // "OneMinusSrcAlpha"
+    [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                 // "One"
+    [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 10           // "OneMinusSrcAlpha"
+    [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+    [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
 }
 
 SubShader {
@@ -95,7 +97,7 @@ SubShader {
     Lighting Off
     Fog { Mode Off }
     ZTest [_ZTest]
-    Blend[_SrcBlend][_DstBlend]
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
     ColorMask [_ColorMask]
 
     Pass {

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsWireframe.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsWireframe.shader
@@ -19,6 +19,8 @@ Shader "Graphics Tools/Wireframe"
         [Enum(RenderingMode)] _CustomMode("Mode", Float) = 0                                         // "Opaque"
         [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                 // "One"
         [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0            // "Zero"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
         [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0                 // "Add"
         [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4                // "LessEqual"
         [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 1                                         // "On"
@@ -35,7 +37,7 @@ Shader "Graphics Tools/Wireframe"
         Pass
         {
             Name "Main"
-            Blend[_SrcBlend][_DstBlend]
+            Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
             BlendOp[_BlendOp]
             ZTest[_ZTest]
             ZWrite[_ZWrite]


### PR DESCRIPTION
## Overview
Adds extra property to all materials which support alpha blending to control alpha channel blending independently from RGB blending. Defaults to one for the source factor alpha and destination factor alpha.
![image](https://user-images.githubusercontent.com/13305729/173458498-7bc4c171-5265-4957-8bd6-76271a7303b9.png)

## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
