### PR TITLE
Downgrade sample project to 2020 LTS

### DIFF
--- a/GraphicsToolsUnityProject/Packages/manifest.json
+++ b/GraphicsToolsUnityProject/Packages/manifest.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
     "com.microsoft.mrtk.graphicstools.unity": "file:../../com.microsoft.mrtk.graphicstools.unity",
-    "com.unity.ide.visualstudio": "2.0.15",
+    "com.unity.ide.visualstudio": "2.0.16",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.inputsystem": "1.3.0",
-    "com.unity.render-pipelines.universal": "12.1.6",
+    "com.unity.render-pipelines.universal": "10.9.0",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.xr.management": "4.2.1",

--- a/GraphicsToolsUnityProject/Packages/packages-lock.json
+++ b/GraphicsToolsUnityProject/Packages/packages-lock.json
@@ -6,15 +6,6 @@
       "source": "local",
       "dependencies": {}
     },
-    "com.unity.burst": {
-      "version": "1.6.5",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.mathematics": "1.2.1"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.ext.nunit": {
       "version": "1.0.6",
       "depth": 2,
@@ -23,7 +14,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.15",
+      "version": "2.0.16",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -48,56 +39,56 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.mathematics": {
-      "version": "1.2.6",
+      "version": "1.1.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
-      "version": "12.1.6",
+      "version": "10.9.0",
       "depth": 1,
-      "source": "builtin",
+      "source": "registry",
       "dependencies": {
         "com.unity.ugui": "1.0.0",
         "com.unity.modules.physics": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
-      }
+      },
+      "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.universal": {
-      "version": "12.1.6",
+      "version": "10.9.0",
       "depth": 0,
-      "source": "builtin",
+      "source": "registry",
       "dependencies": {
-        "com.unity.mathematics": "1.2.1",
-        "com.unity.burst": "1.5.0",
-        "com.unity.render-pipelines.core": "12.1.6",
-        "com.unity.shadergraph": "12.1.6"
-      }
+        "com.unity.mathematics": "1.1.0",
+        "com.unity.render-pipelines.core": "10.9.0",
+        "com.unity.shadergraph": "10.9.0"
+      },
+      "url": "https://packages.unity.com"
     },
     "com.unity.searcher": {
-      "version": "4.9.1",
+      "version": "4.3.2",
       "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.shadergraph": {
-      "version": "12.1.6",
-      "depth": 1,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.render-pipelines.core": "12.1.6",
-        "com.unity.searcher": "4.9.1"
-      }
-    },
-    "com.unity.subsystemregistration": {
-      "version": "1.1.0",
+      "version": "10.9.0",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.modules.subsystems": "1.0.0"
+        "com.unity.render-pipelines.core": "10.9.0",
+        "com.unity.searcher": "4.3.2"
       },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.subsystemregistration": {
