### PR TITLE
Tune URP settings and materials for HoloLens 2 and fix an index out of range issue.

### DIFF
--- a/GraphicsToolsUnityProject/ProjectSettings/QualitySettings.asset
+++ b/GraphicsToolsUnityProject/ProjectSettings/QualitySettings.asset
@@ -21,7 +21,7 @@ QualitySettings:
     skinWeights: 4
     textureQuality: 0
     anisotropicTextures: 1
-    antiAliasing: 2
+    antiAliasing: 0
     softParticles: 0
     softVegetation: 0
     realtimeReflectionProbes: 0

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Canvas/CanvasElementMesh.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Canvas/CanvasElementMesh.cs
@@ -137,7 +137,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         {
             vh.Clear();
 
-            RefresheMesh();
+            RefreshMesh();
 
             if (Mesh == null || uiVerticies.Count == 0)
             {
@@ -204,7 +204,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// Determines if vertex attributes within the Mesh need to be re-cached.
         /// </summary>
         [ContextMenu("Refresh Mesh")]
-        private void RefresheMesh()
+        private void RefreshMesh()
         {
             if (previousMesh != Mesh ||
                 previousColor != color ||
@@ -256,8 +256,15 @@ namespace Microsoft.MixedReality.GraphicsTools
                         // Set the other attributes.
                         vertex.normal = normals[i];
                         vertex.tangent = tangents[i];
-                        vertex.color = colors[i] * color;
 
+                        if (i < colors.Count)
+                        {
+                            vertex.color = colors[i] * color;
+                        }
+                        else
+                        {
+                            vertex.color = color;
+                        }
 
                         if (i < uv0s.Count)
                         {

--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Materials/AcrylicLayer0.mat
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Materials/AcrylicLayer0.mat
@@ -9,7 +9,7 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: AcrylicLayer0
   m_Shader: {fileID: 4800000, guid: 94108ee2b453da64089a4ed5a18d42e7, type: 3}
-  m_ShaderKeywords: _BLUR_TEXTURE_ENABLE_ _IRIDESCENCE_ENABLE_ _REFLECTED__ON
+  m_ShaderKeywords: _BLUR_TEXTURE_ENABLE_ _IRIDESCENCE_ENABLE_ _REFLECTED__ON _SMOOTH_EDGES_
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -71,7 +71,6 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    m_Ints: []
     m_Floats:
     - _Angle_: -45
     - _Blue_Edge_Intensity_: 0.932
@@ -83,6 +82,7 @@ Material:
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
+    - _DstBlendAlpha: 1
     - _Edge_Only_: 0
     - _Edge_Power_: 2
     - _Edge_Width_: 0.5
@@ -111,12 +111,15 @@ Material:
     - _Occluded_Blur_Intensity_: 0.526
     - _Occluded_Intensity_: 1
     - _OcclusionStrength: 1
+    - _Orthographic_Distance_: 400
     - _Parallax: 0.02
     - _Rate_: 0.05
     - _Reflected_: 1
+    - _Smooth_Edges_: 1
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
     - _StencilComparison: 0
     - _StencilOperation: 0
     - _StencilReference: 0

--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Materials/AcrylicLayer1.mat
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Materials/AcrylicLayer1.mat
@@ -9,7 +9,7 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: AcrylicLayer1
   m_Shader: {fileID: 4800000, guid: 94108ee2b453da64089a4ed5a18d42e7, type: 3}
-  m_ShaderKeywords: _BLUR_TEXTURE_2_ENABLE_ _IRIDESCENCE_ENABLE_ _REFLECTED__ON
+  m_ShaderKeywords: _BLUR_TEXTURE_2_ENABLE_ _IRIDESCENCE_ENABLE_ _REFLECTED__ON _SMOOTH_EDGES_
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -71,7 +71,6 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    m_Ints: []
     m_Floats:
     - _Angle_: -45
     - _Blue_Edge_Intensity_: 0.932
@@ -83,6 +82,7 @@ Material:
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
+    - _DstBlendAlpha: 1
     - _Edge_Only_: 0
     - _Edge_Power_: 2
     - _Edge_Width_: 0.5
@@ -111,12 +111,15 @@ Material:
     - _Occluded_Blur_Intensity_: 0.521
     - _Occluded_Intensity_: 1
     - _OcclusionStrength: 1
+    - _Orthographic_Distance_: 400
     - _Parallax: 0.02
     - _Rate_: 0.05
     - _Reflected_: 1
+    - _Smooth_Edges_: 1
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
     - _StencilComparison: 0
     - _StencilOperation: 0
     - _StencilReference: 0

--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/UnityUI/Materials/CanvasMeshPanda.mat
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/UnityUI/Materials/CanvasMeshPanda.mat
@@ -9,7 +9,7 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: CanvasMeshPanda
   m_Shader: {fileID: 4800000, guid: df5380aa6ab293c4fafbb942ed5da93f, type: 3}
-  m_ShaderKeywords: _DIRECTIONAL_LIGHT _SPECULAR_HIGHLIGHTS _USE_WORLD_SCALE _VERTEX_COLORS
+  m_ShaderKeywords: _DIRECTIONAL_LIGHT _SPECULAR_HIGHLIGHTS _USE_WORLD_SCALE
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -119,7 +119,7 @@ Material:
     - _StencilWriteMask: 255
     - _TriplanarMappingBlendSharpness: 4
     - _UseWorldScale: 1
-    - _VertexColors: 1
+    - _VertexColors: 0
     - _VertexExtrusion: 0
     - _VertexExtrusionSmoothNormals: 0
     - _VertexExtrusionValue: 0

--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/UnityUI/Materials/CanvasMeshPanda.mat
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/UnityUI/Materials/CanvasMeshPanda.mat
@@ -9,9 +9,9 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: CanvasMeshPanda
   m_Shader: {fileID: 4800000, guid: df5380aa6ab293c4fafbb942ed5da93f, type: 3}
-  m_ShaderKeywords: _DIRECTIONAL_LIGHT _SPECULAR_HIGHLIGHTS _USE_WORLD_SCALE
+  m_ShaderKeywords: _DIRECTIONAL_LIGHT _SPECULAR_HIGHLIGHTS _USE_WORLD_SCALE _VERTEX_EXTRUSION
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: 2000
   stringTagMap:
@@ -120,7 +120,7 @@ Material:
     - _TriplanarMappingBlendSharpness: 4
     - _UseWorldScale: 1
     - _VertexColors: 0
-    - _VertexExtrusion: 0
+    - _VertexExtrusion: 1
     - _VertexExtrusionSmoothNormals: 0
     - _VertexExtrusionValue: 0
     - _ZOffsetFactor: 0

--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/UniversalRenderPipelineAsset.asset
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/UniversalRenderPipelineAsset.asset
@@ -25,42 +25,30 @@ MonoBehaviour:
   m_SupportsTerrainHoles: 0
   m_StoreActionsOptimization: 0
   m_SupportsHDR: 0
-  m_MSAA: 2
+  m_MSAA: 1
   m_RenderScale: 1
   m_MainLightRenderingMode: 1
-  m_MainLightShadowsSupported: 1
+  m_MainLightShadowsSupported: 0
   m_MainLightShadowmapResolution: 512
   m_AdditionalLightsRenderingMode: 0
   m_AdditionalLightsPerObjectLimit: 4
   m_AdditionalLightShadowsSupported: 0
   m_AdditionalLightsShadowmapResolution: 512
-  m_AdditionalLightsShadowResolutionTierLow: 128
-  m_AdditionalLightsShadowResolutionTierMedium: 256
-  m_AdditionalLightsShadowResolutionTierHigh: 512
-  m_ReflectionProbeBlending: 0
-  m_ReflectionProbeBoxProjection: 0
   m_ShadowDistance: 50
   m_ShadowCascadeCount: 1
   m_Cascade2Split: 0.25
   m_Cascade3Split: {x: 0.1, y: 0.3}
   m_Cascade4Split: {x: 0.067, y: 0.2, z: 0.467}
-  m_CascadeBorder: 0.1
   m_ShadowDepthBias: 1
   m_ShadowNormalBias: 1
   m_SoftShadowsSupported: 0
-  m_ConservativeEnclosingSphere: 0
-  m_NumIterationsEnclosingSphere: 64
-  m_AdditionalLightsCookieResolution: 2048
-  m_AdditionalLightsCookieFormat: 3
   m_UseSRPBatcher: 1
   m_SupportsDynamicBatching: 0
   m_MixedLightingSupported: 1
-  m_SupportsLightLayers: 0
   m_DebugLevel: 0
   m_UseAdaptivePerformance: 1
   m_ColorGradingMode: 0
   m_ColorGradingLutSize: 32
-  m_UseFastSRGBLinearConversion: 0
   m_ShadowType: 1
   m_LocalShadowsSupported: 0
   m_LocalShadowsAtlasResolution: 256


### PR DESCRIPTION
## Overview
Disabled MSAA and dynamic shadows by default since they are not appropriate for HoloLens 2. Also fix this exception for meshes without vertex colors:
![image](https://user-images.githubusercontent.com/13305729/176976951-c96f20a0-1786-4667-bf91-05f124d63bc3.png)

## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
