### PR TITLE
Automatically Create a Canvas for new UI gameobjects

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/CanvasElementBeveledRectInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/CanvasElementBeveledRectInspector.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         [MenuItem("GameObject/UI/Graphics Tools/Beveled Rect")]
         private static void CreateCanvasElement(MenuCommand menuCommand)
         {
-            GameObject gameObject = InspectorUtilities.CreateGameObjectFromMenu<CanvasElementBeveledRect>(menuCommand);
+            GameObject gameObject = InspectorUtilities.CreateGameObjectFromMenu<CanvasElementBeveledRect>(menuCommand, true);
 
             if (gameObject != null)
             {

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/CanvasElementMeshtInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/CanvasElementMeshtInspector.cs
@@ -15,7 +15,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         [MenuItem("GameObject/UI/Graphics Tools/Mesh")]
         private static void CreateCanvasElement(MenuCommand menuCommand)
         {
-            InspectorUtilities.CreateGameObjectFromMenu<CanvasElementMesh>(menuCommand);
+            InspectorUtilities.CreateGameObjectFromMenu<CanvasElementMesh>(menuCommand, true);
         }
     }
 }

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/CanvasElementRoundedRectInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/CanvasElementRoundedRectInspector.cs
@@ -16,7 +16,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         [MenuItem("GameObject/UI/Graphics Tools/Rounded Rect")]
         private static void CreateCanvasElement(MenuCommand menuCommand)
         {
-            GameObject gameObject = InspectorUtilities.CreateGameObjectFromMenu<CanvasElementRoundedRect>(menuCommand);
+            GameObject gameObject = InspectorUtilities.CreateGameObjectFromMenu<CanvasElementRoundedRect>(menuCommand, true);
 
             if (gameObject != null)
             {

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/RectMask2DFastInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/RectMask2DFastInspector.cs
@@ -17,7 +17,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         [MenuItem("GameObject/UI/Graphics Tools/Fast Rect Mask")]
         private static void CreateCanvasElement(MenuCommand menuCommand)
         {
-            InspectorUtilities.CreateGameObjectFromMenu<RectMask2DFast>(menuCommand);
+            InspectorUtilities.CreateGameObjectFromMenu<RectMask2DFast>(menuCommand, true);
         }
     }
 }

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/RoundedRectMask2DInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/RoundedRectMask2DInspector.cs
@@ -36,7 +36,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         [MenuItem("GameObject/UI/Graphics Tools/Rounded Rect Mask")]
         private static void CreateCanvasElement(MenuCommand menuCommand)
         {
-            InspectorUtilities.CreateGameObjectFromMenu<RoundedRectMask2D>(menuCommand);
+            InspectorUtilities.CreateGameObjectFromMenu<RoundedRectMask2D>(menuCommand, true);
         }
 
         /// <inheritdoc/>

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/InspectorUtilities.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/InspectorUtilities.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using UnityEditor;
 using UnityEditor.UI;
 using UnityEngine;
@@ -66,8 +67,6 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                 gameObject.GetComponent<RectTransform>().anchoredPosition3D = Vector3.zero;
             }
 
-            Selection.activeObject = gameObject;
-
             return gameObject;
         }
 
@@ -111,7 +110,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         /// <summary>
         /// Creates a new game object of type T as a child of the menu command.
         /// </summary>