+      "version": "1.0.6",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {

--- a/GraphicsToolsUnityProject/ProjectSettings/ProjectVersion.txt
+++ b/GraphicsToolsUnityProject/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.3f1
-m_EditorVersionWithRevision: 2021.3.3f1 (af2e63e8f9bd)
+m_EditorVersion: 2020.3.36f1
+m_EditorVersionWithRevision: 2020.3.36f1 (71f96b79b9f0)

--- a/GraphicsToolsUnityProject/ProjectSettings/QualitySettings.asset
+++ b/GraphicsToolsUnityProject/ProjectSettings/QualitySettings.asset
@@ -222,11 +222,4 @@ QualitySettings:
     resolutionScalingFixedDPIFactor: 1
     customRenderPipeline: {fileID: 0}
     excludedTargetPlatforms: []
-  m_PerPlatformDefaultQuality:
-    Android: 0
-    GameCoreScarlett: 0
-    GameCoreXboxOne: 0
-    Server: 0
-    Standalone: 0
-    WebGL: 0
-    Windows Store Apps: 0
+  m_PerPlatformDefaultQuality: {}

--- a/GraphicsToolsUnityProject/ProjectSettings/URPProjectSettings.asset
+++ b/GraphicsToolsUnityProject/ProjectSettings/URPProjectSettings.asset
@@ -12,4 +12,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 247994e1f5a72c2419c26a37e9334c01, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_LastMaterialVersion: 5
+  m_LastMaterialVersion: 4

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Shaders/DebugMipColor.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Shaders/DebugMipColor.shader
@@ -7,6 +7,8 @@
 ///  - Red indicates that the texture is larger than necessary.
 ///  - Blue indicates that the texture could be larger.
 /// Note, the ideal texture sizes depend on the resolution at which your application will run and how close the camera can get to a surface.
+/// 
+/// Note, the signature of GetDebugMipColor changed in 12.1.0 so we need two sub shaders.
 /// </summary>
 Shader "Hidden/Graphics Tools/DebugMipColor"
 {
@@ -18,7 +20,7 @@ Shader "Hidden/Graphics Tools/DebugMipColor"
     {
         PackageRequirements
         {
-            "com.unity.render-pipelines.universal": "10.6.0"
+            "com.unity.render-pipelines.universal": "[10.6.0,12.1.0)"
         }
 
         Tags { "RenderType" = "Opaque" }
@@ -68,12 +70,72 @@ Shader "Hidden/Graphics Tools/DebugMipColor"
             half4 PixelStage(Varyings input) : SV_Target
             {
                 half4 albedo = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv);
-                return half4(GetDebugMipColor(albedo.rgb, _MainTex_TexelSize, input.uv), albedo.a);
+                return half4(GetDebugMipColor(albedo.rgb, _MainTex, _MainTex_TexelSize, input.uv), albedo.a);
             }
 
             ENDHLSL
         }
     }
+    SubShader
+        {
+            PackageRequirements
+            {
+                "com.unity.render-pipelines.universal": "12.1.0"
+            }
+    
+            Tags { "RenderType" = "Opaque" }
+            LOD 100
+    
+            Pass
+            {
+                HLSLPROGRAM
+    
+                #pragma vertex VertexStage
+                #pragma fragment PixelStage
+    
+                #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+                #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Debug.hlsl"
+    
+                struct Attributes
+                {
+                    float4 vertex : POSITION;
+                    float2 uv : TEXCOORD0;
+                };
+    
+                struct Varyings
+                {
+                    float4 position : SV_POSITION;
+                    float2 uv : TEXCOORD0;
+                };
+    
+                TEXTURE2D(_MainTex);
+                SAMPLER(sampler_MainTex);
+    
+                CBUFFER_START(UnityPerMaterial)
+                float4 _MainTex_ST;
+                float4 _MainTex_TexelSize;
+                CBUFFER_END
+    
+                Varyings VertexStage(Attributes input)
+                {
+                    Varyings output;
+                    UNITY_SETUP_INSTANCE_ID(input);
+                    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+                    output.position = TransformObjectToHClip(input.vertex.xyz);
+                    output.uv = TRANSFORM_TEX(input.uv, _MainTex);
+    
+                    return output;
+                }
+    
+                half4 PixelStage(Varyings input) : SV_Target
+                {
+                    half4 albedo = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv);
+                    return half4(GetDebugMipColor(albedo.rgb, _MainTex_TexelSize, input.uv), albedo.a);
+                }
+    
+                ENDHLSL
+            }
+        }
 
     Fallback "Hidden/InternalErrorShader"
 }


### PR DESCRIPTION
## Overview
Graphics Tools supports Unity 2020.x LTS so it's best that the sample project cater to that version (2020.3.36f1) beacasue upgrades are often less error prone than downgrades. 

For example, material keywords aren't de-serialized from materials made with 2021.3.3f1 within 2020.3.36f1 LTS: https://github.com/microsoft/MixedReality-GraphicsTools-Unity/pull/40

![image](https://user-images.githubusercontent.com/13305729/176565700-72206a41-756b-4f4a-8010-1856eced982f.png)


## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
