### PR TITLE
Canvas Mesh Unique Texture Support

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Canvas/CanvasElementMesh.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Canvas/CanvasElementMesh.cs
@@ -45,11 +45,6 @@ namespace Microsoft.MixedReality.GraphicsTools
             {
                 if (texture == null)
                 {
-                    if (material != null && material.mainTexture != null)
-                    {
-                        return material.mainTexture;
-                    }
-
                     return s_WhiteTexture;
                 }
 
@@ -58,11 +53,6 @@ namespace Microsoft.MixedReality.GraphicsTools
             set
             {
                 texture = value;
-
-                if (texture != null && material != null)
-                {
-                    material.mainTexture = texture;
-                }
             }
         }
 
@@ -130,6 +120,15 @@ namespace Microsoft.MixedReality.GraphicsTools
 
         #region Graphic Implementation
 
+        /// <inheritdoc/>
+        public override Texture mainTexture
+        {
+            get
+            {
+                return Texture;
+            }
+        }
+
         /// <summary>
         /// Callback function when a UI element needs to generate vertices.
         /// </summary>
@@ -182,20 +181,6 @@ namespace Microsoft.MixedReality.GraphicsTools
             }
 
             vh.AddUIVertexStream(uiVerticiesTRS, uiIndices);
-        }
-
-        /// <summary>
-        /// Called to update the Material of the graphic onto the CanvasRenderer.
-        /// </summary>
-        protected override void UpdateMaterial()
-        {
-            if (!IsActive())
-            {
-                return;
-            }
-
-            canvasRenderer.materialCount = 1;
-            canvasRenderer.SetMaterial(materialForRendering, 0);
         }
 
         #endregion Graphic Implementation

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "msftFeatureCategory": "MRTK3",

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
## Overview

Canvas Element Meshes now support unique textures like Image or RawImage components:
![image](https://user-images.githubusercontent.com/13305729/193099678-4b27a886-b15e-4de8-a2c2-8cb8ccd0c58b.png)

## Changes
- Fixes: #105 

## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
