### PR TITLE
Add NPR Rendering to GraphicsTools/StandardShader

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -26,8 +26,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
     {
         Unlit = 0,
         LitDirectional = 1,
-        LitDistant = 2,
-        NonPhotorealistic = 3
+        LitDistant = 2
     }
 
     /// <summary>
@@ -111,10 +110,10 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             public static readonly GUIContent enableSSAA = new GUIContent("Super Sample Anti-Aliasing", "Enable Super Sample Anti-Aliasing, a technique improves texture clarity at long distances");
             public static readonly GUIContent mipmapBias = new GUIContent("Mipmap Bias", "Degree to bias the mip map. A larger negative value reduces aliasing and improves clarity, but may decrease performance");
             public static readonly GUIContent lightMode = new GUIContent("Light Mode", "What Type of Direct Light Affects the Surface");
-            public static readonly string[] lightModeNames = new string[] { "Unlit", "Lit - Directional", "Lit - Distant" , "Non - Photorealistic" };
+            public static readonly string[] lightModeNames = new string[] { "Unlit", "Lit - Directional", "Lit - Distant" };
             public static readonly string lightModeLitDirectional = "_DIRECTIONAL_LIGHT";
             public static readonly string lightModeLitDistant = "_DISTANT_LIGHT";
-            public static readonly string lightModeNPR = "_NPR_Rendering";
+            public static readonly GUIContent nonPhotorealisticRendering = new GUIContent("Non-Photorealistic Rendering","Non-Photorealistic Rendering");
             public static readonly GUIContent specularHighlights = new GUIContent("Specular Highlights", "Calculate Specular Highlights");
             public static readonly GUIContent sphericalHarmonics = new GUIContent("Spherical Harmonics", "Read From Spherical Harmonics Data for Ambient Light");
             public static readonly GUIContent reflections = new GUIContent("Reflections", "Calculate Glossy Reflections");
@@ -232,6 +231,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         protected MaterialProperty metallic;
         protected MaterialProperty smoothness;
         protected MaterialProperty lightMode;
+        protected MaterialProperty nonPhotorealisticRendering;
         protected MaterialProperty specularHighlights;
         protected MaterialProperty sphericalHarmonics;
         protected MaterialProperty reflections;
@@ -345,6 +345,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             enableSSAA = FindProperty("_EnableSSAA", props);
             mipmapBias = FindProperty("_MipmapBias", props);
             lightMode = FindProperty("_DirectionalLight", props);
+            nonPhotorealisticRendering = FindProperty("_NPR", props);
             specularHighlights = FindProperty("_SpecularHighlights", props);
             sphericalHarmonics = FindProperty("_SphericalHarmonics", props);
             reflections = FindProperty("_Reflections", props);
@@ -697,30 +698,20 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                     {
                         material.DisableKeyword(Styles.lightModeLitDirectional);
                         material.DisableKeyword(Styles.lightModeLitDistant);
-                        material.DisableKeyword(Styles.lightModeNPR);
                     }
                     break;
                 case LightMode.LitDirectional:
                     {
                         material.EnableKeyword(Styles.lightModeLitDirectional);
                         material.DisableKeyword(Styles.lightModeLitDistant);
-                        material.DisableKeyword(Styles.lightModeNPR);
                     }
                     break;
                 case LightMode.LitDistant:
                     {
                         material.DisableKeyword(Styles.lightModeLitDirectional);
                         material.EnableKeyword(Styles.lightModeLitDistant);
-                        material.DisableKeyword(Styles.lightModeNPR);
 
                         GUILayout.Box(string.Format(Styles.propertiesComponentHelp, nameof(DistantLight), Styles.lightModeNames[(int)LightMode.LitDistant]), EditorStyles.helpBox, Array.Empty<GUILayoutOption>());
-                    }
-                    break;
-                case LightMode.NonPhotorealistic:
-                    {
-                        material.EnableKeyword(Styles.lightModeNPR);
-                        material.DisableKeyword(Styles.lightModeLitDirectional);
-                        material.DisableKeyword(Styles.lightModeLitDistant);
                     }
                     break;
             }
@@ -729,6 +720,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             {
                 materialEditor.ShaderProperty(specularHighlights, Styles.specularHighlights, 2);
                 materialEditor.ShaderProperty(sphericalHarmonics, Styles.sphericalHarmonics, 2);
+                materialEditor.ShaderProperty(nonPhotorealisticRendering, Styles.nonPhotorealisticRendering, 2);
             }
 
             materialEditor.ShaderProperty(reflections, Styles.reflections);

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -26,7 +26,8 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
     {
         Unlit = 0,
         LitDirectional = 1,
-        LitDistant = 2
+        LitDistant = 2,
+        NonPhotorealistic = 3
     }
 
     /// <summary>
