### PR TITLE
Clipping Primitive Materials

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/ClippingPrimitiveInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/ClippingPrimitiveInspector.cs
@@ -34,11 +34,12 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         }
 
         /// <summary>
-        /// Looks for changes to the list of renderers and gracefully adds and removes them.
+        /// Looks for changes to the list of renderers and materials and gracefully adds and removes them.
         /// </summary>
         public override void OnInspectorGUI()
         {
             var previousRenderers = clippingPrimitive.GetRenderersCopy();
+            var previousMaterials = clippingPrimitive.GetMaterialsCopy();
 
             using (var check = new EditorGUI.ChangeCheckScope())
             {
@@ -51,17 +52,32 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                 }
             }
 
+            // Add or remove and renderers that were added or removed via the inspector.
             var currentRenderers = clippingPrimitive.GetRenderersCopy();
 
-            // Add or remove and renderers that were added or removed via the inspector.
             foreach (var renderer in previousRenderers.Except(currentRenderers))
             {
-                clippingPrimitive.RemoveRenderer(renderer);
+                // ResetRenderer rather than RemoveRenderer since the renderer has already been removed from the list.
+                clippingPrimitive.ResetRenderer(renderer);
             }
 
             foreach (var renderer in currentRenderers.Except(previousRenderers))
             {
                 clippingPrimitive.AddRenderer(renderer);
+            }
+
+            // Add or remove and materials that were added or removed via the inspector.
+            var currentMaterials = clippingPrimitive.GetMaterialsCopy();
+
+            foreach (var material in previousMaterials.Except(currentMaterials))
+            {
+                // ResetMaterial rather than RemoveMaterial since the material has already been removed from the list.
+                clippingPrimitive.ResetMaterial(material);
+            }
+
+            foreach (var material in currentMaterials.Except(previousMaterials))
+            {
+                clippingPrimitive.AddMaterial(material);
             }
         }
     }

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingBox.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingBox.cs
@@ -65,5 +65,11 @@ namespace Microsoft.MixedReality.GraphicsTools
         {
             materialPropertyBlock.SetMatrix(clipBoxInverseTransformID, clipBoxInverseTransform);
         }
+
+        /// <inheritdoc />
+        protected override void UpdateShaderProperties(Material material)
+        {
+            material.SetMatrix(clipBoxInverseTransformID, clipBoxInverseTransform);
+        }
     }
 }

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingPlane.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingPlane.cs
@@ -66,5 +66,11 @@ namespace Microsoft.MixedReality.GraphicsTools
         {
             materialPropertyBlock.SetVector(clipPlaneID, clipPlane);
         }
+
+        /// <inheritdoc />
+        protected override void UpdateShaderProperties(Material material)
+        {
+            material.SetVector(clipPlaneID, clipPlane);
+        }
     }
 }

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingPrimitive.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingPrimitive.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.GraphicsTools
     public abstract class ClippingPrimitive : MonoBehaviour, IMaterialInstanceOwner
     {
         [Header("Renders to Clip")]
-        [Tooltip("The renderer(s) that should be affected by the primitive.")]
+        [Tooltip("The renderer(s) that should be affected by the primitive. Renderers with materials in the materials list do not need to be added to this list.")]
         [SerializeField]
         protected List<Renderer> renderers = new List<Renderer>();
 
@@ -45,7 +45,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         }
 
         [Header("Materials to Clip")]
-        [Tooltip("The materials(s) that should be affected by the primitive.")]
+        [Tooltip("The materials(s) that should be affected by the primitive. Materials on renderers within the renderers list do not need to be added to this list.")]
         [SerializeField]
         protected List<Material> materials = new List<Material>();
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingPrimitive.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingPrimitive.cs
@@ -14,37 +14,16 @@ namespace Microsoft.MixedReality.GraphicsTools
     [ExecuteAlways]
     public abstract class ClippingPrimitive : MonoBehaviour, IMaterialInstanceOwner
     {
+        [Header("Renders to Clip")]
         [Tooltip("The renderer(s) that should be affected by the primitive.")]
         [SerializeField]
         protected List<Renderer> renderers = new List<Renderer>();
 
-        /// <summary>
-        /// Should clipping occur inside or outside of the clipping shape?
-        /// </summary>
-        public enum Side
-        {
-            Inside = 1,
-            Outside = -1
-        }
-
-        [Tooltip("Which side of the primitive to clip pixels against.")]
-        [SerializeField]
-        protected Side clippingSide = Side.Inside;
-
-        /// <summary>
-        /// Which side of the primitive to clip pixels against.
-        /// </summary>
-        public Side ClippingSide
-        {
-            get => clippingSide;
-            set => clippingSide = value;
-        }
-
-        [SerializeField, Tooltip("Controls clipping features on the shared materials rather than material instances.")]
+        [SerializeField, Tooltip("Toggles whether clipping will apply to shared materials or material instances (default) on Renderers within the renderers list.")]
         private bool applyToSharedMaterial = false;
 
         /// <summary>
-        /// Toggles whether the clipping features will apply to shared materials or material instances (default).
+        /// Toggles whether clipping will apply to shared materials or material instances (default) on Renderers within the renderers list.
         /// </summary>
         /// <remarks>
         /// Applying to shared materials will allow for GPU instancing to batch calls between Renderers that interact with the same clipping primitives.
@@ -63,6 +42,34 @@ namespace Microsoft.MixedReality.GraphicsTools
                     applyToSharedMaterial = value;
                 }
             }
