### PR TITLE
Fix Depth Offset in Wireframe Shader 

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsWireframe.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsWireframe.shader
@@ -24,8 +24,8 @@ Shader "Graphics Tools/Wireframe"
         [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0                         // "Add"
         [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4                        // "LessEqual"
         [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1     // "On"
-        _ZOffsetFactor("Depth Offset Factor", Float) = 50
-        _ZOffsetUnits("Depth Offset Units", Float) = 100
+        _ZOffsetFactor("Depth Offset Factor", Float) = 0                                                     // "Zero"
+        _ZOffsetUnits("Depth Offset Units", Float) = 0                                                       // "Zero"
         [Enum(UnityEngine.Rendering.ColorWriteMask)] _ColorWriteMask("Color Write Mask", Float) = 15         // "All"
         [Enum(UnityEngine.Rendering.CullMode)] _CullMode("Cull Mode", Float) = 2                             // "Back"
         _RenderQueueOverride("Render Queue Override", Range(-1.0, 5000)) = -1


### PR DESCRIPTION
## Overview
This PR fixes a bug that causes rough rendered edges when using the Wireframe Shader 

## Changes
- Fixes: #50 


## Verification
Add a sphere GO
Add a Material with the GraphicsToolsWireframe Shader
Add a cube or plane GO that intersects with the sphere 

The intersection should have clean edges.

![Before](https://user-images.githubusercontent.com/15232740/211899511-b1e3c81c-53ac-4562-a499-acfb42329622.gif)

![After](https://user-images.githubusercontent.com/15232740/211899546-2d807403-04e4-42cc-bb4c-066030d2150f.gif)

