### PR TITLE
Disabling hover lights by default on new materials

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
@@ -55,7 +55,7 @@ Shader "Graphics Tools/Standard"
         _FadeMinValue("Fade Min Value", Range(0.0, 1.0)) = 0.0
 
         // Fluent options.
-        [Toggle(_HOVER_LIGHT)] _HoverLight("Hover Light", Float) = 1.0
+        [Toggle(_HOVER_LIGHT)] _HoverLight("Hover Light", Float) = 0.0
         [Toggle(_HOVER_COLOR_OVERRIDE)] _EnableHoverColorOverride("Hover Color Override", Float) = 0.0
         _HoverColorOverride("Hover Color Override", Color) = (1.0, 1.0, 1.0, 1.0)
         [Toggle(_PROXIMITY_LIGHT)] _ProximityLight("Proximity Light", Float) = 0.0


### PR DESCRIPTION
## Overview
Most users probably don't want [Hover Lights](https://docs.microsoft.com/en-us/windows/mixed-reality/mrtk-unity/mrtk3-graphicstools/features/hover-light) by default. This will improve performance of new materials out-of-the-box. 

## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
