### PR TITLE
#135 propertyDisplay

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/ShaderGUIs/StandardShaderGUI.cs
@@ -894,10 +894,31 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                     }
                 }
             }
+            
+            if (!PropertyEnabled(roundCorners) && PropertyEnabled(borderLight))
+            {
+                materialEditor.ShaderProperty(edgeSmoothingMode, Styles.edgeSmoothingMode, 2);
+
+                switch ((EdgeSmoothingMode)edgeSmoothingMode.floatValue)
+                {
+                    default:
+                    case EdgeSmoothingMode.Manual:
+                    {
+                        material.DisableKeyword(Styles.edgeSmoothingModeAutomaticName);
+                        materialEditor.ShaderProperty(edgeSmoothingValue, Styles.edgeSmoothingValue, 3);
+                    }
+                        break;
+                    case EdgeSmoothingMode.Automatic:
+                    {
+                        material.EnableKeyword(Styles.edgeSmoothingModeAutomaticName);
+                    }
+                        break;
+                }
+            }
 
             if (PropertyEnabled(hoverLight) || PropertyEnabled(proximityLight) || PropertyEnabled(borderLight))
             {
-                materialEditor.ShaderProperty(fluentLightIntensity, Styles.fluentLightIntensity);
+                materialEditor.ShaderProperty(fluentLightIntensity, Styles.fluentLightIntensity, 2);
             }
 
             materialEditor.ShaderProperty(roundCorners, Styles.roundCorners);
@@ -944,9 +965,9 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                 }
             }
 
-            if (PropertyEnabled(roundCorners) || PropertyEnabled(borderLight))
+            if (PropertyEnabled(roundCorners))
             {
-                materialEditor.ShaderProperty(edgeSmoothingMode, Styles.edgeSmoothingMode);
+                materialEditor.ShaderProperty(edgeSmoothingMode, Styles.edgeSmoothingMode, 2);
 
                 switch ((EdgeSmoothingMode)edgeSmoothingMode.floatValue)
                 {
@@ -954,7 +975,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                     case EdgeSmoothingMode.Manual:
                         {
                             material.DisableKeyword(Styles.edgeSmoothingModeAutomaticName);
-                            materialEditor.ShaderProperty(edgeSmoothingValue, Styles.edgeSmoothingValue, 2);
+                            materialEditor.ShaderProperty(edgeSmoothingValue, Styles.edgeSmoothingValue, 3);
                         }
                         break;
                     case EdgeSmoothingMode.Automatic:


### PR DESCRIPTION
## Overview

The GraphicsStandard shader properties LightIntensity and EdgeSmoothnessMode are properties commonly used by multiple properties.

Previously, they were displayed on the layout instead of being child properties with spaces.

For this reason, we felt that some users may not notice them.

In fact, until I started working on this issue, I was unaware of it and attributed it to a display bug.


　So I modified the layout to distinguish it from the others and make it easier to understand.

　However, I honestly think there may be a better way to tackle this issue.


![Wall](https://user-images.githubusercontent.com/36409613/210138827-1c60285a-dd50-428e-b974-33d7ce694252.png)


## Changes
- Fixes: #135  .


## Verification

no