-        public static GameObject CreateGameObjectFromMenu<T>(MenuCommand menuCommand) where T : MonoBehaviour
+        public static GameObject CreateGameObjectFromMenu<T>(MenuCommand menuCommand, Boolean hasCanvasParent = false) where T : MonoBehaviour
         {
             GameObject gameObject = new GameObject(typeof(T).Name, typeof(T));
 
@@ -121,7 +120,14 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             // Register the creation in the undo system.
             Undo.RegisterCreatedObjectUndo(gameObject, "Create " + gameObject.name);
 
-            return SetupCanvas(gameObject, menuCommand);
+            Selection.activeObject = gameObject;
+
+            if (hasCanvasParent)
+            {
+                return SetupCanvas(gameObject, menuCommand);
+            }
+
+            return gameObject;
         }
 
         /// <summary>

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/InspectorUtilities.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/InspectorUtilities.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using UnityEditor;
+using UnityEditor.UI;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace Microsoft.MixedReality.GraphicsTools.Editor
 {
@@ -12,6 +14,101 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
     public static class InspectorUtilities
     {
         /// <summary>
+        /// Line 19 - 109 uses an implementation from MRTK. 
+        /// https://github.com/Zee2/MixedRealityToolkit-Unity/blob/mrtk3/com.microsoft.mrtk.uxcomponents/Editor/CreateElementMenus.cs#L39
+        /// It automatically adds a configured canvas when a Graphics Tools
+        /// UI GameObject is added to the scene.
+        /// </summary>
+         
+        // Reflection into internal UGUI editor utilities.
+        private static System.Reflection.MethodInfo PlaceUIElementRoot = null;
+
+        /// <summary>
+        /// Add canvas for a UI GameObject if none exists.
+        /// </summary>
+        /// <returns></returns>
+        private static GameObject SetupCanvas(GameObject gameObject, MenuCommand menuCommand)
+        {
+            // This is evil :)
+            // UGUI contains plenty of helper utilities for spawning and managing new Canvas objects
+            // at edit-time. Unfortunately, they're all internal, so we have to use reflection to
+            // access them.
+            if (PlaceUIElementRoot == null)
+            {
+                // We're using SelectableEditor type here to grab the assembly instead of going
+                // and hunting down the assembly ourselves. It's a bit more convenient and durable.
+                PlaceUIElementRoot = typeof(SelectableEditor).Assembly.GetType("UnityEditor.UI.MenuOptions")?.GetMethod(
+                                                "PlaceUIElementRoot",
+                                                System.Reflection.BindingFlags.NonPublic |
+                                                System.Reflection.BindingFlags.Static );
+                if (PlaceUIElementRoot == null)
+                {
+                    Debug.LogError("Whoops! Looks like Unity changed the internals of their UGUI editor utilities. Please file a bug!");
+                    // Return early; we can't do anything else.
+                    return gameObject;
+                }
+            }
+
+            PlaceUIElementRoot.Invoke(null, new object[] { gameObject, menuCommand});
+
+            // The above call will create a new Canvas for us (if we don't have one),
+            // but it won't have optimal settings for MRTK UX. Let's fix that!
+            Canvas canvas = gameObject.GetComponentInParent<Canvas>();
+            RectTransform rt = canvas.GetComponent<RectTransform>();
+
+            // If the canvas's only child is us; let's make sure the Canvas has reasonable starting defaults.
+            // Otherwise, it was probably an existing canvas we were added to, so we shouldn't mess with it.
+            if (rt.childCount == 1 && rt.GetChild(0) == gameObject.transform)
+            {
+                SetReasonableCanvasDefaults(canvas);
+                
+                // Reset our own object to zero-position relative to the parent canvas.
+                gameObject.GetComponent<RectTransform>().anchoredPosition3D = Vector3.zero;
+            }
+
+            Selection.activeObject = gameObject;
+
+            return gameObject;
+        }
+
+        /// <summary>
+        /// Configure some default properties for the canvas GameObject.
+        /// Size, position from camera
+        /// </summary>
+        private static void SetReasonableCanvasDefaults(Canvas canvas)
+        {
+            RectTransform rt = canvas.GetComponent<RectTransform>();
+
+            // 1mm : 1 unit measurement ratio.
+            if (rt.lossyScale != Vector3.one * 0.001f)
+            {
+                rt.localScale = Vector3.one * 0.001f;
+            }
+            // 150mm x 150mm.
+            rt.sizeDelta = Vector2.one * 150.0f;
+
+            // All our canvases will be worldspace (by default.)
+            canvas.renderMode = RenderMode.WorldSpace;
+            Undo.RecordObject(canvas, "Set Canvas RenderMode to WorldSpace");
+
+            // 30cm in front of the camera.
+            rt.position = Camera.main.transform.position + Camera.main.transform.forward * 0.3f;
+            Undo.RecordObject(rt, "Set Canvas Position");
+
+            // No GraphicRaycaster by default. Users can add one, if they like.
+            if (canvas.TryGetComponent(out GraphicRaycaster raycaster))
+            {
+                Undo.DestroyObjectImmediate(raycaster);
+            }
+
+            // CanvasScaler should be there by default.
+            if (!canvas.TryGetComponent(out CanvasScaler _))
+            {
+                Undo.AddComponent<CanvasScaler>(canvas.gameObject);
+            }
+        }
+
+        /// <summary>
         /// Creates a new game object of type T as a child of the menu command.
         /// </summary>
         public static GameObject CreateGameObjectFromMenu<T>(MenuCommand menuCommand) where T : MonoBehaviour
@@ -19,14 +116,12 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             GameObject gameObject = new GameObject(typeof(T).Name, typeof(T));
 
             // Ensure the game object gets re-parented to the active context.
-            GameObjectUtility.SetParentAndAlign(gameObject, menuCommand.context as GameObject);
+            // GameObjectUtility.SetParentAndAlign(gameObject, menuCommand.context as GameObject);
 
             // Register the creation in the undo system.
             Undo.RegisterCreatedObjectUndo(gameObject, "Create " + gameObject.name);
 
-            Selection.activeObject = gameObject;
-
-            return gameObject;
+            return SetupCanvas(gameObject, menuCommand);
         }
 
         /// <summary>

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/InspectorUtilities.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/InspectorUtilities.cs
@@ -109,7 +109,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         /// <summary>
         /// Creates a new game object of type T as a child of the menu command.
         /// </summary>
-        public static GameObject CreateGameObjectFromMenu<T>(MenuCommand menuCommand, Boolean hasCanvasParent = false) where T : MonoBehaviour
+        public static GameObject CreateGameObjectFromMenu<T>(MenuCommand menuCommand, bool hasCanvasParent = false) where T : MonoBehaviour
         {
             GameObject gameObject = new GameObject(typeof(T).Name, typeof(T));
 

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/InspectorUtilities.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/InspectorUtilities.cs
@@ -27,7 +27,6 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
         /// <summary>
         /// Add canvas for a UI GameObject if none exists.
         /// </summary>
-        /// <returns></returns>
         private static GameObject SetupCanvas(GameObject gameObject, MenuCommand menuCommand)
         {
             // This is evil :)

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/InspectorUtilities.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/InspectorUtilities.cs
@@ -116,7 +116,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             GameObject gameObject = new GameObject(typeof(T).Name, typeof(T));
 
             // Ensure the game object gets re-parented to the active context.
-            // GameObjectUtility.SetParentAndAlign(gameObject, menuCommand.context as GameObject);
+            GameObjectUtility.SetParentAndAlign(gameObject, menuCommand.context as GameObject);
 
             // Register the creation in the undo system.
             Undo.RegisterCreatedObjectUndo(gameObject, "Create " + gameObject.name);


### PR DESCRIPTION
## Overview
When a new Graphics Tools UI GameObject is added to a scene, this PR adds a check to see if a canvas exists, if none exists, it creates a new canvas GameObject similar to default Unity UI behavior.

## Changes
- Fixes: #84.