@@ -110,9 +111,10 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             public static readonly GUIContent enableSSAA = new GUIContent("Super Sample Anti-Aliasing", "Enable Super Sample Anti-Aliasing, a technique improves texture clarity at long distances");
             public static readonly GUIContent mipmapBias = new GUIContent("Mipmap Bias", "Degree to bias the mip map. A larger negative value reduces aliasing and improves clarity, but may decrease performance");
             public static readonly GUIContent lightMode = new GUIContent("Light Mode", "What Type of Direct Light Affects the Surface");
-            public static readonly string[] lightModeNames = new string[] { "Unlit", "Lit - Directional", "Lit - Distant" };
+            public static readonly string[] lightModeNames = new string[] { "Unlit", "Lit - Directional", "Lit - Distant" , "Non - Photorealistic" };
             public static readonly string lightModeLitDirectional = "_DIRECTIONAL_LIGHT";
             public static readonly string lightModeLitDistant = "_DISTANT_LIGHT";
+            public static readonly string lightModeNPR = "_NPR_Rendering";
             public static readonly GUIContent specularHighlights = new GUIContent("Specular Highlights", "Calculate Specular Highlights");
             public static readonly GUIContent sphericalHarmonics = new GUIContent("Spherical Harmonics", "Read From Spherical Harmonics Data for Ambient Light");
             public static readonly GUIContent reflections = new GUIContent("Reflections", "Calculate Glossy Reflections");
@@ -695,20 +697,30 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                     {
                         material.DisableKeyword(Styles.lightModeLitDirectional);
                         material.DisableKeyword(Styles.lightModeLitDistant);
+                        material.DisableKeyword(Styles.lightModeNPR);
                     }
                     break;
                 case LightMode.LitDirectional:
                     {
                         material.EnableKeyword(Styles.lightModeLitDirectional);
                         material.DisableKeyword(Styles.lightModeLitDistant);
+                        material.DisableKeyword(Styles.lightModeNPR);
                     }
                     break;
                 case LightMode.LitDistant:
                     {
                         material.DisableKeyword(Styles.lightModeLitDirectional);
                         material.EnableKeyword(Styles.lightModeLitDistant);
+                        material.DisableKeyword(Styles.lightModeNPR);
 
                         GUILayout.Box(string.Format(Styles.propertiesComponentHelp, nameof(DistantLight), Styles.lightModeNames[(int)LightMode.LitDistant]), EditorStyles.helpBox, Array.Empty<GUILayoutOption>());
+                    }
+                    break;
+                case LightMode.NonPhotorealistic:
+                    {
+                        material.EnableKeyword(Styles.lightModeNPR);
+                        material.DisableKeyword(Styles.lightModeLitDirectional);
+                        material.DisableKeyword(Styles.lightModeLitDistant);
                     }
                     break;
             }

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -232,10 +232,9 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         protected MaterialProperty smoothness;
         protected MaterialProperty lightMode;
         protected MaterialProperty lightModeProxy;
-        protected MaterialProperty nonPhotorealisticRendering;
-        protected MaterialProperty lightModeProxy;
         protected MaterialProperty specularHighlights;
         protected MaterialProperty sphericalHarmonics;
+        protected MaterialProperty nonPhotorealisticRendering;
         protected MaterialProperty reflections;
         protected MaterialProperty rimLight;
         protected MaterialProperty rimColor;
@@ -348,9 +347,9 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             mipmapBias = FindProperty("_MipmapBias", props);
             lightMode = FindProperty("_DirectionalLight", props);
             lightModeProxy = FindProperty("_DirectionalLightProxy", props, false);
-            nonPhotorealisticRendering = FindProperty("_NPR", props);
             specularHighlights = FindProperty("_SpecularHighlights", props);
             sphericalHarmonics = FindProperty("_SphericalHarmonics", props);
+            nonPhotorealisticRendering = FindProperty("_NPR", props);
             reflections = FindProperty("_Reflections", props);
             rimLight = FindProperty("_RimLight", props);
             rimColor = FindProperty("_RimColor", props);

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsLighting.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsLighting.hlsl
@@ -1,7 +1,6 @@
-// Copyright © 2020 Unity Technologies ApS
+// Copyright ÔøΩ 2020 Unity Technologies ApS
 // Licensed under the Unity Companion License for Unity-dependent projects--see https://unity3d.com/legal/licenses/Unity_Companion_License
