### PR TITLE
Fixing non-main thread acrylic destroy issue

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicBackgroundRectProvider.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicBackgroundRectProvider.cs
@@ -305,6 +305,8 @@ namespace Microsoft.MixedReality.GraphicsTools
 
             layer.ApplyBlur(ref source, ref destination);
 
+            layer.Dispose();
+
             InstanceGraphicComponents();
             UpdateMaterialsProperties();
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicFilterDual.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicFilterDual.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #if GT_USE_URP
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Profiling;
@@ -13,7 +14,7 @@ namespace Microsoft.MixedReality.GraphicsTools
     /// <summary>
     /// Methods to perform dual filter bluring.
     /// </summary>
-    public class AcrylicFilterDual
+    public class AcrylicFilterDual : IDisposable
     {   
         private int lastWidth;
         private int lastHeight;
@@ -32,7 +33,7 @@ namespace Microsoft.MixedReality.GraphicsTools
             buffers = new List<RenderTexture>();
         }
 
-        ~AcrylicFilterDual()
+        public void Dispose()
         {
             FreeBuffers();
         }
@@ -96,7 +97,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         {
             for (int i = 0; i < buffers.Count; i++)
             {
-                Object.Destroy(buffers[i]);
+                UnityEngine.Object.Destroy(buffers[i]);
             }
             buffers.Clear();
         }

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicLayer.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicLayer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #if GT_USE_URP
+using System;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering.Universal;
 using UnityEngine.Profiling;
@@ -14,9 +15,8 @@ namespace Microsoft.MixedReality.GraphicsTools
     /// Class representing a single acrylic layer, used in conjuction with AcrylicLayerManager
     /// </summary>
 
-    public class AcrylicLayer
+    public class AcrylicLayer : IDisposable
     {
-       
         [System.Serializable]
         public class Settings
         {   
@@ -87,6 +87,33 @@ namespace Microsoft.MixedReality.GraphicsTools
             useDualBlur = _useDualBlur;
             kawaseBlur = _kawaseBlur;
             if (useDualBlur) dualBlur = new AcrylicFilterDual(_dualBlur);
+        }
+
+        public void Dispose()
+        {
+            if (blur != null)
+            {
+                DestroyScriptableObject(blur);
+                blur = null;
+            }
+
+            if (renderOpaque != null)
+            {
+                DestroyScriptableObject(renderOpaque);
+                renderOpaque = null;
+            }
+
+            if (renderTransparent != null)
+            {
+                DestroyScriptableObject(renderTransparent);
+                renderTransparent = null;
+            }
+
+            if (dualBlur != null)
+            {
+                dualBlur.Dispose();
+                dualBlur = null;
+            }    
         }
 
 #if UNITY_2021_2_OR_NEWER
@@ -332,24 +359,6 @@ namespace Microsoft.MixedReality.GraphicsTools
             }
         }
 
-        public void DestroyRendererFeatures()
-        {
-            if (blur != null)
-            {
-                DestroyScriptableObject(blur);
-                blur = null;
-            }
-            if (renderOpaque != null)
-            {
-                DestroyScriptableObject(renderOpaque);
-                renderOpaque = null;
-            }
-            if (renderTransparent != null)
-            {
-                DestroyScriptableObject(renderTransparent);
-                renderTransparent = null;
-            }
-        }
 #endregion
 
 #region Blur and blend methods
@@ -544,7 +553,7 @@ namespace Microsoft.MixedReality.GraphicsTools
             cmd.DrawMesh(RenderingUtils.fullscreenMesh, Matrix4x4.identity, material, 0, 0, blitProperties);
         }
 
-        private void DestroyScriptableObject(Object o)
+        private void DestroyScriptableObject(UnityEngine.Object o)
         {
             if (Application.isPlaying)
             {

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicLayerManager.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicLayerManager.cs
@@ -203,10 +203,6 @@ namespace Microsoft.MixedReality.GraphicsTools
                         return;
                     }
 #endif
-                    for (int i = 0; i < layerData.Count; i++)
-                    {
-                        layerData[i].DestroyRendererFeatures();
-                    }
                     break;
 
                 case AcrylicMethod.RenderToTexture:
@@ -219,6 +215,13 @@ namespace Microsoft.MixedReality.GraphicsTools
                 default:
                     break;
             }
+
+            for (int i = 0; i < layerData.Count; ++i)
+            {
+                layerData[i].Dispose();
+            }
+
+            layerData.Clear();
         }
 
         private void Awake()


### PR DESCRIPTION
## Overview

The AcrylicFilterDual filter was destroying Unity objects from the destructor which can be invoked off the main thread. 

> [Exception] UnityException: Destroy can only be called from the main thread.
> Constructors and field initializers will be executed from the loading thread when loading a scene.

To fix this the buffers are now freed using a dispose pattern.

## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
