### PR TITLE
Fixed a problem that caused material errors for primitive objects on …

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Acrylic.unity
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Acrylic.unity
@@ -354,6 +354,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Boost: 1
   MinBoost: 0.5
+  MaxBoost: 4
   PositionLerpTime: 0.2
   MouseSensitivityCurve:
     serializedVersion: 2
@@ -772,6 +773,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   count: 100
   primitiveType: 3
+  orbitalMaterial: {fileID: 2100000, guid: 1e93e41cbd3bc5640aeb000dbbb0910a, type: 2}
   size: 0.03
   sizeVary: 0.7
   speed: 0.2

--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Materials/Orbital.mat
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Materials/Orbital.mat
@@ -1,0 +1,248 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-4988505281690332481
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 5
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Orbital
+  m_Shader: {fileID: 4800000, guid: c331f6c43a2ef0945864cb668f2653c9, type: 3}
+  m_ValidKeywords:
+  - _DIRECTIONAL_LIGHT
+  - _DISABLE_ALBEDO_MAP
+  - _SPECULAR_HIGHLIGHTS
+  - _USE_WORLD_SCALE
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 2000
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ChannelMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissiveMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _IridescentSpectrumMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _NormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlbedoAlphaMode: 0
+    - _AlbedoAssignedAtRuntime: 0
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BlendOp: 0
+    - _BlendedClippingWidth: 0
+    - _BlurBorderIntensity: 0
+    - _BlurMode: 0
+    - _BlurTextureIntensity: 1
+    - _BorderColorMode: 0
+    - _BorderLight: 0
+    - _BorderLightOpaque: 0
+    - _BorderLightOpaqueAlpha: 1
+    - _BorderLightReplacesAlbedo: 0
+    - _BorderMinValue: 0.1
+    - _BorderWidth: 0.1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _ClippingBorder: 0
+    - _ClippingBorderWidth: 0.025
+    - _ColorWriteMask: 15
+    - _Cull: 2
+    - _CullMode: 2
+    - _CustomMode: 0
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DirectionalLight: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 1
+    - _EdgeSmoothingMode: 0
+    - _EdgeSmoothingValue: 0.002
+    - _EnableChannelMap: 0
+    - _EnableEmission: 0
+    - _EnableHoverColorOverride: 0
+    - _EnableLocalSpaceTriplanarMapping: 0
+    - _EnableNormalMap: 0
+    - _EnableProximityLightColorOverride: 0
+    - _EnableSSAA: 0
+    - _EnableStencil: 0
+    - _EnableTriplanarMapping: 0
+    - _EnvironmentColorIntensity: 0.5
+    - _EnvironmentColorThreshold: 1.5
+    - _EnvironmentColoring: 0
+    - _EnvironmentReflections: 1
+    - _Fade: 1
+    - _FadeBeginDistance: 0.85
+    - _FadeCompleteDistance: 0.5
+    - _FadeMinValue: 0
+    - _FluentLightIntensity: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _GradientAngle: 180
+    - _GradientMode: 0
+    - _HoverLight: 0
+    - _IndependentCorners: 0
+    - _InnerGlow: 0
+    - _InnerGlowPower: 4
+    - _IridescenceAngle: -0.78
+    - _IridescenceIntensity: 0.5
+    - _IridescenceThreshold: 0.05
+    - _Metallic: 0
+    - _MipmapBias: -2
+    - _Mode: 0
+    - _NearLightFade: 0
+    - _NearPlaneFade: 0
+    - _NormalMapScale: 1
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _ProximityLight: 0
+    - _ProximityLightSubtractive: 0
+    - _ProximityLightTwoSided: 0
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Reflections: 0
+    - _RenderQueueOverride: -1
+    - _RimLight: 0
+    - _RimPower: 0.25
+    - _RoundCornerMargin: 0.01
+    - _RoundCornerRadius: 0.25
+    - _RoundCorners: 0
+    - _RoundCornersHideInterior: 0
+    - _Smoothness: 0
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SphericalHarmonics: 0
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _StencilComparison: 0
+    - _StencilOperation: 0
+    - _StencilReadMask: 255
+    - _StencilReference: 0
+    - _StencilWriteMask: 255
+    - _Surface: 0
+    - _TriplanarMappingBlendSharpness: 4
+    - _UseWorldScale: 1
+    - _VertexColors: 0
+    - _VertexExtrusion: 0
+    - _VertexExtrusionSmoothNormals: 0
+    - _VertexExtrusionValue: 0
+    - _WorkflowMode: 1
+    - _ZOffsetFactor: 0
+    - _ZOffsetUnits: 0
+    - _ZTest: 4
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _BlurBackgroundRect: {r: 0, g: 0, b: 1, a: 1}
+    - _BorderColor: {r: 1, g: 1, b: 1, a: 0}
+    - _ClippingBorderColor: {r: 1, g: 0.19999996, b: 0, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EmissiveColor: {r: 0, g: 0, b: 0, a: 1}
+    - _EnvironmentColorX: {r: 1, g: 0, b: 0, a: 1}
+    - _EnvironmentColorY: {r: 0, g: 1, b: 0, a: 1}
+    - _EnvironmentColorZ: {r: 0, g: 0, b: 1, a: 1}
+    - _GradientAlpha: {r: 1, g: 1, b: 1, a: 1}
+    - _GradientAlphaTime: {r: 0, g: 0, b: 0, a: 0}
+    - _GradientColor0: {r: 0.631373, g: 0.631373, b: 0.631373, a: 0}
+    - _GradientColor1: {r: 1, g: 0.690196, b: 0.976471, a: 0.25}
+    - _GradientColor2: {r: 0, g: 0.32999998, b: 0.88, a: 0.5}
+    - _GradientColor3: {r: 0, g: 0.32999998, b: 0.88, a: 1}
+    - _GradientColor4: {r: 1, g: 1, b: 1, a: 1}
+    - _HoverColorOverride: {r: 1, g: 1, b: 1, a: 1}
+    - _InnerGlowColor: {r: 1, g: 1, b: 1, a: 0.75}
+    - _ProximityLightCenterColorOverride: {r: 1, g: 0, b: 0, a: 0}
+    - _ProximityLightMiddleColorOverride: {r: 0, g: 1, b: 0, a: 0.5}
+    - _ProximityLightOuterColorOverride: {r: 0, g: 0, b: 1, a: 1}
+    - _RimColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+    - _RoundCornersRadius: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []

--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Materials/Orbital.mat.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Materials/Orbital.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1e93e41cbd3bc5640aeb000dbbb0910a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Scripts/Orbitals.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Scripts/Orbitals.cs
@@ -13,6 +13,8 @@ namespace Microsoft.MixedReality.GraphicsTools.Samples.Acrylic
 
         public PrimitiveType primitiveType = PrimitiveType.Cube;
 
+        public Material orbitalMaterial;
+
         public float size = 0.1f;
 
         public float sizeVary = 0.5f;
@@ -36,7 +38,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Samples.Acrylic
             private float angle;
             private float speed;
             private float tiltY, tiltX;
-            public Orbiter(PrimitiveType primitiveType, Transform parent, int index, float size, float radius, float startSpeed, float startAngle, float tiltx, float tilty, Color color)
+            public Orbiter(PrimitiveType primitiveType, Material material, Transform parent, int index, float size, float radius, float startSpeed, float startAngle, float tiltx, float tilty, Color color)
             {
                 GameObject go = GameObject.CreatePrimitive(primitiveType);
                 goParent = new GameObject("Orb " + index);
@@ -52,7 +54,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Samples.Acrylic
                 Renderer r = go.GetComponent<Renderer>();
                 if (r != null)
                 {
-                    r.material.color = color;
+                    r.material = material;
                 }
                 UpdatePosition(0.0f);
             }
@@ -77,7 +79,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Samples.Acrylic
                 float tangle = 360.0f * t;
                 float tiltx = tiltVary * (0.5f - Random.value) * 180.0f;
                 float tilty = tiltVary * (0.5f - Random.value) * 180.0f;
-                orbiters.Add(new Orbiter(primitiveType, transform, i, tsize, tradius, tspeed, tangle, tiltx, tilty, color));
+                orbiters.Add(new Orbiter(primitiveType, orbitalMaterial, transform, i, tsize, tradius, tspeed, tangle, tiltx, tilty, color));
             }
         }
 