-// Unless expressly provided otherwise, the Software under this license is made available strictly on an ìAS ISÅEBASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. Please review the license for details on these and other terms and conditions.
-
+// Unless expressly provided otherwise, the Software under this license is made available strictly on an AS IS BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. Please review the license for details on these and other terms and conditions.
 #ifndef GT_LIGHTING
 #define GT_LIGHTING
 
@@ -18,8 +17,8 @@ struct GTMainLight
 GTMainLight GTGetMainLight()
 {
     GTMainLight light;
-#if defined(_DIRECTIONAL_LIGHT) || defined(_DISTANT_LIGHT)|| defined(_NPR_Rendering)
-#if defined(_DISTANT_LIGHT) 
+#if defined(_DIRECTIONAL_LIGHT) || defined(_DISTANT_LIGHT)|| defined(_NON_PHOTOREALISTIC)
+#if defined(_DISTANT_LIGHT)
     light.direction = _DistantLightData[0].xyz;
     light.color = _DistantLightData[1].xyz;
 #else

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsLighting.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsLighting.hlsl
@@ -1,6 +1,6 @@
 // Copyright © 2020 Unity Technologies ApS
 // Licensed under the Unity Companion License for Unity-dependent projects--see https://unity3d.com/legal/licenses/Unity_Companion_License
-// Unless expressly provided otherwise, the Software under this license is made available strictly on an ìAS ISî BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. Please review the license for details on these and other terms and conditions.
+// Unless expressly provided otherwise, the Software under this license is made available strictly on an ìAS ISÅEBASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. Please review the license for details on these and other terms and conditions.
 
 #ifndef GT_LIGHTING
 #define GT_LIGHTING
@@ -18,8 +18,8 @@ struct GTMainLight
 GTMainLight GTGetMainLight()
 {
     GTMainLight light;
-#if defined(_DIRECTIONAL_LIGHT) || defined(_DISTANT_LIGHT)
-#if defined(_DISTANT_LIGHT)
+#if defined(_DIRECTIONAL_LIGHT) || defined(_DISTANT_LIGHT)|| defined(_NPR_Rendering)
+#if defined(_DISTANT_LIGHT) 
     light.direction = _DistantLightData[0].xyz;
     light.color = _DistantLightData[1].xyz;
 #else
@@ -231,6 +231,19 @@ half3 GTLightingPhysicallyBased(GTBRDFData brdfData,
 #endif
 
     return brdf * radiance;
+}
+
+
+half3 GTLightingNonPhotorealistic(GTBRDFData brdfData,
+half3 lightColor, half3 lightDirectionWS,
+half3 normalWS, half3 viewDirectionWS)
+{
+   half NdotL = ceil(saturate(dot(normalWS, lightDirectionWS)));
+   half3 radiance = lightColor * NdotL;
+
+   half3 brdf = brdfData.diffuse;
+
+   return brdf * radiance;
 }
 
 #endif // GT_LIGHTING

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsLighting.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsLighting.hlsl
@@ -17,7 +17,7 @@ struct GTMainLight
 GTMainLight GTGetMainLight()
 {
     GTMainLight light;
-#if defined(_DIRECTIONAL_LIGHT) || defined(_DISTANT_LIGHT)|| defined(_NON_PHOTOREALISTIC)
+#if defined(_DIRECTIONAL_LIGHT) || defined(_DISTANT_LIGHT)
 #if defined(_DISTANT_LIGHT)
     light.direction = _DistantLightData[0].xyz;
     light.color = _DistantLightData[1].xyz;

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
@@ -34,6 +34,7 @@ Shader "Graphics Tools/Standard"
 
         // Rendering options.
         [Enum(Microsoft.MixedReality.GraphicsTools.Editor.LightMode)] _DirectionalLight("Light Mode", Float) = 1.0 // "LitDirectional"
+        [Toggle(_NON_PHOTOREALISTIC)] _NPR("Non-Photorealistic Rendering", Float) = 0.0
         [Toggle(_SPECULAR_HIGHLIGHTS)] _SpecularHighlights("Specular Highlights", Float) = 1.0
         [Toggle(_SPHERICAL_HARMONICS)] _SphericalHarmonics("Spherical Harmonics", Float) = 0.0
         [Toggle(_REFLECTIONS)] _Reflections("Reflections", Float) = 0.0

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvas.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvas.shader
@@ -34,6 +34,7 @@ Shader "Graphics Tools/Standard Canvas"
 
         // Rendering options.
         [Enum(Microsoft.MixedReality.GraphicsTools.Editor.LightMode)] _DirectionalLight("Light Mode", Float) = 0.0 // "Unlit"
+        [Toggle(_NON_PHOTOREALISTIC)] _NPR("Non-Photorealistic Rendering", Float) = 0.0
         [Toggle(_SPECULAR_HIGHLIGHTS)] _SpecularHighlights("Specular Highlights", Float) = 1.0
         [Toggle(_SPHERICAL_HARMONICS)] _SphericalHarmonics("Spherical Harmonics", Float) = 0.0
         [Toggle(_REFLECTIONS)] _Reflections("Reflections", Float) = 0.0

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
@@ -25,7 +25,8 @@
 #pragma shader_feature_local _TRIPLANAR_MAPPING
 #pragma shader_feature_local _LOCAL_SPACE_TRIPLANAR_MAPPING
 #pragma shader_feature_local_fragment _USE_SSAA
-#pragma shader_feature_local _ _DIRECTIONAL_LIGHT _DISTANT_LIGHT _NPR_Rendering
+#pragma shader_feature_local _ _DIRECTIONAL_LIGHT _DISTANT_LIGHT
+#pragma shader_feature_local _NON_PHOTOREALISTIC
 #pragma shader_feature_local_fragment _SPECULAR_HIGHLIGHTS
 #pragma shader_feature_local _SPHERICAL_HARMONICS
 #pragma shader_feature_local _REFLECTIONS
@@ -59,7 +60,7 @@
 ///  Defines and includes.
 /// </summary>
 
-#if defined(_TRIPLANAR_MAPPING) || defined(_DIRECTIONAL_LIGHT) || defined(_DISTANT_LIGHT) || defined(_NPR_Rendering) || defined(_SPHERICAL_HARMONICS) || defined(_REFLECTIONS) || defined(_RIM_LIGHT) || defined(_PROXIMITY_LIGHT) || defined(_ENVIRONMENT_COLORING) || defined(LIGHTMAP_ON)
+#if defined(_TRIPLANAR_MAPPING) || defined(_DIRECTIONAL_LIGHT) || defined(_DISTANT_LIGHT) || defined(_SPHERICAL_HARMONICS) || defined(_REFLECTIONS) || defined(_RIM_LIGHT) || defined(_PROXIMITY_LIGHT) || defined(_ENVIRONMENT_COLORING) || defined(LIGHTMAP_ON)
 #define _NORMAL
 #else
 #undef _NORMAL
@@ -762,7 +763,7 @@ half4 PixelStage(Varyings input, bool facing : SV_IsFrontFace) : SV_Target
     // Final lighting mix.
     half4 output = albedo;
 
-#if defined(_DIRECTIONAL_LIGHT) || defined(_DISTANT_LIGHT) || defined(_NPR_Rendering) || defined(_REFLECTIONS)
+#if defined(_DIRECTIONAL_LIGHT) || defined(_DISTANT_LIGHT) || defined(_REFLECTIONS)
 #if defined(_CHANNEL_MAP)
     half occlusion = channel.g;
 #else
@@ -785,7 +786,8 @@ half4 PixelStage(Varyings input, bool facing : SV_IsFrontFace) : SV_Target
 
     // Direct lighting.
     GTMainLight light = GTGetMainLight();
-#if defined(_NPR_Rendering)
+    // Non Photorealistic
+#if defined(_NON_PHOTOREALISTIC)
     output.rgb += GTLightingNonPhotorealistic(brdfData, light.color, light.direction, worldNormal, worldViewDir);
 #else
     output.rgb += GTLightingPhysicallyBased(brdfData, light.color, light.direction, worldNormal, worldViewDir);


### PR DESCRIPTION
## Overview

NPR functionality has been added to the light mode of GraphicsTools/Standard shaders.

Please see the following video for the actual operation.

https://youtu.be/rB6KaXwDAB4

The use of MeshOutline enables comic-like rendering.

　I would like to add new features to ToonShader in the future, but even at this point, we think it is possible to create some very interesting expressions.

　Personally, I think that the ability to use the existing StandardShader features in conjunction with the MeshOutline allows for a much greater variety of expressions!



## Changes
- Fixes: #108



## Verification

https://youtu.be/rB6KaXwDAB4

![image](https://user-images.githubusercontent.com/36409613/195098243-69716475-fa9f-4a2b-9a79-0816b9b36563.png)

## Additional
 @Cameron-Micka 
　Sorry I'm a little late as I was learning the new LightMode process!

　TokyoHoloLensMeetup will be held on 10/12 in Japan!
I will be presenting MRGT in a 5 minute slot. I'm off to talk about what MRGT has to offer, including this NPR feature!
