### PR TITLE
Clipping Primitive Improvements

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/ClippingBoxInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/ClippingBoxInspector.cs
@@ -26,5 +26,11 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             Debug.Assert(primitive != null);
             return new Bounds(primitive.transform.position, primitive.transform.lossyScale);
         }
+
+        [MenuItem("GameObject/Effects/Graphics Tools/Clipping Box")]
+        private static void CreateClippingBox(MenuCommand menuCommand)
+        {
+            InspectorUtilities.CreateGameObjectFromMenu<ClippingBox>(menuCommand);
+        }
     }
 }

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/ClippingPlaneInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/ClippingPlaneInspector.cs
@@ -26,5 +26,11 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             Debug.Assert(primitive != null);
             return new Bounds(primitive.transform.position, Vector3.one);
         }
+
+        [MenuItem("GameObject/Effects/Graphics Tools/Clipping Plane")]
+        private static void CreateClippingPlane(MenuCommand menuCommand)
+        {
+            InspectorUtilities.CreateGameObjectFromMenu<ClippingPlane>(menuCommand);
+        }
     }
 }

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/ClippingSphereInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/ClippingSphereInspector.cs
@@ -26,5 +26,11 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             Debug.Assert(primitive != null);
             return new Bounds(primitive.transform.position, primitive.Radii);
         }
+
+        [MenuItem("GameObject/Effects/Graphics Tools/Clipping Sphere")]
+        private static void CreateClippingSphere(MenuCommand menuCommand)
+        {
+            InspectorUtilities.CreateGameObjectFromMenu<ClippingSphere>(menuCommand);
+        }
     }
 }

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/ScreenshotUtilities.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/ScreenshotUtilities.cs
@@ -79,16 +79,6 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                 return false;
             }
 
-            // If a transparent clear color isn't needed and we are capturing from the default camera, use Unity's screenshot API.
-            if (!transparentClearColor && (camera == null || camera == Camera.main))
-            {
-                ScreenCapture.CaptureScreenshot(path, superSize);
-
-                Debug.LogFormat("Screenshot captured to: {0}", path);
-
-                return true;
-            }
-
             // Make sure we have a valid camera to render from.
             if (camera == null)
             {
@@ -96,9 +86,18 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
 
                 if (camera == null)
                 {
-                    Debug.Log("Failed to acquire a valid camera to capture a screenshot from.");
+                    camera = GameObject.FindObjectOfType<Camera>();
 
-                    return false;
+                    if (camera == null)
+                    {
+                        Debug.LogError("Failed to find a any cameras to capture a screenshot from.");
+
+                        return false;
+                    }
+                    else
+                    {
+                        Debug.LogWarning($"Capturing screenshot from a camera named \"{camera.name}\" because there is no camera tagged \"MainCamera\".");
+                    }
                 }
             }
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingPrimitive.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Clipping/ClippingPrimitive.cs
@@ -15,15 +15,11 @@ namespace Microsoft.MixedReality.GraphicsTools
     public abstract class ClippingPrimitive : MonoBehaviour, IMaterialInstanceOwner
     {
         [Header("Renders to Clip")]
-        [Tooltip("The renderer(s) that should be affected by the primitive. Renderers with materials in the materials list do not need to be added to this list.")]
-        [SerializeField]
-        protected List<Renderer> renderers = new List<Renderer>();
-
-        [SerializeField, Tooltip("Toggles whether clipping will apply to shared materials or material instances (default) on Renderers within the renderers list.")]
+        [SerializeField, Tooltip("Toggles whether clipping will apply to shared materials or material instances (default) on renderers within the renderers list. This cannot be altered when renderers are already specified.")]
         private bool applyToSharedMaterial = false;
 
         /// <summary>
-        /// Toggles whether clipping will apply to shared materials or material instances (default) on Renderers within the renderers list.
+        /// Toggles whether clipping will apply to shared materials or material instances (default) on renderers within the renderers list. This cannot be altered when renderers are already specified.
         /// </summary>
         /// <remarks>
         /// Applying to shared materials will allow for GPU instancing to batch calls between Renderers that interact with the same clipping primitives.
@@ -43,6 +39,10 @@ namespace Microsoft.MixedReality.GraphicsTools
                 }
             }
         }
+
+        [Tooltip("The renderer(s) that should be affected by the primitive. Renderers with materials in the materials list do not need to be added to this list.")]
+        [SerializeField]
+        protected List<Renderer> renderers = new List<Renderer>();
 
         [Header("Materials to Clip")]
         [Tooltip("The materials(s) that should be affected by the primitive. Materials on renderers within the renderers list do not need to be added to this list.")]
@@ -182,6 +182,10 @@ namespace Microsoft.MixedReality.GraphicsTools
                 {
                     materialInstance.ReleaseMaterial(this, autoDestroyMaterial);
                 }
+
+                // Reset the material property block.
+                materialPropertyBlock.Clear();
+                _renderer.SetPropertyBlock(materialPropertyBlock);
             }
         }
 
@@ -432,7 +436,7 @@ namespace Microsoft.MixedReality.GraphicsTools
                     var _renderer = renderers[i];
                     if (_renderer == null)
                     {
-                        if (Application.isPlaying)
+                        if (!Application.isEditor)
                         {
                             RemoveRenderer(i);
                         }
@@ -453,7 +457,7 @@ namespace Microsoft.MixedReality.GraphicsTools
                     var material = materials[i];
                     if (material == null)
                     {
-                        if (Application.isPlaying)
+                        if (!Application.isEditor)
                         {
                             RemoveMaterial(i);
                         }

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardMetaProgram.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardMetaProgram.hlsl
@@ -77,9 +77,9 @@ half4 PixelStage(MetaVaryings input) : SV_Target
     output.Albedo = SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, input.uv).rgb * _Color.rgb;
 #if defined(_EMISSION)
 #if defined(_CHANNEL_MAP)
-    output.Emission = SAMPLE_TEXTURE2D(_ChannelMap, sampler_ChannelMap, input.uv) * _EmissiveColor;
+    output.Emission = SAMPLE_TEXTURE2D(_ChannelMap, sampler_ChannelMap, input.uv).rgb * _EmissiveColor.rgb;
 #else
-    output.Emission = SAMPLE_TEXTURE2D(_EmissiveMap, sampler_EmissiveMap, input.uv) * _EmissiveColor;
+    output.Emission = SAMPLE_TEXTURE2D(_EmissiveMap, sampler_EmissiveMap, input.uv).rgb * _EmissiveColor.rgb;
 #endif
 #endif
 

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "msftFeatureCategory": "MRTK3",

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
## Overview

- Fixes an issue where clipping primitives did not react to state changes in edit mode.
- Makes clipping primitive inspector more explicit about when state can change.
- Added menu item to easily add clipping primitives.

## Changes
- Fixes: #115


## Verification

Tested in editor and player builds sample scenes.

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
