### PR TITLE
Restore original mesh when adding and removing MeshSmoother

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshOutline.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshOutline.cs
@@ -23,7 +23,6 @@ namespace Microsoft.MixedReality.GraphicsTools
 
         private Renderer meshRenderer = null;
         private MaterialPropertyBlock propertyBlock = null;
-        private int vertexExtrusionValueID = 0;
         private Material[] defaultMaterials = null;
         private MeshSmoother createdMeshSmoother = null;
 
@@ -36,12 +35,11 @@ namespace Microsoft.MixedReality.GraphicsTools
         {
             if (GetComponent<SpriteRenderer>() != null)
             {
-                Debug.LogWarning($"{this.GetType()} is not supported on SpriteRenderers");
+                Debug.LogWarning($"{GetType()} is not supported on SpriteRenderers");
             }
 
             meshRenderer = GetComponent<Renderer>();
             propertyBlock = new MaterialPropertyBlock();
-            vertexExtrusionValueID = Shader.PropertyToID(vertexExtrusionValueName);
             defaultMaterials = meshRenderer.sharedMaterials;
         }
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshOutline.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshOutline.cs
@@ -23,6 +23,7 @@ namespace Microsoft.MixedReality.GraphicsTools
 
         private Renderer meshRenderer = null;
         private MaterialPropertyBlock propertyBlock = null;
+        private int vertexExtrusionValueID = 0;
         private Material[] defaultMaterials = null;
         private MeshSmoother createdMeshSmoother = null;
 
@@ -35,11 +36,12 @@ namespace Microsoft.MixedReality.GraphicsTools
         {
             if (GetComponent<SpriteRenderer>() != null)
             {
-                Debug.LogWarning($"{GetType()} is not supported on SpriteRenderers");
+                Debug.LogWarning($"{this.GetType()} is not supported on SpriteRenderers");
             }
 
             meshRenderer = GetComponent<Renderer>();
             propertyBlock = new MaterialPropertyBlock();
+            vertexExtrusionValueID = Shader.PropertyToID(vertexExtrusionValueName);
             defaultMaterials = meshRenderer.sharedMaterials;
         }
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshSmoother.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshSmoother.cs
@@ -30,10 +30,10 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// </summary>
         private class MeshReference
         {
-            public UnityEngine.Mesh Mesh;
+            public Mesh Mesh;
             private int referenceCount;
 
-            public MeshReference(UnityEngine.Mesh mesh)
+            public MeshReference(Mesh mesh)
             {
                 Mesh = mesh;
                 referenceCount = 1;
@@ -55,7 +55,7 @@ namespace Microsoft.MixedReality.GraphicsTools
             }
         }
 
-        private static Dictionary<UnityEngine.Mesh, MeshReference> processedMeshes = new Dictionary<UnityEngine.Mesh, MeshReference>();
+        private static Dictionary<Mesh, MeshReference> processedMeshes = new Dictionary<Mesh, MeshReference>();
 
         /// <summary>
         /// Performs normal smoothing on the current mesh filter associated with this component synchronously.