+        }
+
+        [Header("Materials to Clip")]
+        [Tooltip("The materials(s) that should be affected by the primitive.")]
+        [SerializeField]
+        protected List<Material> materials = new List<Material>();
+
+        /// <summary>
+        /// Should clipping occur inside or outside of the clipping shape?
+        /// </summary>
+        public enum Side
+        {
+            Inside = 1,
+            Outside = -1
+        }
+
+        [Header("Clip Settings")]
+        [Tooltip("Which side of the primitive to clip pixels against.")]
+        [SerializeField]
+        protected Side clippingSide = Side.Inside;
+
+        /// <summary>
+        /// Which side of the primitive to clip pixels against.
+        /// </summary>
+        public Side ClippingSide
+        {
+            get => clippingSide;
+            set => clippingSide = value;
         }
 
         [SerializeField]
@@ -132,7 +139,6 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// <summary>
         /// Adds a renderer to the list of objects this clipping primitive clips.
         /// </summary>
-        /// <param name="_renderer">The renderer to add.</param>
         public void AddRenderer(Renderer _renderer)
         {
             if (_renderer != null)
@@ -148,7 +154,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         }
 
         /// <summary>
-        /// Removes a renderer to the list of objects this clipping primitive clips.
+        /// Removes a renderer from the list of objects this clipping primitive clips.
         /// </summary>
         public void RemoveRenderer(Renderer _renderer)
         {
@@ -200,12 +206,82 @@ namespace Microsoft.MixedReality.GraphicsTools
         }
 
         /// <summary>
+        /// Adds a material to the list of objects this clipping primitive clips.
+        /// </summary>
+        public void AddMaterial(Material material)
+        {
+            if (material != null)
+            {
+                if (!materials.Contains(material))
+                {
+                    materials.Add(material);
+                }
+
+                ToggleClippingFeature(material, gameObject.activeInHierarchy);
+                IsDirty = true;
+            }
+        }
+
+        /// <summary>
+        /// Removes a material from the list of objects this clipping primitive clips.
+        /// </summary>
+        public void RemoveMaterial(Material material)
+        {
+            int index = materials.IndexOf(material);
+            if (index >= 0)
+            {
+                RemoveMaterial(index);
+            }
+        }
+
+        private void RemoveMaterial(int index)
+        {
+            Material material = materials[index];
+
+            int lastIndex = materials.Count - 1;
+            if (index != lastIndex)
+            {
+                materials[index] = materials[lastIndex];
+            }
+
+            materials.RemoveAt(lastIndex);
+
+            if (material != null)
+            {
+                // There is no need to acquire new instances if ones do not already exist since we are 
+                // in the process of removing.
+                ToggleClippingFeature(material, false);
+            }
+        }
+
+        /// <summary>
+        /// Removes all materials in the list of objects this clipping primitive clips.
+        /// </summary>
+        public void ClearMaterials()
+        {
+            if (materials != null)
+            {
+                while (materials.Count != 0)
+                {
+                    RemoveMaterial(materials.Count - 1);
+                }
+            }
+        }
+
+        /// <summary>
         /// Returns a copy of the current list of renderers.
         /// </summary>
-        /// <returns>The current list of renderers.</returns>
         public IEnumerable<Renderer> GetRenderersCopy()
         {
             return new List<Renderer>(renderers);
+        }
+
+        /// <summary>
+        /// Returns a copy of the current list of materials.
+        /// </summary>
+        public IEnumerable<Material> GetMaterialsCopy()
+        {
+            return new List<Material>(materials);
         }
 
         #region MonoBehaviour Implementation
@@ -216,7 +292,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         protected void OnEnable()
         {
             Initialize();
-            UpdateRenderers();
+            UpdateRenderState();
 
 #if UNITY_EDITOR
             if (!Application.isPlaying)
@@ -243,7 +319,7 @@ namespace Microsoft.MixedReality.GraphicsTools
             UnityEditor.EditorApplication.update -= EditorUpdate;
 #endif
 
-            UpdateRenderers();
+            UpdateRenderState();
             ToggleClippingFeature(false);
 
             if (cameraMethods != null)
@@ -260,7 +336,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         protected void EditorUpdate()
         {
             Initialize();
-            UpdateRenderers();
+            UpdateRenderState();
         }
 #endif
 
@@ -272,7 +348,7 @@ namespace Microsoft.MixedReality.GraphicsTools
             // Deferring the LateUpdate() call to OnCameraPreRender()
             if (!useOnPreRender)
             {
-                UpdateRenderers();
+                UpdateRenderState();
             }
         }
 
@@ -282,7 +358,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         protected void OnCameraPreRender(CameraEventRouter router)
         {
             // Only subscribed to via UseOnPreRender property setter
-            UpdateRenderers();
+            UpdateRenderState();
         }
 
         /// <summary>
@@ -291,6 +367,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         protected void OnDestroy()
         {
             ClearRenderers();
+            ClearMaterials();
         }
 
         #endregion MonoBehaviour Implementation
@@ -305,7 +382,7 @@ namespace Microsoft.MixedReality.GraphicsTools
                 ToggleClippingFeature(materialInstance.AcquireMaterials(this), gameObject.activeInHierarchy);
             }
 
-            UpdateRenderers();
+            UpdateRenderState();
         }
 
         #endregion IMaterialInstanceOwner Implementation
@@ -320,33 +397,57 @@ namespace Microsoft.MixedReality.GraphicsTools
         }
 
         /// <summary>
-        /// Updates the render state of all renderers.
+        /// Updates the render state of all renderers and materials.
         /// </summary>