--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Scripts/Orbitals.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/Experimental/Acrylic/Scripts/Orbitals.cs
@@ -29,8 +29,6 @@ namespace Microsoft.MixedReality.GraphicsTools.Samples.Acrylic
 
         public float tiltVary = 0.1f;
 
-        public Color color = Color.white;
-
         public class Orbiter
         {
             GameObject goParent;
@@ -38,7 +36,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Samples.Acrylic
             private float angle;
             private float speed;
             private float tiltY, tiltX;
-            public Orbiter(PrimitiveType primitiveType, Material material, Transform parent, int index, float size, float radius, float startSpeed, float startAngle, float tiltx, float tilty, Color color)
+            public Orbiter(PrimitiveType primitiveType, Material material, Transform parent, int index, float size, float radius, float startSpeed, float startAngle, float tiltx, float tilty)
             {
                 GameObject go = GameObject.CreatePrimitive(primitiveType);
                 goParent = new GameObject("Orb " + index);
@@ -79,7 +77,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Samples.Acrylic
                 float tangle = 360.0f * t;
                 float tiltx = tiltVary * (0.5f - Random.value) * 180.0f;
                 float tilty = tiltVary * (0.5f - Random.value) * 180.0f;
-                orbiters.Add(new Orbiter(primitiveType, orbitalMaterial, transform, i, tsize, tradius, tspeed, tangle, tiltx, tilty, color));
+                orbiters.Add(new Orbiter(primitiveType, orbitalMaterial, transform, i, tsize, tradius, tspeed, tangle, tiltx, tilty));
             }
         }
 


### PR DESCRIPTION

## Overview

Resolved the material error in the acrylic sample scene mentioned in #91.


## Changes

#91 
#65  (I think it is relevant to this issue here.)

What I did was the following points
Added public material to the Orbitals class.
 Added a material argument to Orbiter. I also changed the original process of making the material color white to refer to the added material.

````
                if (r ! = null)
                {
                    r.material = material;
                }
````

Acrylic/Material folder

<img width="1916" alt="vr_network_sns" src="https://user-images.githubusercontent.com/36409613/184464367-461c874c-1578-4147-9b8b-12733de45b01.png">

Attached materials for reference in the Acrylic/Material folder.

This material uses MRGTStandardShader.



