### PR TITLE
Add Emissionmap in GrachicsToolsStandardShader

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -629,7 +629,9 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
 
             if (PropertyEnabled(enableEmission))
             {
+                EditorGUI.indentLevel += 2;
                 materialEditor.TexturePropertySingleLine(Styles.emissiveColor,emissiveMap, emissiveColor);
+                EditorGUI.indentLevel -= 2;
             }
 
             GUI.enabled = !PropertyEnabled(enableSSAA);

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -93,7 +93,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             public static readonly GUIContent normalMap = new GUIContent("Normal Map");
             public static readonly GUIContent enableEmission = new GUIContent("Emission", "Enable Emission");
             public static readonly GUIContent emissiveColor = new GUIContent("Color");
-            public static readonly GUIContent emissiveMap = new GUIContent("EmissiveMap");
+            public static readonly GUIContent emissiveMap = new GUIContent("EmissionMap");
             public static readonly GUIContent enableTriplanarMapping = new GUIContent("Triplanar Mapping", "Enable Triplanar Mapping, a technique which programmatically generates UV coordinates");
             public static readonly GUIContent enableLocalSpaceTriplanarMapping = new GUIContent("Local Space", "If True Triplanar Mapping is Calculated in Local Space");
             public static readonly GUIContent triplanarMappingBlendSharpness = new GUIContent("Blend Sharpness", "The Power of the Blend with the Normal");
@@ -629,8 +629,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
 
             if (PropertyEnabled(enableEmission))
             {
-                materialEditor.ShaderProperty(emissiveColor, Styles.emissiveColor, 2);
-                materialEditor.ShaderProperty(emissiveMap,Styles.emissiveMap);
+                materialEditor.TexturePropertySingleLine(Styles.emissiveColor,emissiveMap, emissiveColor);
             }
 
             GUI.enabled = !PropertyEnabled(enableSSAA);

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -452,6 +452,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             Texture normalMapTexture = material.HasProperty("_BumpMap") ? material.GetTexture("_BumpMap") : null;
             float? emission = null;
             Color? emissionColor = GetColorProperty(material, "_EmissionColor");
+            Texture emissionMapTexture = material.HasProperty("_EmissionMap") ? material.GetTexture("_EmissionMap") : null;
             float? reflections = null;
             float? rimLighting = null;
             Vector4? textureScaleOffset = null;
@@ -492,6 +493,11 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             if (normalMapTexture)
             {
                 material.SetTexture("_NormalMap", normalMapTexture);
+            }
+
+            if (emissionMapTexture)
+            {
+                material.SetTexture("_EmissiveMap", emissionMapTexture);
             }
 
             SetShaderFeatureActive(material, "_EMISSION", "_EnableEmission", emission);
@@ -630,7 +636,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             if (PropertyEnabled(enableEmission))
             {
                 EditorGUI.indentLevel += 2;
-                materialEditor.TexturePropertySingleLine(Styles.emissiveColor,emissiveMap, emissiveColor);
+                materialEditor.TexturePropertySingleLine(Styles.emissiveColor, emissiveMap, emissiveColor);
                 EditorGUI.indentLevel -= 2;
             }
 

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -93,6 +93,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             public static readonly GUIContent normalMap = new GUIContent("Normal Map");
             public static readonly GUIContent enableEmission = new GUIContent("Emission", "Enable Emission");
             public static readonly GUIContent emissiveColor = new GUIContent("Color");
+            public static readonly GUIContent emissiveMap = new GUIContent("EmissiveMap");
             public static readonly GUIContent enableTriplanarMapping = new GUIContent("Triplanar Mapping", "Enable Triplanar Mapping, a technique which programmatically generates UV coordinates");
             public static readonly GUIContent enableLocalSpaceTriplanarMapping = new GUIContent("Local Space", "If True Triplanar Mapping is Calculated in Local Space");
             public static readonly GUIContent triplanarMappingBlendSharpness = new GUIContent("Blend Sharpness", "The Power of the Blend with the Normal");
@@ -208,6 +209,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         protected MaterialProperty normalMap;
         protected MaterialProperty enableEmission;
         protected MaterialProperty emissiveColor;
+        protected MaterialProperty emissiveMap;
         protected MaterialProperty enableTriplanarMapping;
         protected MaterialProperty enableLocalSpaceTriplanarMapping;
         protected MaterialProperty triplanarMappingBlendSharpness;