-        protected virtual void UpdateRenderers()
+        protected virtual void UpdateRenderState()
         {
-            if (renderers == null) { return; }
-
             CheckTransformChange();
-            if (!IsDirty) { return; }
+
+            if (!IsDirty) 
+            { 
+                return; 
+            }
 
             BeginUpdateShaderProperties();
 
-            for (int i = renderers.Count - 1; i >= 0; --i)
+            if (renderers != null)
             {
-                var _renderer = renderers[i];
-                if (_renderer == null)
+                for (int i = renderers.Count - 1; i >= 0; --i)
                 {
-                    if (Application.isPlaying)
+                    var _renderer = renderers[i];
+                    if (_renderer == null)
                     {
-                        RemoveRenderer(i);
+                        if (Application.isPlaying)
+                        {
+                            RemoveRenderer(i);
+                        }
+                        continue;
                     }
-                    continue;
-                }
 
-                _renderer.GetPropertyBlock(materialPropertyBlock);
-                materialPropertyBlock.SetFloat(clippingSideID, (float)clippingSide);
-                UpdateShaderProperties(materialPropertyBlock);
-                _renderer.SetPropertyBlock(materialPropertyBlock);
+                    _renderer.GetPropertyBlock(materialPropertyBlock);
+                    materialPropertyBlock.SetFloat(clippingSideID, (float)clippingSide);
+                    UpdateShaderProperties(materialPropertyBlock);
+                    _renderer.SetPropertyBlock(materialPropertyBlock);
+                }
+            }
+
+            if (materials != null)
+            {
+                for (int i = materials.Count - 1; i >= 0; --i)
+                {
+                    var material = materials[i];
+                    if (material == null)
+                    {
+                        if (Application.isPlaying)
+                        {
+                            RemoveMaterial(i);
+                        }
+                        continue;
+                    }
+
+                    material.SetFloat(clippingSideID, (float)clippingSide);
+                    UpdateShaderProperties(material);
+                }
             }
 
             EndUpdateShaderProperties();
@@ -361,8 +462,12 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// <summary>
         /// Method called for each renderer.
         /// </summary>
-        /// <param name="materialPropertyBlock">The property block on the renderer to be updated.</param>
         protected abstract void UpdateShaderProperties(MaterialPropertyBlock materialPropertyBlock);
+
+        /// <summary>
+        /// Method called for each material.
+        /// </summary>
+        protected abstract void UpdateShaderProperties(Material material);
 
         /// <summary>
         /// Method called when after each renderer is updated.
@@ -372,7 +477,6 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// <summary>
         /// Enables or disables clipping for all renderers.
         /// </summary>
-        /// <param name="keywordOn">True to turn on clipping.</param>
         protected void ToggleClippingFeature(bool keywordOn)
         {
             if (renderers != null)
@@ -387,18 +491,29 @@ namespace Microsoft.MixedReality.GraphicsTools
                     }
                 }
             }
+
+            if (materials != null)
+            {
+                for (var i = 0; i < materials.Count; ++i)
+                {
+                    var material = materials[i];
+
+                    if (material != null)
+                    {
+                        ToggleClippingFeature(material, keywordOn);
+                    }
+                }
+            }
         }
 
         /// <summary>
         /// Enables or disables clipping for a list of materials.
         /// </summary>
-        /// <param name="materials">The materials to update.</param>
-        /// <param name="keywordOn">True to turn on clipping.</param>
-        protected void ToggleClippingFeature(Material[] materials, bool keywordOn)
+        protected void ToggleClippingFeature(Material[] materialsToToggle, bool keywordOn)
         {
-            if (materials != null)
+            if (materialsToToggle != null)
             {
-                foreach (var material in materials)
+                foreach (var material in materialsToToggle)
                 {
                     ToggleClippingFeature(material, keywordOn);
                 }
@@ -408,19 +523,17 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// <summary>
         /// Enables or disables clipping on a material.
         /// </summary>
-        /// <param name="materials">The materials to update.</param>
-        /// <param name="keywordOn">True to turn on clipping.</param>
-        protected void ToggleClippingFeature(Material material, bool keywordOn)
+        protected void ToggleClippingFeature(Material materialToToggle, bool keywordOn)
         {
-            if (material != null)
+            if (materialToToggle != null)
             {
                 if (keywordOn)
                 {
-                    material.EnableKeyword(Keyword);
+                    materialToToggle.EnableKeyword(Keyword);
                 }
                 else
                 {
-                    material.DisableKeyword(Keyword);
+                    materialToToggle.DisableKeyword(Keyword);
                 }
             }
         }

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingPrimitive.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingPrimitive.cs
@@ -165,6 +165,26 @@ namespace Microsoft.MixedReality.GraphicsTools
             }
         }
 
+        /// <summary>
+        /// Resets the state of the renderer to before being added to the primitive.
+        /// </summary>
+        public void ResetRenderer(Renderer _renderer, bool autoDestroyMaterial = true)
+        {
+            if (_renderer != null)
+            {
+                // There is no need to acquire new instances if ones do not already exist since we are 
+                // in the process of removing.
+                ToggleClippingFeature(AcquireMaterials(_renderer, instance: false), false);
+
+                var materialInstance = _renderer.GetComponent<MaterialInstance>();
+
+                if (materialInstance != null)
+                {
+                    materialInstance.ReleaseMaterial(this, autoDestroyMaterial);
+                }
+            }
+        }
+
         private void RemoveRenderer(int index, bool autoDestroyMaterial = true)
         {
             Renderer _renderer = renderers[index];
@@ -177,18 +197,7 @@ namespace Microsoft.MixedReality.GraphicsTools
 
             renderers.RemoveAt(lastIndex);
 
-            if (_renderer != null)
-            {
-                // There is no need to acquire new instances if ones do not already exist since we are 
-                // in the process of removing.
-                ToggleClippingFeature(AcquireMaterials(_renderer, instance: false), false);
-
-                var materialInstance = _renderer.GetComponent<MaterialInstance>();
-                if (materialInstance != null)
-                {
-                    materialInstance.ReleaseMaterial(this, autoDestroyMaterial);
-                }
-            }
+            ResetRenderer(_renderer, autoDestroyMaterial);
         }
 
         /// <summary>
