### PR TITLE
add normalMapSacle to MRGTStandardShader

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -101,6 +101,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             public static readonly GUIContent channelMap = new GUIContent("Channel Map", "Metallic (Red), Occlusion (Green), Emission (Blue), Smoothness (Alpha)");
             public static readonly GUIContent enableNormalMap = new GUIContent("Normal Map", "Enable Normal Map");
             public static readonly GUIContent normalMap = new GUIContent("Normal Map");
+            public static readonly GUIContent normalMaoScale = new GUIContent("Normal Map Scale");
             public static readonly GUIContent enableEmission = new GUIContent("Emission", "Enable Emission");
             public static readonly GUIContent emissiveColor = new GUIContent("Color");
             public static readonly GUIContent emissiveMap = new GUIContent("EmissionMap");
@@ -220,6 +221,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         protected MaterialProperty channelMap;
         protected MaterialProperty enableNormalMap;
         protected MaterialProperty normalMap;
+        protected MaterialProperty normalMapScale;
         protected MaterialProperty enableEmission;
         protected MaterialProperty emissiveColor;
         protected MaterialProperty emissiveMap;
@@ -336,6 +338,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             channelMap = FindProperty("_ChannelMap", props);
             enableNormalMap = FindProperty("_EnableNormalMap", props);
             normalMap = FindProperty("_NormalMap", props);
+            normalMapScale = FindProperty("_NormalMapScale", props);
             enableEmission = FindProperty("_EnableEmission", props);
             emissiveMap = FindProperty("_EmissiveMap", props);
             emissiveColor = FindProperty("_EmissiveColor", props);
@@ -463,6 +466,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             float? specularHighlights = GetFloatProperty(material, "_SpecularHighlights");
             float? normalMap = null;
             Texture normalMapTexture = material.HasProperty("_BumpMap") ? material.GetTexture("_BumpMap") : null;
+            float? normalMapScale = GetFloatProperty(material, "_BumpScale");
             float? emission = null;
             Color? emissionColor = GetColorProperty(material, "_EmissionColor");
             Texture emissionMapTexture = material.HasProperty("_EmissionMap") ? material.GetTexture("_EmissionMap") : null;
@@ -507,6 +511,8 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             {
                 material.SetTexture("_NormalMap", normalMapTexture);
             }
+            
+            SetShaderFeatureActive(material, null, "_NormalScale", normalMapScale);
 
             if (emissionMapTexture)
             {
@@ -639,7 +645,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                 if (PropertyEnabled(enableNormalMap))
                 {
                     EditorGUI.indentLevel += 2;
-                    materialEditor.TexturePropertySingleLine(Styles.normalMap, normalMap);
+                    materialEditor.TexturePropertySingleLine(Styles.normalMap, normalMap,normalMapScale);
                     EditorGUI.indentLevel -= 2;
                 }
             }

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -100,8 +100,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             public static readonly GUIContent enableChannelMap = new GUIContent("Channel Map", "Enable Channel Map, a Channel Packing Texture That Follows Unity's Standard Channel Setup");
             public static readonly GUIContent channelMap = new GUIContent("Channel Map", "Metallic (Red), Occlusion (Green), Emission (Blue), Smoothness (Alpha)");
             public static readonly GUIContent enableNormalMap = new GUIContent("Normal Map", "Enable Normal Map");
-            public static readonly GUIContent normalMap = new GUIContent("Normal Map");
-            public static readonly GUIContent normalMaoScale = new GUIContent("Normal Map Scale");
+            public static readonly GUIContent normalMap = new GUIContent("Normal Map"); 
             public static readonly GUIContent enableEmission = new GUIContent("Emission", "Enable Emission");
             public static readonly GUIContent emissiveColor = new GUIContent("Color");
             public static readonly GUIContent emissiveMap = new GUIContent("EmissionMap");
@@ -512,7 +511,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                 material.SetTexture("_NormalMap", normalMapTexture);
             }
             
-            SetShaderFeatureActive(material, null, "_NormalScale", normalMapScale);
+            SetShaderFeatureActive(material, null, "_NormalMapScale", normalMapScale);
 
             if (emissionMapTexture)
             {
@@ -645,7 +644,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                 if (PropertyEnabled(enableNormalMap))
                 {
                     EditorGUI.indentLevel += 2;
-                    materialEditor.TexturePropertySingleLine(Styles.normalMap, normalMap,normalMapScale);
+                    materialEditor.TexturePropertySingleLine(Styles.normalMap, normalMap, normalMapScale);
                     EditorGUI.indentLevel -= 2;
                 }
             }

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
@@ -198,6 +198,7 @@ CBUFFER_START(UnityPerMaterial)
     half _Metallic;
     half _Smoothness;
 
+    float _NormalMapScale;
     // #if defined(_ALPHA_CLIP)
     half _Cutoff;
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
@@ -198,7 +198,7 @@ CBUFFER_START(UnityPerMaterial)
     half _Metallic;
     half _Smoothness;
 
-    float _NormalMapScale;
+    half _NormalMapScale;
     // #if defined(_ALPHA_CLIP)
     half _Cutoff;
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
@@ -571,13 +571,13 @@ half4 PixelStage(Varyings input, bool facing : SV_IsFrontFace) : SV_Target
 #if defined(_NORMAL_MAP)
 #if defined(_TRIPLANAR_MAPPING)
 #if defined(_URP)