@@ -322,6 +324,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             enableNormalMap = FindProperty("_EnableNormalMap", props);
             normalMap = FindProperty("_NormalMap", props);
             enableEmission = FindProperty("_EnableEmission", props);
+            emissiveMap = FindProperty("_EmissiveMap", props);
             emissiveColor = FindProperty("_EmissiveColor", props);
             enableTriplanarMapping = FindProperty("_EnableTriplanarMapping", props);
             enableLocalSpaceTriplanarMapping = FindProperty("_EnableLocalSpaceTriplanarMapping", props);
@@ -627,6 +630,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             if (PropertyEnabled(enableEmission))
             {
                 materialEditor.ShaderProperty(emissiveColor, Styles.emissiveColor, 2);
+                materialEditor.ShaderProperty(emissiveMap,Styles.emissiveMap);
             }
 
             GUI.enabled = !PropertyEnabled(enableSSAA);

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
@@ -25,6 +25,7 @@ Shader "Graphics Tools/Standard"
         _NormalMapScale("Scale", Float) = 1.0
         [Toggle(_EMISSION)] _EnableEmission("Enable Emission", Float) = 0.0
         [HDR]_EmissiveColor("Emissive Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _EmissiveMap("Emissive Map",2D)="white"{}
         [Toggle(_TRIPLANAR_MAPPING)] _EnableTriplanarMapping("Triplanar Mapping", Float) = 0.0
         [Toggle(_LOCAL_SPACE_TRIPLANAR_MAPPING)] _EnableLocalSpaceTriplanarMapping("Local Space", Float) = 0.0
         _TriplanarMappingBlendSharpness("Blend Sharpness", Range(1.0, 16.0)) = 4.0

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
@@ -25,7 +25,7 @@ Shader "Graphics Tools/Standard"
         _NormalMapScale("Scale", Float) = 1.0
         [Toggle(_EMISSION)] _EnableEmission("Enable Emission", Float) = 0.0
         [HDR]_EmissiveColor("Emissive Color", Color) = (0.0, 0.0, 0.0, 1.0)
-        _EmissiveMap("Emissive Map",2D)="white"{}
+        _EmissiveMap("Emissive Map",2D) = "white" {}
         [Toggle(_TRIPLANAR_MAPPING)] _EnableTriplanarMapping("Triplanar Mapping", Float) = 0.0
         [Toggle(_LOCAL_SPACE_TRIPLANAR_MAPPING)] _EnableLocalSpaceTriplanarMapping("Local Space", Float) = 0.0
         _TriplanarMappingBlendSharpness("Blend Sharpness", Range(1.0, 16.0)) = 4.0

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader.meta
@@ -2,7 +2,12 @@ fileFormatVersion: 2
 guid: c331f6c43a2ef0945864cb668f2653c9
 ShaderImporter:
   externalObjects: {}
-  defaultTextures: []
+  defaultTextures:
+  - _MainTex: {fileID: 10309, guid: 0000000000000000f000000000000000, type: 0}
+  - _ChannelMap: {instanceID: 0}
+  - _NormalMap: {instanceID: 0}
+  - _EmissiveMap: {instanceID: 0}
+  - _IridescentSpectrumMap: {instanceID: 0}
   nonModifiableTextures: []
   preprocessorOverride: 0
   userData: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader.meta
@@ -3,7 +3,7 @@ guid: c331f6c43a2ef0945864cb668f2653c9
 ShaderImporter:
   externalObjects: {}
   defaultTextures:
-  - _MainTex: {fileID: 10309, guid: 0000000000000000f000000000000000, type: 0}
+  - _MainTex: {instanceID: 0}
   - _ChannelMap: {instanceID: 0}
   - _NormalMap: {instanceID: 0}
   - _EmissiveMap: {instanceID: 0}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvas.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvas.shader
@@ -25,6 +25,7 @@ Shader "Graphics Tools/Standard Canvas"
         _NormalMapScale("Scale", Float) = 1.0
         [Toggle(_EMISSION)] _EnableEmission("Enable Emission", Float) = 0.0
         [HDR]_EmissiveColor("Emissive Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _EmissiveMap("Emissive Map",2D) = "white" {}
         [Toggle(_TRIPLANAR_MAPPING)] _EnableTriplanarMapping("Triplanar Mapping", Float) = 0.0
         [Toggle(_LOCAL_SPACE_TRIPLANAR_MAPPING)] _EnableLocalSpaceTriplanarMapping("Local Space", Float) = 0.0
         _TriplanarMappingBlendSharpness("Blend Sharpness", Range(1.0, 16.0)) = 4.0

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
@@ -103,6 +103,10 @@ SAMPLER(sampler_ChannelMap);
 TEXTURE2D(_NormalMap);
 SAMPLER(sampler_NormalMap);
 #endif
+#if defined(_EMISSION)
+TEXTURE2D(_EmissiveMap);
+SAMPLER(sampler_EmissiveMap);
+#endif
 #if defined(_IRIDESCENCE)
 TEXTURE2D(_IridescentSpectrumMap);
 SAMPLER(sampler_IridescentSpectrumMap);
@@ -124,6 +128,9 @@ sampler2D _ChannelMap;
 #endif
 #if defined(_NORMAL_MAP)
 sampler2D _NormalMap;
+#endif
+#if defined(_EMISSION)
+sampler2D _EmissiveMap;
 #endif
 #if defined(_IRIDESCENCE)
 sampler2D _IridescentSpectrumMap;

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
@@ -123,6 +123,7 @@ SAMPLER(sampler_blurTexture);
 #endif
 #else
 sampler2D _MainTex;
+sampler2D _EmissiveMap;
 #if defined(_CHANNEL_MAP)
 sampler2D _ChannelMap;
 #endif
@@ -130,7 +131,7 @@ sampler2D _ChannelMap;
 sampler2D _NormalMap;
 #endif
 #if defined(_EMISSION)
-sampler2D _EmissiveMap;
+//sampler2D _EmissiveMap;
 #endif
 #if defined(_IRIDESCENCE)
 sampler2D _IridescentSpectrumMap;

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
@@ -123,7 +123,6 @@ SAMPLER(sampler_blurTexture);
 #endif
 #else
 sampler2D _MainTex;
-sampler2D _EmissiveMap;
 #if defined(_CHANNEL_MAP)
 sampler2D _ChannelMap;
 #endif
@@ -131,7 +130,7 @@ sampler2D _ChannelMap;
 sampler2D _NormalMap;
 #endif
 #if defined(_EMISSION)
-//sampler2D _EmissiveMap;
+sampler2D _EmissiveMap;
 #endif
 #if defined(_IRIDESCENCE)
 sampler2D _IridescentSpectrumMap;

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardMetaProgram.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardMetaProgram.hlsl
@@ -78,6 +78,8 @@ half4 PixelStage(MetaVaryings input) : SV_Target
 #if defined(_EMISSION)
 #if defined(_CHANNEL_MAP)
     output.Emission = SAMPLE_TEXTURE2D(_ChannelMap, sampler_ChannelMap, input.uv) * _EmissiveColor;
+#else
+    output.Emission = SAMPLE_TEXTURE2D(_EmissiveMap, sampler_EmissiveMap, input.uv) * _EmissiveColor;
 #endif
 #endif
 
@@ -89,7 +91,7 @@ half4 PixelStage(MetaVaryings input) : SV_Target
 #if defined(_CHANNEL_MAP)
     output.Emission += tex2D(_ChannelMap, input.uv).b * _EmissiveColor;
 #else
-    output.Emission += _EmissiveColor;
+    output.Emission = tex2D(_EmissiveMap, input.uv) * _EmissiveColor;
 #endif
 #endif
     output.SpecularColor = _LightColor0.rgb;

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
@@ -466,6 +466,14 @@ half4 PixelStage(Varyings input, bool facing : SV_IsFrontFace) : SV_Target
 #endif 
 #endif
 
+#if defined(_EMISSION)
+#if defined(_URP)
+    half3 emissionMap = SAMPLE_TEXTURE2D(_EmissiveMap, sampler_EmissiveMap, input.uv);
+#else
+    half3 emissionMap = tex2D(_EmissiveMap, input.uv);
+#endif
+#endif
+    
     // Primitive clipping.
 #if defined(_CLIPPING_PRIMITIVE)
     float primitiveDistance = 1.0;
@@ -839,8 +847,10 @@ half4 PixelStage(Varyings input, bool facing : SV_IsFrontFace) : SV_Target
 #if defined(_EMISSION)
 #if defined(UNITY_COLORSPACE_GAMMA)
     half3 emission = _EmissiveColor.rgb;
+    emission *= emissionMap;
 #else // Since emission is an HDR color convert from sRGB to linear.
     half3 emission = GTsRGBToLinear(_EmissiveColor.rgb);
+    emission *= emissionMap;
 #endif
 #if defined(_CHANNEL_MAP)
     output.rgb += emission * channel.b;

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
@@ -19,7 +19,7 @@
 #pragma shader_feature_local_fragment _ _METALLIC_TEXTURE_ALBEDO_CHANNEL_A _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
 #pragma shader_feature_local _CHANNEL_MAP
 #pragma shader_feature_local _NORMAL_MAP
-#pragma shader_feature_local_fragment _EMISSION
+#pragma shader_feature_local _EMISSION
 #pragma shader_feature_local _TRIPLANAR_MAPPING
 #pragma shader_feature_local _LOCAL_SPACE_TRIPLANAR_MAPPING
 #pragma shader_feature_local_fragment _USE_SSAA

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
@@ -266,7 +266,7 @@ Varyings VertexStage(Attributes input)
 #endif
 
 #elif defined(_UV)
- output.uv = TRANSFORM_TEX(input.uv, _MainTex);
+    output.uv = TRANSFORM_TEX(input.uv, _MainTex);
 #endif
 
 #if defined(_UV_SCREEN)

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
@@ -118,7 +118,7 @@
 #undef _GRADIENT
 #endif
 
-#if !defined(_DISABLE_ALBEDO_MAP) || defined(_TRIPLANAR_MAPPING) || defined(_CHANNEL_MAP) || defined(_NORMAL_MAP) || defined(_DISTANCE_TO_EDGE) || defined(_GRADIENT)
+#if !defined(_DISABLE_ALBEDO_MAP) || defined(_TRIPLANAR_MAPPING) || defined(_CHANNEL_MAP) || defined(_NORMAL_MAP) || defined(_DISTANCE_TO_EDGE) || defined(_GRADIENT) || defined(_EMISSION)
 #define _UV
 #else
 #undef _UV
@@ -266,7 +266,7 @@ Varyings VertexStage(Attributes input)
 #endif
 
 #elif defined(_UV)
-    output.uv = TRANSFORM_TEX(input.uv, _MainTex);
+ output.uv = TRANSFORM_TEX(input.uv, _MainTex);
 #endif
 
 #if defined(_UV_SCREEN)
@@ -468,9 +468,9 @@ half4 PixelStage(Varyings input, bool facing : SV_IsFrontFace) : SV_Target
 
 #if defined(_EMISSION)
 #if defined(_URP)
-    half3 emissionMap = SAMPLE_TEXTURE2D(_EmissiveMap, sampler_EmissiveMap, input.uv);
+    half3 emissionMap = SAMPLE_TEXTURE2D(_EmissiveMap, sampler_EmissiveMap, input.uv).xyz;
 #else
-    half3 emissionMap = tex2D(_EmissiveMap, input.uv);
+    half3 emissionMap = tex2D(_EmissiveMap, input.uv).xyz;
 #endif
 #endif
     


### PR DESCRIPTION
## Overview

Added EmissionMap functionality to GraphicsToolsStandardShader as suggested in #19 

<img width="1547" alt="untitleds2" src="https://user-images.githubusercontent.com/36409613/175809716-43fe6420-39b7-4990-8e1a-de025a905cba.png">


## Changes


The main changes are in the following files
(1)GraphicsToolsStandardShader.shader
 　 EmmissiveMap is added to the Properties block.
(2) GraphicsToolsStandardProgram.hlsl
　　The _UV is changed so that _UV is also defined when _EMISSION is used.
　Also, the emissiveMap is newly multiplied to the existing half3 emission.
　
(3)GraphicsToolsStandardInput.hlsl
　Samplers were defined for each URP and build-in.

(4) StandardShaderGUI.cs
　The following files have been changed so that EmissionMap can be used together with Color when Emisston is enabled.

## Verification

By checking the Emission checkbox in the Material property of the GraphicsToolsStandardShader and enabling the function, the emission image  will be available in conjunction with EmissionColor.

I am willing to work on any small modifications to this PR.
　I am sure it will be a good learning experience for me and I am sure it will help all developers as well.