@@ -234,6 +243,17 @@ namespace Microsoft.MixedReality.GraphicsTools
             }
         }
 
+        /// <summary>
+        /// Resets the state of the material to before being added to the primitive.
+        /// </summary>
+        public void ResetMaterial(Material material)
+        {
+            if (material != null)
+            {
+                ToggleClippingFeature(material, false);
+            }
+        }
+
         private void RemoveMaterial(int index)
         {
             Material material = materials[index];
@@ -246,12 +266,7 @@ namespace Microsoft.MixedReality.GraphicsTools
 
             materials.RemoveAt(lastIndex);
 
-            if (material != null)
-            {
-                // There is no need to acquire new instances if ones do not already exist since we are 
-                // in the process of removing.
-                ToggleClippingFeature(material, false);
-            }
+            ResetMaterial(material);
         }
 
         /// <summary>

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingSphere.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingSphere.cs
@@ -82,5 +82,11 @@ namespace Microsoft.MixedReality.GraphicsTools
         {
             materialPropertyBlock.SetMatrix(clipSphereInverseTransformID, clipSphereInverseTransform);
         }
+
+        /// <inheritdoc />
+        protected override void UpdateShaderProperties(Material material)
+        {
+            material.SetMatrix(clipSphereInverseTransformID, clipSphereInverseTransform);
+        }
     }
 }

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshInstancing/MeshInstancer.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshInstancing/MeshInstancer.cs
@@ -664,6 +664,7 @@ namespace Microsoft.MixedReality.GraphicsTools
             }
         }
 
+#if UNITY_EDITOR
         private void OnGUI()
         {
             if (DisplayUpdateTime)
@@ -689,6 +690,7 @@ namespace Microsoft.MixedReality.GraphicsTools
                 GUI.Label(new Rect(10.0f, Screen.height - 24.0f, Screen.height, 128.0f), label);
             }
         }
+#endif
 
         private void Initialize()
         {

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshInstancing/MeshInstancer.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshInstancing/MeshInstancer.cs
@@ -664,7 +664,6 @@ namespace Microsoft.MixedReality.GraphicsTools
             }
         }
 
-#if UNITY_EDITOR
         private void OnGUI()
         {
             if (DisplayUpdateTime)
@@ -690,7 +689,6 @@ namespace Microsoft.MixedReality.GraphicsTools
                 GUI.Label(new Rect(10.0f, Screen.height - 24.0f, Screen.height, 128.0f), label);
             }
         }
