### PR TITLE
Adding a namespace to all enum declarations

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/BaseShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/BaseShaderGUI.cs
@@ -10,32 +10,32 @@ using Object = UnityEngine.Object;
 namespace Microsoft.MixedReality.GraphicsTools.Editor
 {
     /// <summary>
+    /// Groups render state into a handful of common surface configurations.
+    /// </summary>
+    public enum RenderingMode
+    {
+        Opaque = 0,
+        Cutout = 1,
+        Fade = 2,
+        Transparent = 3,
+        Additive = 4,
+        Custom = 5
+    }
+
+    /// <summary>
+    /// Toggle for depth writing.
+    /// </summary>
+    public enum DepthWrite
+    {
+        Off = 0,
+        On = 1
+    }
+
+    /// <summary>
     /// A custom base shader inspector for Graphics Tools shaders.
     /// </summary>
     public abstract class BaseShaderGUI : ShaderGUI
     {
-        /// <summary>
-        /// Groups render state into a handful of common surface configurations.
-        /// </summary>
-        public enum RenderingMode
-        {
-            Opaque = 0,
-            Cutout = 1,
-            Fade = 2,
-            Transparent = 3,
-            Additive = 4,
-            Custom = 5
-        }
-
-        /// <summary>
-        /// Toggle for depth writing.
-        /// </summary>
-        public enum DepthWrite
-        {
-            Off = 0,
-            On = 1
-        }
-
         /// <summary>
         /// Common names, keywords, and tooltips.
         /// </summary>

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -10,72 +10,72 @@ using UnityEngine.Rendering;
 namespace Microsoft.MixedReality.GraphicsTools.Editor
 {
     /// <summary>
+    /// How to treat the alpha channel of the albedo texture.
+    /// </summary>
+    public enum AlbedoAlphaMode
+    {
+        Transparency = 0,
+        Metallic = 1,
+        Smoothness = 2
+    }
+
+    /// <summary>
+    /// What type of direct light affects the surface.
+    /// </summary>
+    public enum LightMode
+    {
+        Unlit = 0,
+        LitDirectional = 1,
+        LitDistant = 2
+    }
+
+    /// <summary>
+    /// What type of gradient to generate.
+    /// </summary>
+    public enum GradientMode
+    {
+        None = 0,
+        Iridescence = 1,
+        FourPoint = 2,
+        Linear = 3
+    }
+
+    /// <summary>
+    /// How the border color should be calculated.
+    /// </summary>
+    public enum BorderColorMode
+    {
+        Brightness = 0,
+        HoverColor = 1,
+        Color = 2,
+        Gradient = 3
+    }
+
+    /// <summary>
+    /// Is edge smoothing controlled by a user defined value or programmatically.
+    /// </summary>
+    public enum EdgeSmoothingMode
+    {
+        Manual = 0,
+        Automatic = 1
+    }
+
+    /// <summary>
+    /// How to sample the blur texture.
+    /// </summary>
+    public enum BlurMode
+    {
+        None = 0,
+        Layer1 = 1,
+        Layer2 = 2,
+        PrebakedBackground = 3
+    }
+
+    /// <summary>
     /// A custom shader inspector for the "Graphics Tools/Standard" and "Graphics Tools/Standard Canvas" shaders.
     /// </summary>
     public class StandardShaderGUI : BaseShaderGUI
     {
-        /// <summary>
-        /// How to treat the alpha channel of the albedo texture.
-        /// </summary>
-        protected enum AlbedoAlphaMode
-        {
-            Transparency = 0,
-            Metallic = 1,
-            Smoothness = 2
-        }
-
-        /// <summary>
-        /// What type of direct light affects the surface.
-        /// </summary>
-        protected enum LightMode
-        {
-            Unlit = 0,
-            LitDirectional = 1,
-            LitDistant = 2
-        }
-
-        /// <summary>
-        /// What type of gradient to generate.
-        /// </summary>
-        protected enum GradientMode
-        {
-            None = 0,
-            Iridescence = 1,
-            FourPoint = 2,
-            Linear = 3
-        }
-
-        /// <summary>
-        /// How the border color should be calculated.
-        /// </summary>
-        protected enum BorderColorMode
-        {
-            Brightness = 0,
-            HoverColor = 1,
-            Color = 2,
-            Gradient = 3
-        }
-
-        /// <summary>
-        /// Is edge smoothing controlled by a user defined value or programmatically.
-        /// </summary>
-        protected enum EdgeSmoothingMode
-        {
-            Manual = 0,
-            Automatic = 1
-        }
-
-        /// <summary>
-        /// How to sample the blur texture.
-        /// </summary>
-        protected enum BlurMode
-        {
-            None = 0,
-            Layer1 = 1,
-            Layer2 = 2,
-            PrebakedBackground = 3
-        }
-
         /// <summary>
         /// Common names, keywords, and tooltips.
         /// </summary>

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Shaders/CanvasBackplateAcrylic.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Shaders/CanvasBackplateAcrylic.shader
@@ -80,7 +80,7 @@ Properties {
 
     [Header(Depth)]
         [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
-        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
 
     [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
     [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBackplate.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBackplate.shader
@@ -65,7 +65,7 @@ Properties {
 
     [Header(Depth)]
         [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
-        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
 
     [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
     [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBeveled.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBeveled.shader
@@ -50,7 +50,7 @@ Properties {
      
     [Header(Depth)]
         [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
-        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
 
     [Header(Stencil)]
         _StencilReference("Stencil Reference", Range(0, 255)) = 0

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasFrontplate.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasFrontplate.shader
@@ -76,7 +76,7 @@ Properties {
 
     [Header(Depth)]
         [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
-        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 0 // "Off"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 0 // "Off"
 
     [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
     [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasGlow.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasGlow.shader
@@ -39,7 +39,7 @@ Properties {
 
     [Header(Depth)]
         [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
-        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 0 // "Off"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 0 // "Off"
 
     [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
     [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasProgressBar.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasProgressBar.shader
@@ -38,7 +38,7 @@ Properties {
 
     [Header(Depth)]
         [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
-        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
 
     [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
     [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasQuadGlow.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasQuadGlow.shader
@@ -33,7 +33,7 @@ Properties {
 
     [Header(Depth)]
         [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
-        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 0 // "Off"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 0 // "Off"
 
     [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
     [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasRadialSpinner.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasRadialSpinner.shader
@@ -41,7 +41,7 @@ Properties {
 
     [Header(Depth)]
         [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
-        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
 
     [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
     [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
@@ -12,7 +12,7 @@ Shader "Graphics Tools/Standard"
         // Main maps.
         _Color("Color", Color) = (1.0, 1.0, 1.0, 1.0)
         _MainTex("Albedo", 2D) = "white" {}
-        [Enum(AlbedoAlphaMode)] _AlbedoAlphaMode("Albedo Alpha Mode", Float) = 0 // "Transparency"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.AlbedoAlphaMode)] _AlbedoAlphaMode("Albedo Alpha Mode", Float) = 0 // "Transparency"
         [Toggle] _AlbedoAssignedAtRuntime("Albedo Assigned at Runtime", Float) = 0.0
         _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
         _Fade("Alpha Fade", Range(0.0, 1.0)) = 1.0
@@ -33,7 +33,7 @@ Shader "Graphics Tools/Standard"
         _MipmapBias("Mipmap Bias", Range(-5.0, 0.0)) = -2.0
 
         // Rendering options.
-        [Enum(LightMode)] _DirectionalLight("Light Mode", Float) = 1.0 // "LitDirectional"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.LightMode)] _DirectionalLight("Light Mode", Float) = 1.0 // "LitDirectional"
         [Toggle(_SPECULAR_HIGHLIGHTS)] _SpecularHighlights("Specular Highlights", Float) = 1.0
         [Toggle(_SPHERICAL_HARMONICS)] _SphericalHarmonics("Spherical Harmonics", Float) = 0.0
         [Toggle(_REFLECTIONS)] _Reflections("Reflections", Float) = 0.0
@@ -76,16 +76,16 @@ Shader "Graphics Tools/Standard"
         [Toggle(_BORDER_LIGHT_REPLACES_ALBEDO)] _BorderLightReplacesAlbedo("Border Light Replaces Albedo", Float) = 0.0
         [Toggle(_BORDER_LIGHT_OPAQUE)] _BorderLightOpaque("Border Light Opaque", Float) = 0.0
         _BorderWidth("Border Width", Range(0.0, 1.0)) = 0.1
-        [Enum(BorderColorMode)] _BorderColorMode("Border Color Mode", Float) = 0 // "Brightness"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.BorderColorMode)] _BorderColorMode("Border Color Mode", Float) = 0 // "Brightness"
         _BorderMinValue("Border Min Value", Range(0.0, 1.0)) = 0.1
         _BorderColor("Border Color", Color) = (1.0, 1.0, 1.0, 0.0)
-        [Enum(EdgeSmoothingMode)] _EdgeSmoothingMode("Edge Smoothing Mode", Float) = 0 // "Manual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.EdgeSmoothingMode)] _EdgeSmoothingMode("Edge Smoothing Mode", Float) = 0 // "Manual"
         _EdgeSmoothingValue("Edge Smoothing Value", Float) = 0.002
         _BorderLightOpaqueAlpha("Border Light Opaque Alpha", Range(0.0, 1.0)) = 1.0
         [Toggle(_INNER_GLOW)] _InnerGlow("Inner Glow", Float) = 0.0
         _InnerGlowColor("Inner Glow Color (RGB) and Intensity (A)", Color) = (1.0, 1.0, 1.0, 0.75)
         _InnerGlowPower("Inner Glow Power", Range(2.0, 32.0)) = 4.0
-        [Enum(GradientMode)] _GradientMode("Gradient Mode", Float) = 0 // "None"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.GradientMode)] _GradientMode("Gradient Mode", Float) = 0 // "None"
         [NoScaleOffset] _IridescentSpectrumMap("Iridescent Spectrum Map", 2D) = "white" {}
         _IridescenceIntensity("Iridescence Intensity", Range(0.0, 1.0)) = 0.5
         _IridescenceThreshold("Iridescence Threshold", Range(0.0, 1.0)) = 0.05
@@ -104,25 +104,25 @@ Shader "Graphics Tools/Standard"
         _EnvironmentColorX("Environment Color X (RGB)", Color) = (1.0, 0.0, 0.0, 1.0)
         _EnvironmentColorY("Environment Color Y (RGB)", Color) = (0.0, 1.0, 0.0, 1.0)
         _EnvironmentColorZ("Environment Color Z (RGB)", Color) = (0.0, 0.0, 1.0, 1.0)
-        [Enum(BlurMode)] _BlurMode("Blur Mode", Float) = 0 // "None"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.BlurMode)] _BlurMode("Blur Mode", Float) = 0 // "None"
         _BlurTextureIntensity("Blur Texture Intensity", Range(0.0, 1.0)) = 1.0
         _BlurBorderIntensity("Blur Border Intensity", Range(0.0, 1.0)) = 0.0
         _BlurBackgroundRect("Blur Background Rect", Vector) = (0.0, 0.0, 1.0, 1.0)
 
         // Advanced options.
-        [Enum(RenderingMode)] _Mode("Rendering Mode", Float) = 0                                     // "Opaque"
-        [Enum(RenderingMode)] _CustomMode("Mode", Float) = 0                                         // "Opaque"
-        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                 // "One"
-        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0            // "Zero"
-        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
-        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
-        [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0                 // "Add"
-        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4                // "LessEqual"
-        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 1                                         // "On"
-        _ZOffsetFactor("Depth Offset Factor", Float) = 0                                             // "Zero"
-        _ZOffsetUnits("Depth Offset Units", Float) = 0                                               // "Zero"
-        [Enum(UnityEngine.Rendering.ColorWriteMask)] _ColorWriteMask("Color Write Mask", Float) = 15 // "All"
-        [Enum(UnityEngine.Rendering.CullMode)] _CullMode("Cull Mode", Float) = 2                     // "Back"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.RenderingMode)] _Mode("Rendering Mode", Float) = 0 // "Opaque"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.RenderingMode)] _CustomMode("Mode", Float) = 0     // "Opaque"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                         // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0                    // "Zero"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1              // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1         // "One"
+        [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0                         // "Add"
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4                        // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1     // "On"
+        _ZOffsetFactor("Depth Offset Factor", Float) = 0                                                     // "Zero"
+        _ZOffsetUnits("Depth Offset Units", Float) = 0                                                       // "Zero"
+        [Enum(UnityEngine.Rendering.ColorWriteMask)] _ColorWriteMask("Color Write Mask", Float) = 15         // "All"
+        [Enum(UnityEngine.Rendering.CullMode)] _CullMode("Cull Mode", Float) = 2                             // "Back"
         _RenderQueueOverride("Render Queue Override", Range(-1.0, 5000)) = -1
         [Toggle(_USE_WORLD_SCALE)] _UseWorldScale("Absolute Size", Float) = 1.0
         [Toggle(_STENCIL)] _EnableStencil("Enable Stencil Testing", Float) = 0.0

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvas.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvas.shader
@@ -12,7 +12,7 @@ Shader "Graphics Tools/Standard Canvas"
         // Main maps.
         _Color("Color", Color) = (1.0, 1.0, 1.0, 1.0)
         [PerRendererData] _MainTex("Albedo", 2D) = "white" {}
-        [Enum(AlbedoAlphaMode)] _AlbedoAlphaMode("Albedo Alpha Mode", Float) = 0 // "Transparency"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.AlbedoAlphaMode)] _AlbedoAlphaMode("Albedo Alpha Mode", Float) = 0 // "Transparency"
         [Toggle] _AlbedoAssignedAtRuntime("Albedo Assigned at Runtime", Float) = 0.0
         _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
         _Fade("Alpha Fade", Range(0.0, 1.0)) = 1.0
@@ -33,7 +33,7 @@ Shader "Graphics Tools/Standard Canvas"
         _MipmapBias("Mipmap Bias", Range(-5.0, 0.0)) = -2.0
 
         // Rendering options.
-        [Enum(LightMode)] _DirectionalLight("Light Mode", Float) = 0.0 // "Unlit"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.LightMode)] _DirectionalLight("Light Mode", Float) = 0.0 // "Unlit"
         [Toggle(_SPECULAR_HIGHLIGHTS)] _SpecularHighlights("Specular Highlights", Float) = 1.0
         [Toggle(_SPHERICAL_HARMONICS)] _SphericalHarmonics("Spherical Harmonics", Float) = 0.0
         [Toggle(_REFLECTIONS)] _Reflections("Reflections", Float) = 0.0
@@ -76,16 +76,16 @@ Shader "Graphics Tools/Standard Canvas"
         [Toggle(_BORDER_LIGHT_REPLACES_ALBEDO)] _BorderLightReplacesAlbedo("Border Light Replaces Albedo", Float) = 0.0
         [Toggle(_BORDER_LIGHT_OPAQUE)] _BorderLightOpaque("Border Light Opaque", Float) = 0.0
         _BorderWidth("Border Width", Range(0.0, 1.0)) = 0.1
-        [Enum(BorderColorMode)] _BorderColorMode("Border Color Mode", Float) = 0 // "Brightness"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.BorderColorMode)] _BorderColorMode("Border Color Mode", Float) = 0 // "Brightness"
         _BorderMinValue("Border Min Value", Range(0.0, 1.0)) = 0.1
         _BorderColor("Border Color", Color) = (1.0, 1.0, 1.0, 0.0)
-        [Enum(EdgeSmoothingMode)] _EdgeSmoothingMode("Edge Smoothing Mode", Float) = 0 // "Manual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.EdgeSmoothingMode)] _EdgeSmoothingMode("Edge Smoothing Mode", Float) = 0 // "Manual"
         _EdgeSmoothingValue("Edge Smoothing Value", Float) = 0.002
         _BorderLightOpaqueAlpha("Border Light Opaque Alpha", Range(0.0, 1.0)) = 1.0
         [Toggle(_INNER_GLOW)] _InnerGlow("Inner Glow", Float) = 0.0
         _InnerGlowColor("Inner Glow Color (RGB) and Intensity (A)", Color) = (1.0, 1.0, 1.0, 0.75)
         _InnerGlowPower("Inner Glow Power", Range(2.0, 32.0)) = 4.0
-        [Enum(GradientMode)] _GradientMode("Gradient Mode", Float) = 0 // "None"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.GradientMode)] _GradientMode("Gradient Mode", Float) = 0 // "None"
         [NoScaleOffset] _IridescentSpectrumMap("Iridescent Spectrum Map", 2D) = "white" {}
         _IridescenceIntensity("Iridescence Intensity", Range(0.0, 1.0)) = 0.5
         _IridescenceThreshold("Iridescence Threshold", Range(0.0, 1.0)) = 0.05
@@ -104,25 +104,25 @@ Shader "Graphics Tools/Standard Canvas"
         _EnvironmentColorX("Environment Color X (RGB)", Color) = (1.0, 0.0, 0.0, 1.0)
         _EnvironmentColorY("Environment Color Y (RGB)", Color) = (0.0, 1.0, 0.0, 1.0)
         _EnvironmentColorZ("Environment Color Z (RGB)", Color) = (0.0, 0.0, 1.0, 1.0)
-        [Enum(BlurMode)] _BlurMode("Blur Mode", Float) = 0 // "None"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.BlurMode)] _BlurMode("Blur Mode", Float) = 0 // "None"
         _BlurTextureIntensity("Blur Texture Intensity", Range(0.0, 1.0)) = 1.0
         _BlurBorderIntensity("Blur Border Intensity", Range(0.0, 1.0)) = 0.0
         _BlurBackgroundRect("Blur Background Rect", Vector) = (0.0, 0.0, 1.0, 1.0)
 
         // Advanced options.
-        [Enum(RenderingMode)] _Mode("Rendering Mode", Float) = 3                                  // "Transparent"
-        [Enum(RenderingMode)] _CustomMode("Mode", Float) = 2                                      // "Fade"
-        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1              // "One"
-        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 10        // "OneMinusSrcAlpha"
-        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
-        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
-        [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0              // "Add"
-        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4             // "LessEqual"
-        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 0                                      // "Off"
-        _ZOffsetFactor("Depth Offset Factor", Float) = 0                                          // "Zero"
-        _ZOffsetUnits("Depth Offset Units", Float) = 0                                            // "Zero"
-        [Enum(UnityEngine.Rendering.ColorWriteMask)] _ColorMask("Color Write Mask", Float) = 15   // "All"
-        [Enum(UnityEngine.Rendering.CullMode)] _CullMode("Cull Mode", Float) = 0                  // "Off"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.RenderingMode)] _Mode("Rendering Mode", Float) = 3 // "Transparent"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.RenderingMode)] _CustomMode("Mode", Float) = 2     // "Fade"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                         // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 10                   // "OneMinusSrcAlpha"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1              // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1         // "One"
+        [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0                         // "Add"
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4                        // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 0     // "Off"
+        _ZOffsetFactor("Depth Offset Factor", Float) = 0                                                     // "Zero"
+        _ZOffsetUnits("Depth Offset Units", Float) = 0                                                       // "Zero"
+        [Enum(UnityEngine.Rendering.ColorWriteMask)] _ColorMask("Color Write Mask", Float) = 15              // "All"
+        [Enum(UnityEngine.Rendering.CullMode)] _CullMode("Cull Mode", Float) = 0                             // "Off"
         _RenderQueueOverride("Render Queue Override", Range(-1.0, 5000)) = -1
         [Toggle(_USE_WORLD_SCALE)] _UseWorldScale("Absolute Size", Float) = 1.0
         [Toggle(_STENCIL)] _EnableStencil("Enable Stencil Testing", Float) = 0.0

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsTextMeshPro.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsTextMeshPro.shader
@@ -65,7 +65,7 @@ Properties {
     _CullMode             ("Cull Mode", Float) = 0
     _ColorMask            ("Color Mask", Float) = 15
 
-    [Enum(DepthWrite)] _ZWrite                          ("Depth Write", Float) = 0     // Off
+    [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite                          ("Depth Write", Float) = 0     // Off
     [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4      // "LessEqual"
 
     [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                 // "One"

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsWireframe.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsWireframe.shader
@@ -15,19 +15,19 @@ Shader "Graphics Tools/Wireframe"
         _WireThickness("Wire thickness", Range(0, 800)) = 100
 
         // Advanced options.
-        [Enum(RenderingMode)] _Mode("Rendering Mode", Float) = 0                                     // "Opaque"
-        [Enum(RenderingMode)] _CustomMode("Mode", Float) = 0                                         // "Opaque"
-        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                 // "One"
-        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0            // "Zero"
-        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
-        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
-        [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0                 // "Add"
-        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4                // "LessEqual"
-        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 1                                         // "On"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.RenderingMode)] _Mode("Rendering Mode", Float) = 0 // "Opaque"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.RenderingMode)] _CustomMode("Mode", Float) = 0     // "Opaque"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                         // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0                    // "Zero"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1              // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1         // "One"
+        [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0                         // "Add"
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4                        // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1     // "On"
         _ZOffsetFactor("Depth Offset Factor", Float) = 50
         _ZOffsetUnits("Depth Offset Units", Float) = 100
-        [Enum(UnityEngine.Rendering.ColorWriteMask)] _ColorWriteMask("Color Write Mask", Float) = 15 // "All"
-        [Enum(UnityEngine.Rendering.CullMode)] _CullMode("Cull Mode", Float) = 2                     // "Back"
+        [Enum(UnityEngine.Rendering.ColorWriteMask)] _ColorWriteMask("Color Write Mask", Float) = 15         // "All"
+        [Enum(UnityEngine.Rendering.CullMode)] _CullMode("Cull Mode", Float) = 2                             // "Back"
         _RenderQueueOverride("Render Queue Override", Range(-1.0, 5000)) = -1
     }
     SubShader

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplate.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplate.shader
@@ -69,7 +69,7 @@ Properties {
 
     [Header(Depth)]
         [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
-        [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
 }
 
 SubShader {

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasQuadGlow.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasQuadGlow.shader
@@ -26,7 +26,7 @@ Properties {
 
     [Header(Blend)]
     [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4
-    [Enum(DepthWrite)] _ZWrite("Depth Write", Float) = 0
+    [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 0
 }
 
 SubShader {


### PR DESCRIPTION
## Overview
All enums in shader properties are now prefixed with their exact namespace. If a collison occurs (like [GradientMode ](https://github.com/microsoft/MixedReality-GraphicsTools-Unity/blob/385952c3e0c59b934f7846cb2b815977cb22dcda/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs#L30)and [GradientMode](https://docs.unity3d.com/ScriptReference/GradientMode.html)) then you might get inconsistent results on what enum list is displayed. 

Before this change (in some projects):
![image](https://user-images.githubusercontent.com/13305729/184456018-a97d4b10-47d7-41d8-8c19-77d6a91021f9.png)

After this change:
![image](https://user-images.githubusercontent.com/13305729/184456032-9443713e-dac5-47ec-b73f-52b9bf9fccb1.png)

Note this is a breaking change because I had to move some enums out of their class. It appears classes [aren't considered](https://forum.unity.com/threads/issue-with-enums-in-namespaces.413513/) when searching for named enums. 

## Changes
- Fixes: #88 

## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.