### PR TITLE
Remove trailing / to fix folder detector for MeasureToolSettings.asset

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/MeasureTool/MeasureToolSettings.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/MeasureTool/MeasureToolSettings.cs
@@ -80,8 +80,8 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             var settings = AssetDatabase.LoadAssetAtPath<MeasureToolSettings>(MeasureToolSettingsPath);
             if (settings == null)
             {
-                settings = ScriptableObject.CreateInstance<MeasureToolSettings>();
-                if (!AssetDatabase.IsValidFolder("Assets/Editor/"))
+                settings = CreateInstance<MeasureToolSettings>();
+                if (!AssetDatabase.IsValidFolder("Assets/Editor"))
                 {
                     AssetDatabase.CreateFolder("Assets", "Editor");
                     AssetDatabase.Refresh();


### PR DESCRIPTION
## Overview

This trailing `/` seems to throw Unity off and cause the folder detector to return `false`, which causes Unity to try to create a second `Editor` folder, leading to one called `Editor 1`. Removing the `/` restores the intended behavior.

## Changes
- Fixes: #95 