-#endif
 
         private void Initialize()
         {

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBackplate.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBackplate.shader
@@ -96,6 +96,7 @@ SubShader {
 
     #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
     #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
     #include "UnityCG.cginc"
     #include "GraphicsToolsCommon.hlsl"
@@ -517,6 +518,8 @@ CBUFFER_END
 
     half4 frag(VertexOutput fragInput) : SV_Target
     {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
     #ifdef UNITY_UI_CLIP_RECT
         clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
     #endif
@@ -733,6 +736,8 @@ CBUFFER_END
 
         half4 secondFragment(VertexOutput fragInput) : SV_Target
         {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
     #ifdef UNITY_UI_CLIP_RECT
         clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
     #endif

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBeveled.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBeveled.shader
@@ -95,6 +95,7 @@ SubShader {
 
      #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
      #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+     #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
     #include "UnityCG.cginc"
     #include "GraphicsToolsCommon.hlsl"
@@ -433,6 +434,8 @@ CBUFFER_END
 
     half4 frag(VertexOutput fragInput) : SV_Target
     {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
 #if defined(UNITY_UI_CLIP_RECT)
         clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
 #endif

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasFrontplate.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasFrontplate.shader
@@ -113,6 +113,7 @@ SubShader {
     #pragma shader_feature_local _ _BLOB_ENABLE_2_
     #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
     #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
     #include "UnityCG.cginc"
     #include "GraphicsToolsCommon.hlsl"
@@ -181,6 +182,7 @@ CBUFFER_END
 
     struct VertexOutput {
         float4 pos : SV_POSITION;
+        float3 posWorld : TEXCOORD7;
 #ifdef UNITY_UI_CLIP_RECT
         float3 posLocal : TEXCOORD8;
 #endif
@@ -628,6 +630,7 @@ CBUFFER_END
         float4 Extra3 = Blob_Info_Q286;
 
         o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
 #ifdef UNITY_UI_CLIP_RECT
         o.posLocal = vertInput.vertex.xyz;
 #endif
@@ -719,6 +722,8 @@ CBUFFER_END
 
     half4 frag(VertexOutput fragInput) : SV_Target
     {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
     #ifdef UNITY_UI_CLIP_RECT
         clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
     #endif

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasGlow.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasGlow.shader
@@ -74,6 +74,7 @@ SubShader {
     #pragma target 4.0
     #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
     #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
     #include "UnityCG.cginc"
     #include "GraphicsToolsCommon.hlsl"
@@ -111,6 +112,7 @@ CBUFFER_END
 
     struct VertexOutput {
         float4 pos : SV_POSITION;
+        float3 posWorld : TEXCOORD7;
 #ifdef UNITY_UI_CLIP_RECT
         float3 posLocal : TEXCOORD8;
 #endif
@@ -184,6 +186,7 @@ CBUFFER_END
         float4 Color = vertInput.color;
 
         o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
 #ifdef UNITY_UI_CLIP_RECT
         o.posLocal = vertInput.vertex.xyz;
 #endif
@@ -233,6 +236,8 @@ CBUFFER_END
 
     half4 frag(VertexOutput fragInput) : SV_Target
     {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
     #ifdef UNITY_UI_CLIP_RECT
         clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
     #endif

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasProgressBar.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasProgressBar.shader
@@ -74,6 +74,7 @@ SubShader {
     #pragma shader_feature_local _ _CYCLE_
     #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
     #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
     #include "UnityCG.cginc"
     #include "GraphicsToolsCommon.hlsl"
@@ -111,6 +112,7 @@ CBUFFER_END
 
     struct VertexOutput {
         float4 pos : SV_POSITION;
+        float3 posWorld : TEXCOORD7;
 #ifdef UNITY_UI_CLIP_RECT
         float3 posLocal : TEXCOORD8;
 #endif
@@ -194,6 +196,7 @@ CBUFFER_END
         float4 Extra1 = Vec4_Q79;
 
         o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
 #ifdef UNITY_UI_CLIP_RECT
         o.posLocal = vertInput.vertex.xyz;
 #endif
@@ -278,6 +281,8 @@ CBUFFER_END
 
     half4 frag(VertexOutput fragInput) : SV_Target
     {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
     #ifdef UNITY_UI_CLIP_RECT
         clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
     #endif

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasQuadGlow.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasQuadGlow.shader
@@ -67,6 +67,7 @@ SubShader {
     #pragma target 4.0
     #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
     #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
     #include "UnityCG.cginc"
     #include "GraphicsToolsCommon.hlsl"
@@ -98,6 +99,7 @@ CBUFFER_END
 
     struct VertexOutput {
         float4 pos : SV_POSITION;
+        float3 posWorld : TEXCOORD7;
 #ifdef UNITY_UI_CLIP_RECT
         float3 posLocal : TEXCOORD8;
 #endif
@@ -147,6 +149,7 @@ CBUFFER_END
         float4 Color = vertInput.color;
 
         o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
 #ifdef UNITY_UI_CLIP_RECT
         o.posLocal = vertInput.vertex.xyz;
 #endif
@@ -196,6 +199,8 @@ CBUFFER_END
 
     half4 frag(VertexOutput fragInput) : SV_Target
     {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
     #ifdef UNITY_UI_CLIP_RECT
         clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
     #endif

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasRadialSpinner.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasRadialSpinner.shader
@@ -77,6 +77,7 @@ SubShader {
     #pragma shader_feature_local _ _CYCLE_
     #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
     #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
     #include "UnityCG.cginc"
     #include "GraphicsToolsCommon.hlsl"
@@ -113,6 +114,7 @@ CBUFFER_END
 
     struct VertexOutput {
         float4 pos : SV_POSITION;
+        float3 posWorld : TEXCOORD7;
 #ifdef UNITY_UI_CLIP_RECT
         float3 posLocal : TEXCOORD8;
 #endif
@@ -203,6 +205,7 @@ CBUFFER_END
         float4 Extra1 = Vec4_Q108;
 
         o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
 #ifdef UNITY_UI_CLIP_RECT
         o.posLocal = vertInput.vertex.xyz;
 #endif
@@ -271,6 +274,8 @@ CBUFFER_END
 
     half4 frag(VertexOutput fragInput) : SV_Target
     {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
     #ifdef UNITY_UI_CLIP_RECT
         clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
     #endif

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
@@ -178,7 +178,6 @@ Shader "Graphics Tools/Standard"
 
             #pragma multi_compile_instancing
             #pragma multi_compile _ LIGHTMAP_ON
-            #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
             #pragma shader_feature_local_fragment _CLIPPING_BORDER
 
@@ -241,7 +240,6 @@ Shader "Graphics Tools/Standard"
 
             #pragma multi_compile_instancing
             #pragma multi_compile _ LIGHTMAP_ON
-            #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
             #pragma shader_feature_local_fragment _CLIPPING_BORDER
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
@@ -170,21 +170,6 @@ float4 _HoverLightData[HOVER_LIGHT_COUNT * HOVER_LIGHT_DATA_SIZE];
 float4 _ProximityLightData[PROXIMITY_LIGHT_COUNT * PROXIMITY_LIGHT_DATA_SIZE];
 #endif
 
-#if defined(_CLIPPING_PLANE)
-half _ClipPlaneSide;
-float4 _ClipPlane;
-#endif
-
-#if defined(_CLIPPING_SPHERE)
-half _ClipSphereSide;
-float4x4 _ClipSphereInverseTransform;
-#endif
-
-#if defined(_CLIPPING_BOX)
-half _ClipBoxSide;
-float4x4 _ClipBoxInverseTransform;
-#endif
-
 /// <summary>
 /// Per material properties.
 /// </summary>

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
@@ -14,6 +14,8 @@
 /// Features.
 /// </summary>
 
+#pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
 #pragma shader_feature_local _ _ALPHATEST_ON _ALPHABLEND_ON _ALPHABLEND_TRANS_ON _ADDITIVE_ON
 #pragma shader_feature_local _DISABLE_ALBEDO_MAP
 #pragma shader_feature_local_fragment _ _METALLIC_TEXTURE_ALBEDO_CHANNEL_A _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsTextMeshPro.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsTextMeshPro.shader
@@ -209,19 +209,6 @@ SubShader {
         uniform float        _ScaleY;
         uniform float        _PerspectiveFilter;
         uniform float        _Sharpness;
-
-        // #if defined(_CLIPPING_PLANE)
-        fixed _ClipPlaneSide;
-        float4 _ClipPlane;
-
-        // #if defined(_CLIPPING_SPHERE)
-        fixed _ClipSphereSide;
-        float4x4 _ClipSphereInverseTransform;
-
-        // #if defined(_CLIPPING_BOX)
-        fixed _ClipBoxSide;
-        float4x4 _ClipBoxInverseTransform;
-
 CBUFFER_END
 
         struct vertex_t {

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsWireframe.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsWireframe.shader
@@ -68,19 +68,6 @@ Shader "Graphics Tools/Wireframe"
             float _WireThickness;
             CBUFFER_END
 
-#if defined (_CLIPPING_PLANE)
-            half _ClipPlaneSide;
-            float4 _ClipPlane;
-#endif
-#if defined(_CLIPPING_SPHERE)
-            half _ClipSphereSide;
-            float4x4 _ClipSphereInverseTransform;
-#endif
-#if defined (_CLIPPING_BOX)
-            half _ClipBoxSide;
-            float4x4 _ClipBoxInverseTransform;
-#endif
-
             struct v2g
             {
                 float4 viewPos : SV_POSITION;
@@ -158,17 +145,7 @@ Shader "Graphics Tools/Wireframe"
             float4 frag(g2f i) : COLOR
             {
 #if defined(_CLIPPING_PRIMITIVE)
-                float primitiveDistance = 1.0;
-#if defined(_CLIPPING_PLANE)
-                primitiveDistance = min(primitiveDistance, GTPointVsPlane(i.worldPos.xyz, _ClipPlane) * _ClipPlaneSide);
-#endif
-#if defined(_CLIPPING_SPHERE)
-                primitiveDistance = min(primitiveDistance, GTPointVsSphere(i.worldPos.xyz, _ClipSphereInverseTransform) * _ClipSphereSide);
-#endif
-#if defined(_CLIPPING_BOX)
-                primitiveDistance = min(primitiveDistance, GTPointVsBox(i.worldPos.xyz, _ClipBoxInverseTransform) * _ClipBoxSide);
-#endif
-                clip(primitiveDistance);
+                ClipAgainstPrimitive(i.worldPos);
 #endif
 
                 // Calculate  minimum distance to one of the triangle lines, making sure to correct

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplate.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplate.shader
@@ -109,12 +109,6 @@ SubShader {
 
     #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
-    #if defined(_CLIPPING_PLANE) || defined(_CLIPPING_SPHERE) || defined(_CLIPPING_BOX)
-        #define _CLIPPING_PRIMITIVE
-    #else
-        #undef _CLIPPING_PRIMITIVE
-    #endif
-
     #include "UnityCG.cginc"
     #include "GraphicsToolsCommon.hlsl"
 
@@ -158,19 +152,6 @@ CBUFFER_START(UnityPerMaterial)
     //bool _Smooth_Edges_;
 
 CBUFFER_END
-
-#if defined (_CLIPPING_PLANE)
-    half _ClipPlaneSide;
-    float4 _ClipPlane;
-#endif
-#if defined(_CLIPPING_SPHERE)
-    half _ClipSphereSide;
-    float4x4 _ClipSphereInverseTransform;
-#endif
-#if defined (_CLIPPING_BOX)
-    half _ClipBoxSide;
-    float4x4 _ClipBoxInverseTransform;
-#endif
 
     struct VertexInput {
         float4 vertex : POSITION;
@@ -601,19 +582,8 @@ CBUFFER_END
 
     half4 frag(VertexOutput fragInput) : SV_Target
     {
-#if defined(_CLIPPING_PRIMITIVE)
-        float primitiveDistance = 1.0;
-#if defined(_CLIPPING_PLANE)
-        primitiveDistance = min(primitiveDistance, GTPointVsPlane(fragInput.posWorld.xyz, _ClipPlane) * _ClipPlaneSide);
-#endif
-#if defined(_CLIPPING_SPHERE)
-        primitiveDistance = min(primitiveDistance, GTPointVsSphere(fragInput.posWorld.xyz, _ClipSphereInverseTransform) * _ClipSphereSide);
-#endif
-#if defined(_CLIPPING_BOX)
-        primitiveDistance = min(primitiveDistance, GTPointVsBox(fragInput.posWorld.xyz, _ClipBoxInverseTransform) * _ClipBoxSide);
-#endif
-        clip(primitiveDistance);
-#endif
+        ClipAgainstPrimitive(fragInput.posWorld);
+
         half4 result;
 
         half Inside_Rect_Q1162;

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBeveled.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBeveled.shader
@@ -150,19 +150,6 @@ CBUFFER_START(UnityPerMaterial)
 
 CBUFFER_END
 
-#if defined (_CLIPPING_PLANE)
-    half _ClipPlaneSide;
-    float4 _ClipPlane;
-#endif
-#if defined(_CLIPPING_SPHERE)
-    half _ClipSphereSide;
-    float4x4 _ClipSphereInverseTransform;
-#endif
-#if defined (_CLIPPING_BOX)
-    half _ClipBoxSide;
-    float4x4 _ClipBoxInverseTransform;
-#endif
-
     struct VertexInput {
         float4 vertex : POSITION;
         half3 normal : NORMAL;
@@ -453,19 +440,8 @@ CBUFFER_END
 
     half4 frag(VertexOutput fragInput) : SV_Target
     {
-#if defined(_CLIPPING_PRIMITIVE)
-        float primitiveDistance = 1.0;
-#if defined(_CLIPPING_PLANE)
-        primitiveDistance = min(primitiveDistance, GTPointVsPlane(fragInput.posWorld.xyz, _ClipPlane) * _ClipPlaneSide);
-#endif
-#if defined(_CLIPPING_SPHERE)
-        primitiveDistance = min(primitiveDistance, GTPointVsSphere(fragInput.posWorld.xyz, _ClipSphereInverseTransform) * _ClipSphereSide);
-#endif
-#if defined(_CLIPPING_BOX)
-        primitiveDistance = min(primitiveDistance, GTPointVsBox(fragInput.posWorld.xyz, _ClipBoxInverseTransform) * _ClipBoxSide);
-#endif
-        clip(primitiveDistance);
-#endif
+        ClipAgainstPrimitive(fragInput.posWorld);
+
         half4 result;
 
         // Normalize3 (#1414)

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasFrontplate.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasFrontplate.shader
@@ -101,12 +101,6 @@ SubShader {
     #pragma target 4.0
     #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
-    #if defined(_CLIPPING_PLANE) || defined(_CLIPPING_SPHERE) || defined(_CLIPPING_BOX)
-        #define _CLIPPING_PRIMITIVE
-    #else
-        #undef _CLIPPING_PRIMITIVE
-    #endif
-
     #include "UnityCG.cginc"
     #include "GraphicsToolsCommon.hlsl"
 
@@ -157,19 +151,6 @@ CBUFFER_END
 
     float4 Global_Left_Index_Tip_Position;
     float4 Global_Right_Index_Tip_Position;
-
-#if defined (_CLIPPING_PLANE)
-    half _ClipPlaneSide;
-    float4 _ClipPlane;
-#endif
-#if defined(_CLIPPING_SPHERE)
-    half _ClipSphereSide;
-    float4x4 _ClipSphereInverseTransform;
-#endif
-#if defined (_CLIPPING_BOX)
-    half _ClipBoxSide;
-    float4x4 _ClipBoxInverseTransform;
-#endif
 
     struct VertexInput {
         float4 vertex : POSITION;
@@ -724,19 +705,8 @@ CBUFFER_END
 
     half4 frag(VertexOutput fragInput) : SV_Target
     {
-#if defined(_CLIPPING_PRIMITIVE)
-        float primitiveDistance = 1.0;
-#if defined(_CLIPPING_PLANE)
-        primitiveDistance = min(primitiveDistance, GTPointVsPlane(fragInput.posWorld.xyz, _ClipPlane) * _ClipPlaneSide);
-#endif
-#if defined(_CLIPPING_SPHERE)
-        primitiveDistance = min(primitiveDistance, GTPointVsSphere(fragInput.posWorld.xyz, _ClipSphereInverseTransform) * _ClipSphereSide);
-#endif
-#if defined(_CLIPPING_BOX)
-        primitiveDistance = min(primitiveDistance, GTPointVsBox(fragInput.posWorld.xyz, _ClipBoxInverseTransform) * _ClipBoxSide);
-#endif
-        clip(primitiveDistance);
-#endif
+        ClipAgainstPrimitive(fragInput.posWorld);
+
         half4 result;
 
         // Is_Quad (#1252)

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasGlow.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasGlow.shader
@@ -61,12 +61,6 @@ SubShader {
     #pragma target 4.0
     #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
-    #if defined(_CLIPPING_PLANE) || defined(_CLIPPING_SPHERE) || defined(_CLIPPING_BOX)
-        #define _CLIPPING_PRIMITIVE
-    #else
-        #undef _CLIPPING_PRIMITIVE
-    #endif
-
     #include "UnityCG.cginc"
     #include "GraphicsToolsCommon.hlsl"
 
@@ -87,19 +81,6 @@ CBUFFER_START(UnityPerMaterial)
     half _Bias_;
 
 CBUFFER_END
-
-#if defined (_CLIPPING_PLANE)
-    half _ClipPlaneSide;
-    float4 _ClipPlane;
-#endif
-#if defined(_CLIPPING_SPHERE)
-    half _ClipSphereSide;
-    float4x4 _ClipSphereInverseTransform;
-#endif
-#if defined (_CLIPPING_BOX)
-    half _ClipBoxSide;
-    float4x4 _ClipBoxInverseTransform;
-#endif
 
     struct VertexInput {
         float4 vertex : POSITION;
@@ -204,19 +185,8 @@ CBUFFER_END
 
     half4 frag(VertexOutput fragInput) : SV_Target
     {
-#if defined(_CLIPPING_PRIMITIVE)
-        float primitiveDistance = 1.0;
-#if defined(_CLIPPING_PLANE)
-        primitiveDistance = min(primitiveDistance, GTPointVsPlane(fragInput.posWorld.xyz, _ClipPlane) * _ClipPlaneSide);
-#endif
-#if defined(_CLIPPING_SPHERE)
-        primitiveDistance = min(primitiveDistance, GTPointVsSphere(fragInput.posWorld.xyz, _ClipSphereInverseTransform) * _ClipSphereSide);
-#endif
-#if defined(_CLIPPING_BOX)
-        primitiveDistance = min(primitiveDistance, GTPointVsBox(fragInput.posWorld.xyz, _ClipBoxInverseTransform) * _ClipBoxSide);
-#endif
-        clip(primitiveDistance);
-#endif
+        ClipAgainstPrimitive(fragInput.posWorld);
+
         half4 result;
 
         // To_XY (#197)

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasQuadGlow.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasQuadGlow.shader
@@ -58,12 +58,6 @@ SubShader {
     #pragma target 4.0
     #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
-    #if defined(_CLIPPING_PLANE) || defined(_CLIPPING_SPHERE) || defined(_CLIPPING_BOX)
-        #define _CLIPPING_PRIMITIVE
-    #else
-        #undef _CLIPPING_PRIMITIVE
-    #endif
-
     #include "UnityCG.cginc"
     #include "GraphicsToolsCommon.hlsl"
 
@@ -77,19 +71,6 @@ CBUFFER_START(UnityPerMaterial)
     half _Glow_Falloff_;
 
 CBUFFER_END
-
-#if defined (_CLIPPING_PLANE)
-    half _ClipPlaneSide;
-    float4 _ClipPlane;
-#endif
-#if defined(_CLIPPING_SPHERE)
-    half _ClipSphereSide;
-    float4x4 _ClipSphereInverseTransform;
-#endif
-#if defined (_CLIPPING_BOX)
-    half _ClipBoxSide;
-    float4x4 _ClipBoxInverseTransform;
-#endif
 
     struct VertexInput {
         float4 vertex : POSITION;
@@ -203,19 +184,8 @@ CBUFFER_END
 
     half4 frag(VertexOutput fragInput) : SV_Target
     {
-#if defined(_CLIPPING_PRIMITIVE)
-        float primitiveDistance = 1.0;
-#if defined(_CLIPPING_PLANE)
-        primitiveDistance = min(primitiveDistance, GTPointVsPlane(fragInput.posWorld.xyz, _ClipPlane) * _ClipPlaneSide);
-#endif
-#if defined(_CLIPPING_SPHERE)
-        primitiveDistance = min(primitiveDistance, GTPointVsSphere(fragInput.posWorld.xyz, _ClipSphereInverseTransform) * _ClipSphereSide);
-#endif
-#if defined(_CLIPPING_BOX)
-        primitiveDistance = min(primitiveDistance, GTPointVsBox(fragInput.posWorld.xyz, _ClipBoxInverseTransform) * _ClipBoxSide);
-#endif
-        clip(primitiveDistance);
-#endif
+        ClipAgainstPrimitive(fragInput.posWorld);
+
         half4 result;
 
         // To_XYZ (#1374)

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasSlateProximity.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasSlateProximity.shader
@@ -59,8 +59,10 @@ SubShader {
     #pragma multi_compile_instancing
     #pragma target 4.0
     #pragma multi_compile_local _ _ROUNDED_
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
 
     #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
 
 CBUFFER_START(UnityPerMaterial)
     //bool _Rounded_;
@@ -100,6 +102,7 @@ CBUFFER_END
 
     struct VertexOutput {
         float4 pos : SV_POSITION;
+        float3 posWorld : TEXCOORD7;
         half4 normalWorld : TEXCOORD5;
         float2 uv : TEXCOORD0;
         float4 extra1 : TEXCOORD4;
@@ -290,6 +293,7 @@ CBUFFER_END
         float4 Extra1 = Clip_Info_Q985;
 
         o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
         o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
         o.uv = UV;
         o.extra1=Extra1;
@@ -327,6 +331,8 @@ CBUFFER_END
 
     half4 frag(VertexOutput fragInput) : SV_Target
     {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
         half4 result;
 
         half Result_Q984;

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/FlyCameraController.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/FlyCameraController.cs
@@ -172,6 +172,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// <summary>
         /// Displays the camera controls via a user interface.
         /// </summary>
+#if UNITY_EDITOR
         private void OnGUI()
         {
             if (!XRDeviceIsPresent() && showControlsText)
@@ -192,6 +193,7 @@ namespace Microsoft.MixedReality.GraphicsTools
                 }
             }
         }
+#endif
 
         /// <summary>
         /// Returns true if an XR device is connected and running. For example a VR headset.

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/FlyCameraController.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/FlyCameraController.cs
@@ -172,7 +172,6 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// <summary>
         /// Displays the camera controls via a user interface.
         /// </summary>
-#if UNITY_EDITOR
         private void OnGUI()
         {
             if (!XRDeviceIsPresent() && showControlsText)
@@ -193,7 +192,6 @@ namespace Microsoft.MixedReality.GraphicsTools
                 }
             }
         }
-#endif
 
         /// <summary>
         /// Returns true if an XR device is connected and running. For example a VR headset.

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "msftFeatureCategory": "MRTK3",

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
## Overview

This PR adds a new property to the base clipping primitive that allows for materials to also be targets for clipping:
![image](https://user-images.githubusercontent.com/13305729/190000458-2845f890-62c3-4f14-b95f-cb2edf89011d.png)

This allows "pro" users to manage what gets clipping on a per-material basis for better performance and control. This also unlocks the ability to clip canvas-based objects:

![CanvasClip](https://user-images.githubusercontent.com/13305729/190001654-a3f28cfc-34a5-4954-9be1-7815ca9144a9.gif)

This also fixes an issue where renderers were not being removed correctly when edited in the inspector.


## Changes
- Fixes: #98 


## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
