### PR TITLE
Adding blend mode options to the non-canvas backplate

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplate.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplate.shader
@@ -56,16 +56,27 @@ Properties {
     [Header(Antialiasing)]
         [Toggle(_SMOOTH_EDGES_)] _Smooth_Edges_("Smooth Edges", Float) = 0
      
+    [Header(Blending)]
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0  // "Zero"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
 
     [Header(Stencil)]
         _StencilReference("Stencil Reference", Range(0, 255)) = 0
         [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
         [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+
+    [Header(Depth)]
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
+        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
 }
 
 SubShader {
     Tags{ "RenderType" = "Opaque" }
-    Blend Off
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+    ZWrite[_ZWrite]
+    ZTest[_ZTest]
     Tags {"DisableBatching" = "True"}
     Stencil
     {


### PR DESCRIPTION
## Overview
Before this PR the non-canvas backplate shader didn't have options for alpha blending, whereas the canvas version did. This pull request adds those blending options:
![image](https://user-images.githubusercontent.com/13305729/179318498-8568db32-c727-475d-bcfe-a858fc7af29f.png)


## Changes
- Fixes: #75 


## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
