### PR TITLE
Moving menu items to "Graphics Tools" directory

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/CanvasElementBeveledRectInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/CanvasElementBeveledRectInspector.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
     [CustomEditor(typeof(CanvasElementBeveledRect))]
     public class CanvasElementBeveledRectInspector : UnityEditor.Editor
     {
-        [MenuItem("GameObject/UI/Beveled Rect - Graphics Tools")]
+        [MenuItem("GameObject/UI/Graphics Tools/Beveled Rect")]
         private static void CreateCanvasElement(MenuCommand menuCommand)
         {
             GameObject gameObject = InspectorUtilities.CreateGameObjectFromMenu<CanvasElementBeveledRect>(menuCommand);

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/CanvasElementMeshtInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/CanvasElementMeshtInspector.cs
@@ -11,7 +11,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
     [CustomEditor(typeof(CanvasElementMesh))]
     public class CanvasElementMeshInspector : UnityEditor.Editor
     {
-        [MenuItem("GameObject/UI/Mesh - Graphics Tools")]
+        [MenuItem("GameObject/UI/Graphics Tools/Mesh")]
         private static void CreateCanvasElement(MenuCommand menuCommand)
         {
             InspectorUtilities.CreateGameObjectFromMenu<CanvasElementMesh>(menuCommand);

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/CanvasElementRoundedRectInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/CanvasElementRoundedRectInspector.cs
@@ -12,7 +12,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
     [CustomEditor(typeof(CanvasElementRoundedRect))]
     public class CanvasElementRoundedRectInspector : UnityEditor.Editor
     {
-        [MenuItem("GameObject/UI/Rounded Rect - Graphics Tools")]
+        [MenuItem("GameObject/UI/Graphics Tools/Rounded Rect")]
         private static void CreateCanvasElement(MenuCommand menuCommand)
         {
             GameObject gameObject = InspectorUtilities.CreateGameObjectFromMenu<CanvasElementRoundedRect>(menuCommand);

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/DistantLightInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/DistantLightInspector.cs
@@ -72,7 +72,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             return new Bounds(light.transform.position, Vector3.one);
         }
 
-        [MenuItem("GameObject/Light/Distant Light")]
+       [MenuItem("GameObject/Light/Graphics Tools/Distant Light")]
         private static void CreateDistantLight(MenuCommand menuCommand)
         {
             GameObject gameObject = InspectorUtilities.CreateGameObjectFromMenu<DistantLight>(menuCommand);

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/HoverLightInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/HoverLightInspector.cs
@@ -47,7 +47,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             return new Bounds(light.transform.position, Vector3.one * light.Radius);
         }
 
-        [MenuItem("GameObject/Light/Hover Light")]
+       [MenuItem("GameObject/Light/Graphics Tools/Hover Light")]
         private static void CreateHoverLight(MenuCommand menuCommand)
         {
             InspectorUtilities.CreateGameObjectFromMenu<HoverLight>(menuCommand);

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/ProximityLightInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/ProximityLightInspector.cs
@@ -77,7 +77,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             return new Bounds(light.transform.position, Vector3.one * Mathf.Max(light.Settings.NearRadius, light.Settings.FarRadius));
         }
 
-        [MenuItem("GameObject/Light/Proximity Light")]
+       [MenuItem("GameObject/Light/Graphics Tools/Proximity Light")]
         private static void CreateProximityLight(MenuCommand menuCommand)
         {
             InspectorUtilities.CreateGameObjectFromMenu<ProximityLight>(menuCommand);

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/RectMask2DFastInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/RectMask2DFastInspector.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
     [CanEditMultipleObjects]
     public class RectMask2DFastInspector : RectMask2DEditor
     {
-        [MenuItem("GameObject/UI/Rect Mask Fast - Graphics Tools")]
+        [MenuItem("GameObject/UI/Graphics Tools/Rect Mask Fast")]
         private static void CreateCanvasElement(MenuCommand menuCommand)
         {
             InspectorUtilities.CreateGameObjectFromMenu<RectMask2DFast>(menuCommand);

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/RectMask2DFastInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/RectMask2DFastInspector.cs
@@ -13,7 +13,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
     [CanEditMultipleObjects]
     public class RectMask2DFastInspector : RectMask2DEditor
     {
-        [MenuItem("GameObject/UI/Graphics Tools/Rect Mask Fast")]
+        [MenuItem("GameObject/UI/Graphics Tools/Fast Rect Mask")]
         private static void CreateCanvasElement(MenuCommand menuCommand)
         {
             InspectorUtilities.CreateGameObjectFromMenu<RectMask2DFast>(menuCommand);

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/RoundedRectMask2DInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/RoundedRectMask2DInspector.cs
@@ -32,7 +32,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         private SerializedProperty radii;
         private SerializedProperty padding;
 
-        [MenuItem("GameObject/UI/Rounded Rect Mask - Graphics Tools")]
+        [MenuItem("GameObject/UI/Graphics Tools/Rounded Rect Mask")]
         private static void CreateCanvasElement(MenuCommand menuCommand)
         {
             InspectorUtilities.CreateGameObjectFromMenu<RoundedRectMask2D>(menuCommand);


### PR DESCRIPTION
## Overview
Ensures all GameObject menu items are in the "Graphics Tools" directory:
![image](https://user-images.githubusercontent.com/13305729/180846041-6c0aefe9-bcc7-4ed3-9386-a02d854fd931.png)

![image](https://user-images.githubusercontent.com/13305729/180846148-5826c3a0-ae7a-4916-aecc-940c103e8ec7.png)

## Changes
- Fixes: #82 


## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