@@ -63,7 +63,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// </summary>
         public void SmoothNormals()
         {
-            UnityEngine.Mesh mesh;
+            Mesh mesh;
 
             // No need to do any smoothing if this mesh has already been processed.
             if (AcquirePreprocessedMesh(out mesh))
@@ -82,7 +82,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// <returns>A task which will complete once normal smoothing is finished.</returns>
         public Task SmoothNormalsAsync()
         {
-            UnityEngine.Mesh mesh;
+            Mesh mesh;
 
             // No need to do any smoothing if this mesh has already been processed.
             if (AcquirePreprocessedMesh(out mesh))
@@ -150,7 +150,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// </summary>
         /// <param name="mesh">A reference to the mesh which was already processed or is ready to be processed.</param>
         /// <returns>True if the mesh was already processed, false otherwise.</returns>
-        private bool AcquirePreprocessedMesh(out UnityEngine.Mesh mesh)
+        private bool AcquirePreprocessedMesh(out Mesh mesh)
         {
             if (meshFilter == null)
             {

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshSmoother.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshSmoother.cs
@@ -144,7 +144,6 @@ namespace Microsoft.MixedReality.GraphicsTools
                     processedMeshes.Remove(sharedMesh);
                 }
             }
-
         }
 
         #endregion MonoBehaviour Implementation

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshSmoother.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshSmoother.cs
@@ -24,17 +24,17 @@ namespace Microsoft.MixedReality.GraphicsTools
         private bool smoothNormalsOnAwake = false;
 
         private MeshFilter meshFilter = null;
-        private Mesh originalMesh;
+        private UnityEngine.Mesh originalMesh;
 
         /// <summary>
         /// Helper class to track mesh references.
         /// </summary>
         private class MeshReference
         {
-            public Mesh Mesh;
+            public UnityEngine.Mesh Mesh;
             private int referenceCount;
 
-            public MeshReference(Mesh mesh)
+            public MeshReference(UnityEngine.Mesh mesh)
             {
                 Mesh = mesh;
                 referenceCount = 1;
@@ -56,7 +56,7 @@ namespace Microsoft.MixedReality.GraphicsTools
             }
         }
 
-        private static Dictionary<Mesh, MeshReference> processedMeshes = new Dictionary<Mesh, MeshReference>();
+        private static Dictionary<UnityEngine.Mesh, MeshReference> processedMeshes = new Dictionary<UnityEngine.Mesh, MeshReference>();
 
         /// <summary>
         /// Performs normal smoothing on the current mesh filter associated with this component synchronously.
@@ -64,7 +64,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// </summary>
         public void SmoothNormals()
         {
-            Mesh mesh;
+            UnityEngine.Mesh mesh;
 
             // No need to do any smoothing if this mesh has already been processed.
             if (AcquirePreprocessedMesh(out mesh))
@@ -83,7 +83,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// <returns>A task which will complete once normal smoothing is finished.</returns>
         public Task SmoothNormalsAsync()
         {
-            Mesh mesh;
+            UnityEngine.Mesh mesh;
 
             // No need to do any smoothing if this mesh has already been processed.
             if (AcquirePreprocessedMesh(out mesh))
@@ -153,7 +153,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// </summary>
         /// <param name="mesh">A reference to the mesh which was already processed or is ready to be processed.</param>
         /// <returns>True if the mesh was already processed, false otherwise.</returns>
-        private bool AcquirePreprocessedMesh(out Mesh mesh)
+        private bool AcquirePreprocessedMesh(out UnityEngine.Mesh mesh)
         {
             if (meshFilter == null)
             {

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshSmoother.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshSmoother.cs
@@ -23,6 +23,9 @@ namespace Microsoft.MixedReality.GraphicsTools
         [SerializeField]
         private bool smoothNormalsOnAwake = false;
 
+        [SerializeField]
+        private Mesh originalMesh;
+
         private MeshFilter meshFilter = null;
 
         /// <summary>
@@ -127,6 +130,8 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// </summary>
         private void OnDestroy()
         {
+            meshFilter.sharedMesh = originalMesh;
+
             MeshReference meshReference;
             var sharedMesh = meshFilter.sharedMesh;
 
@@ -141,6 +146,7 @@ namespace Microsoft.MixedReality.GraphicsTools
                     processedMeshes.Remove(sharedMesh);
                 }
             }
+
         }
 
         #endregion MonoBehaviour Implementation
@@ -170,6 +176,8 @@ namespace Microsoft.MixedReality.GraphicsTools
 
                 return true;
             }
+
+            originalMesh = meshFilter.sharedMesh;
 
             // Clone the mesh, and create a mesh reference which can be keyed off either the original mesh or cloned mesh.
             mesh = meshFilter.mesh;

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshSmoother.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshSmoother.cs
@@ -23,10 +23,8 @@ namespace Microsoft.MixedReality.GraphicsTools
         [SerializeField]
         private bool smoothNormalsOnAwake = false;
 
-        [SerializeField]
-        private Mesh originalMesh;
-
         private MeshFilter meshFilter = null;
+        private Mesh originalMesh;
 
         /// <summary>
         /// Helper class to track mesh references.


### PR DESCRIPTION
## Overview

- Updates MeshSmoother.cs to remember the original mesh so it can be restored when pragmatically added and removed. 
- Applies visual studio suggestions for code cleanup

## Changes
- Fixes: #53 

## Verification
Steps to reproduce:
1. Import samples
2. Create a 3d GameObject like a cube, and play
3. Add a MeshOutline component on cube
4. Assign outline material such as Assets/Samples/MeshOutlines/Materials/OutlineRainbow.mat to MeshOutline component
5. Observe mesh filter now has mesh instance
6. Remove MeshOutline component
7. Observe mesh filter has original reference Mesh