-    half3 tangentNormalX = UnpackNormal(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, uvX));
-    half3 tangentNormalY = UnpackNormal(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, uvY));
-    half3 tangentNormalZ = UnpackNormal(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, uvZ));
+    half3 tangentNormalX = UnpackNormalScale(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, uvX), _NormalMapScale);
+    half3 tangentNormalY = UnpackNormalScale(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, uvY), _NormalMapScale);
+    half3 tangentNormalZ = UnpackNormalScale(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, uvZ), _NormalMapScale);
 #else
-    half3 tangentNormalX = UnpackNormal(tex2D(_NormalMap, uvX));
-    half3 tangentNormalY = UnpackNormal(tex2D(_NormalMap, uvY));
-    half3 tangentNormalZ = UnpackNormal(tex2D(_NormalMap, uvZ));
+    half3 tangentNormalX = UnpackScaleNormal(tex2D(_NormalMap, uvX), _NormalMapScale);
+    half3 tangentNormalY = UnpackScaleNormal(tex2D(_NormalMap, uvY), _NormalMapScale);
+    half3 tangentNormalZ = UnpackScaleNormal(tex2D(_NormalMap, uvZ), _NormalMapScale);
 #endif
     tangentNormalX.x *= axisSign.x;
     tangentNormalY.x *= axisSign.y;
@@ -591,20 +591,20 @@ half4 PixelStage(Varyings input, bool facing : SV_IsFrontFace) : SV_Target
     // Swizzle tangent normals to match world normal and blend together.
     worldNormal = normalize(tangentNormalX.zyx * triplanarBlend.x +
                             tangentNormalY.xzy * triplanarBlend.y +
-                            tangentNormalZ.xyz * triplanarBlend.z)*_NormalMapScale;
+                            tangentNormalZ.xyz * triplanarBlend.z);
 #else
 #if defined(_URP)
-    half3 tangentNormal = UnpackNormal(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, input.uv));
+    half3 tangentNormal = UnpackNormalScale(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, input.uv), _NormalMapScale);
 #else
-    half3 tangentNormal = UnpackNormal(tex2D(_NormalMap, input.uv));
+    half3 tangentNormal = UnpackScaleNormal(tex2D(_NormalMap, input.uv), _NormalMapScale);
 #endif
     worldNormal.x = dot(input.tangentX, tangentNormal);
     worldNormal.y = dot(input.tangentY, tangentNormal);
     worldNormal.z = dot(input.tangentZ, tangentNormal);
-    worldNormal = normalize(worldNormal) * (facing ? 1.0 : -1.0)*_NormalMapScale;
+    worldNormal = normalize(worldNormal) * (facing ? 1.0 : -1.0);
 #endif
 #else
-    worldNormal = normalize(input.worldNormal) * (facing ? 1.0 : -1.0)*_NormalMapScale;
+    worldNormal = normalize(input.worldNormal) * (facing ? 1.0 : -1.0);
 #endif
 #endif
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
@@ -591,7 +591,7 @@ half4 PixelStage(Varyings input, bool facing : SV_IsFrontFace) : SV_Target
     // Swizzle tangent normals to match world normal and blend together.
     worldNormal = normalize(tangentNormalX.zyx * triplanarBlend.x +
                             tangentNormalY.xzy * triplanarBlend.y +
-                            tangentNormalZ.xyz * triplanarBlend.z);
+                            tangentNormalZ.xyz * triplanarBlend.z)*_NormalMapScale;
 #else
 #if defined(_URP)
     half3 tangentNormal = UnpackNormal(SAMPLE_TEXTURE2D(_NormalMap, sampler_NormalMap, input.uv));
@@ -601,10 +601,10 @@ half4 PixelStage(Varyings input, bool facing : SV_IsFrontFace) : SV_Target
     worldNormal.x = dot(input.tangentX, tangentNormal);
     worldNormal.y = dot(input.tangentY, tangentNormal);
     worldNormal.z = dot(input.tangentZ, tangentNormal);
-    worldNormal = normalize(worldNormal) * (facing ? 1.0 : -1.0);
+    worldNormal = normalize(worldNormal) * (facing ? 1.0 : -1.0)*_NormalMapScale;
 #endif
 #else
-    worldNormal = normalize(input.worldNormal) * (facing ? 1.0 : -1.0);
+    worldNormal = normalize(input.worldNormal) * (facing ? 1.0 : -1.0)*_NormalMapScale;
 #endif
 #endif
 


### PR DESCRIPTION
## Overview

The _NormalMapScale parameter, which was unused and dead from the MRGStandardShader parameters, can now be used to change the intensity of the normal map.

![スクリーンショット 2022-07-17 184014](https://user-images.githubusercontent.com/36409613/179392697-8bc603c6-b4a7-4684-83fe-96132d330553.png)





## Changes


fix #77  

**・StandardShaderGUI**

normalMapScale is now displayed on the inspector.

**・GraphicsToolsStandardProgram**

Changed to multiply WorldNormal by _NormalMapScale value after normal map packing is complete.

## Verification

I have confirmed that I can change the intensity of the normal map both in normal and when using TriplanerMapping.

![ダウンロード](https://user-images.githubusercontent.com/36409613/179392736-d366efcb-c4dd-43e2-8dc1-b89914d947e7.gif)


