### PR TITLE
Initial Shader State Fixes

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -230,6 +230,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         protected MaterialProperty metallic;
         protected MaterialProperty smoothness;
         protected MaterialProperty lightMode;
+        protected MaterialProperty lightModeProxy;
         protected MaterialProperty specularHighlights;
         protected MaterialProperty sphericalHarmonics;
         protected MaterialProperty reflections;
@@ -343,6 +344,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             enableSSAA = FindProperty("_EnableSSAA", props);
             mipmapBias = FindProperty("_MipmapBias", props);
             lightMode = FindProperty("_DirectionalLight", props);
+            lightModeProxy = FindProperty("_DirectionalLightProxy", props, false);
             specularHighlights = FindProperty("_SpecularHighlights", props);
             sphericalHarmonics = FindProperty("_SphericalHarmonics", props);
             reflections = FindProperty("_Reflections", props);
@@ -695,18 +697,33 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                     {
                         material.DisableKeyword(Styles.lightModeLitDirectional);
                         material.DisableKeyword(Styles.lightModeLitDistant);
+
+                        if (lightModeProxy != null)
+                        {
+                            lightModeProxy.floatValue = 0.0f;
+                        }
                     }
                     break;
                 case LightMode.LitDirectional:
                     {
                         material.EnableKeyword(Styles.lightModeLitDirectional);
                         material.DisableKeyword(Styles.lightModeLitDistant);
+
+                        if (lightModeProxy != null)
+                        {
+                            lightModeProxy.floatValue = 1.0f;
+                        }
                     }
                     break;
                 case LightMode.LitDistant:
                     {
                         material.DisableKeyword(Styles.lightModeLitDirectional);
                         material.EnableKeyword(Styles.lightModeLitDistant);
+
+                        if (lightModeProxy != null)
+                        {
+                            lightModeProxy.floatValue = 0.0f;
+                        }
 
                         GUILayout.Box(string.Format(Styles.propertiesComponentHelp, nameof(DistantLight), Styles.lightModeNames[(int)LightMode.LitDistant]), EditorStyles.helpBox, Array.Empty<GUILayoutOption>());
                     }

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -1237,19 +1237,9 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             // Show the RenderQueueField but do not allow users to directly manipulate it. That is done via the renderQueueOverride.
             GUI.enabled = false;
             materialEditor.RenderQueueField();
-
-            // Enable instancing to disable batching. Static and dynamic batching will normalize the object scale, which breaks 
-            // features which utilize object scale.
-            GUI.enabled = !ScaleRequired();
-
-            if (!GUI.enabled && !material.enableInstancing)
-            {
-                material.enableInstancing = true;
-            }
+            GUI.enabled = true;
 
             materialEditor.EnableInstancingField();
-
-            GUI.enabled = true;
 
             materialEditor.ShaderProperty(enableStencil, Styles.stencil);
 
@@ -1269,10 +1259,15 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                 material.SetInt(Styles.stencilOperationName, (int)StencilOp.Keep);
             }
 
-            if (ScaleRequired())
+            bool scaleRequired = ScaleRequired();
+
+            if (scaleRequired)
             {
                 materialEditor.ShaderProperty(useWorldScale, Styles.useWorldScale);
             }
+
+            // Static and dynamic batching will normalize the object scale, which breaks features which utilize object scale.
+            material.SetOverrideTag("DisableBatching", scaleRequired ? "True" : "False");
         }
 
         /// <summary>

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
@@ -34,6 +34,7 @@ Shader "Graphics Tools/Standard"
 
         // Rendering options.
         [Enum(Microsoft.MixedReality.GraphicsTools.Editor.LightMode)] _DirectionalLight("Light Mode", Float) = 1.0 // "LitDirectional"
+        [Toggle(_DIRECTIONAL_LIGHT)] _DirectionalLightProxy("Directional Light", Float) = 1.0 // "LitDirectional"
         [Toggle(_SPECULAR_HIGHLIGHTS)] _SpecularHighlights("Specular Highlights", Float) = 1.0
         [Toggle(_SPHERICAL_HARMONICS)] _SphericalHarmonics("Spherical Harmonics", Float) = 0.0
         [Toggle(_REFLECTIONS)] _Reflections("Reflections", Float) = 0.0
@@ -146,7 +147,8 @@ Shader "Graphics Tools/Standard"
         Tags
         { 
             "RenderPipeline" = "UniversalPipeline"
-            "RenderType" = "Opaque" 
+            "RenderType" = "Opaque"
+            "DisableBatching" = "False"
         }
 
         // Default pass (only pass outside of the editor).
@@ -210,7 +212,8 @@ Shader "Graphics Tools/Standard"
     {
         Tags
         { 
-            "RenderType" = "Opaque" 
+            "RenderType" = "Opaque"
+            "DisableBatching" = "False"
         }
 
         // Default pass (only pass outside of the editor).

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvas.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvas.shader
@@ -34,7 +34,6 @@ Shader "Graphics Tools/Standard Canvas"
 
         // Rendering options.
         [Enum(Microsoft.MixedReality.GraphicsTools.Editor.LightMode)] _DirectionalLight("Light Mode", Float) = 0.0 // "Unlit"
-        [Toggle(_DIRECTIONAL_LIGHT)] _DirectionalLightProxy("Directional Light", Float) = 0.0 // "Unlit"
         [Toggle(_SPECULAR_HIGHLIGHTS)] _SpecularHighlights("Specular Highlights", Float) = 1.0
         [Toggle(_SPHERICAL_HARMONICS)] _SphericalHarmonics("Spherical Harmonics", Float) = 0.0
         [Toggle(_REFLECTIONS)] _Reflections("Reflections", Float) = 0.0

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvas.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvas.shader
@@ -34,6 +34,7 @@ Shader "Graphics Tools/Standard Canvas"
 
         // Rendering options.
         [Enum(Microsoft.MixedReality.GraphicsTools.Editor.LightMode)] _DirectionalLight("Light Mode", Float) = 0.0 // "Unlit"
+        [Toggle(_DIRECTIONAL_LIGHT)] _DirectionalLightProxy("Directional Light", Float) = 0.0 // "Unlit"
         [Toggle(_SPECULAR_HIGHLIGHTS)] _SpecularHighlights("Specular Highlights", Float) = 1.0
         [Toggle(_SPHERICAL_HARMONICS)] _SphericalHarmonics("Spherical Harmonics", Float) = 0.0
         [Toggle(_REFLECTIONS)] _Reflections("Reflections", Float) = 0.0

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "msftFeatureCategory": "MRTK3",

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
## Overview

This PR fixes two issues. 

1. A more [robust way](https://github.com/microsoft/MixedRealityToolkit-Unity/issues/11098) to disable batching when object scale is needed.
2. Ensures the standard shader has the directional light keyword enabled by default when programmatically used to create a material. (This broke in [this ](https://github.com/microsoft/MixedReality-GraphicsTools-Unity/pull/37) PR). 

## Changes
- Fixes: #111 and #112

## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
