### PR TITLE
Fix for unlit materials becoming lit in Unity 2021.x

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -231,7 +231,6 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         protected MaterialProperty metallic;
         protected MaterialProperty smoothness;
         protected MaterialProperty lightMode;
-        protected MaterialProperty lightModeProxy;
         protected MaterialProperty specularHighlights;
         protected MaterialProperty sphericalHarmonics;
         protected MaterialProperty nonPhotorealisticRendering;
@@ -346,7 +345,6 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             enableSSAA = FindProperty("_EnableSSAA", props);
             mipmapBias = FindProperty("_MipmapBias", props);
             lightMode = FindProperty("_DirectionalLight", props);
-            lightModeProxy = FindProperty("_DirectionalLightProxy", props, false);
             specularHighlights = FindProperty("_SpecularHighlights", props);
             sphericalHarmonics = FindProperty("_SphericalHarmonics", props);
             nonPhotorealisticRendering = FindProperty("_NPR", props);
@@ -700,33 +698,18 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                     {
                         material.DisableKeyword(Styles.lightModeLitDirectional);
                         material.DisableKeyword(Styles.lightModeLitDistant);
-
-                        if (lightModeProxy != null)
-                        {
-                            lightModeProxy.floatValue = 0.0f;
-                        }
                     }
                     break;
                 case LightMode.LitDirectional:
                     {
                         material.EnableKeyword(Styles.lightModeLitDirectional);
                         material.DisableKeyword(Styles.lightModeLitDistant);
-
-                        if (lightModeProxy != null)
-                        {
-                            lightModeProxy.floatValue = 1.0f;
-                        }
                     }
                     break;
                 case LightMode.LitDistant:
                     {
                         material.DisableKeyword(Styles.lightModeLitDirectional);
                         material.EnableKeyword(Styles.lightModeLitDistant);
-
-                        if (lightModeProxy != null)
-                        {
-                            lightModeProxy.floatValue = 0.0f;
-                        }
 
                         GUILayout.Box(string.Format(Styles.propertiesComponentHelp, nameof(DistantLight), Styles.lightModeNames[(int)LightMode.LitDistant]), EditorStyles.helpBox, Array.Empty<GUILayoutOption>());
                     }

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandard.shader
@@ -33,8 +33,7 @@ Shader "Graphics Tools/Standard"
         _MipmapBias("Mipmap Bias", Range(-5.0, 0.0)) = -2.0
 
         // Rendering options.
-        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.LightMode)] _DirectionalLight("Light Mode", Float) = 1.0 // "LitDirectional"
-        [Toggle(_DIRECTIONAL_LIGHT)] _DirectionalLightProxy("Directional Light", Float) = 1.0 // "LitDirectional"
+        [Toggle(_DIRECTIONAL_LIGHT)] _DirectionalLight("Light Mode", Float) = 1.0 // "LitDirectional"
         [Toggle(_SPECULAR_HIGHLIGHTS)] _SpecularHighlights("Specular Highlights", Float) = 1.0
         [Toggle(_SPHERICAL_HARMONICS)] _SphericalHarmonics("Spherical Harmonics", Float) = 0.0
         [Toggle(_NON_PHOTOREALISTIC)] _NPR("Non-Photorealistic Rendering", Float) = 0.0

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
## Overview
This PR is to fix a regression in https://github.com/microsoft/MixedReality-GraphicsTools-Unity/pull/110 that made it so unlit materials when opening in 2021.x+ would become lit until refreshed in the material inspector. 

To resolve this the existing `_DirectionalLight` property is observed as the keyword initializer and materials made in code still are lit correctly. 

In summary the fix is to use Unity's toggle rather than enum property drawer to handle initializing the keyword. We have a custom inspector for this field, so nothing changes for the end user. 

## Changes
- Fixes: # 110 + new regession


## Verification
Note the unlit shader ball in the Material Gallery looks unlit in 2020 and 2021. 

> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
