### PR TITLE
Fix independent rounded radii aliasing

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsCommon.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsCommon.hlsl
@@ -110,7 +110,13 @@ inline float FilterDistance(in float distance)
 {
     float2 filterWidth = length(float2(ddx(distance), ddy(distance)));
     float pixelDistance = distance / length(filterWidth);
+
+#if defined(_INDEPENDENT_CORNERS) || defined(_UI_CLIP_RECT_ROUNDED_INDEPENDENT)
+    // To avoid artifacts at discontinuities in the SDF distance increase the pixel width.
+    return saturate(1.0 - pixelDistance);
+#else
     return saturate(0.5 - pixelDistance);
+#endif
 }
 
 inline float GTRoundCornersSmooth(in float2 position, in float2 cornerCircleDistance, in float cornerCircleRadius, in float smoothingValue)
@@ -132,17 +138,17 @@ inline float GTRoundCorners(in float2 position, in float2 cornerCircleDistance, 
 #endif
 }
 
-inline float GTFindCornerRadius(in float2 offset, in float4 radii)
+inline float GTFindCornerRadius(in float2 uv, in float4 radii)
 {
-    if (offset.x < 0)
+    if (uv.x < 0.5)
     {
-        if (offset.y > 0) { return radii.x; }
-        else { return radii.z; }
+        if (uv.y > 0.5) { return radii.x; } // Top left.
+        else { return radii.z; } // Bottom left.
     }
     else
     {
-        if (offset.y > 0) { return radii.y; }
-        else { return radii.w; }
+        if (uv.y > 0.5) { return radii.y; } // Top right.
+        else { return radii.w; } // Bottom right.
     }
 }
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
@@ -507,7 +507,7 @@ half4 PixelStage(Varyings input, bool facing : SV_IsFrontFace) : SV_Target
 #if !defined(_USE_WORLD_SCALE)
     _RoundCornersRadius = clamp(_RoundCornersRadius, 0.0h, 0.5h);
 #endif
-    currentCornerRadius = GTFindCornerRadius((input.uv - float2(0.5, 0.5)) * 2.0, _RoundCornersRadius);
+    currentCornerRadius = GTFindCornerRadius(input.uv.xy, _RoundCornersRadius);
 #else 
     currentCornerRadius = _RoundCornerRadius;
 #endif


### PR DESCRIPTION
## Overview
I tried a few different methods to fix this artifact (such as interpolated radii, which gave a melting effect 😅). But increasing the filtered pixel width for independent rounded radii seems like the quickest and least destructive fix. 

Tests include a quad with independent radii (left) and an image component within a rounded rect mask with independent corners (right):
![image](https://user-images.githubusercontent.com/13305729/182264076-aaeb77db-02c0-4887-a6b0-64b34ca57fb4.png)

+Minor optimization and commenting improvements to corner selection for independent corners. 

## Changes
- Fixes: #74 


## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
