### PR TITLE
Don't ToArray a locally created List, new up an array.

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshOutline.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshOutline.cs
@@ -129,16 +129,18 @@ namespace Microsoft.MixedReality.GraphicsTools
             ApplyStencilReference();
 
             // Add the outline material as another material pass.
-            var materials = new List<Material>(defaultMaterials);
+            var materials = new Material[UseStencilOutline ? defaultMaterials.Length + 2 : defaultMaterials.Length + 1];
+            defaultMaterials.CopyTo(materials, 0);
+            int nextFreeIdx = defaultMaterials.Length;
 
             if (UseStencilOutline)
             {
-                materials.Add(stencilWriteMaterial);
+                materials[nextFreeIdx++] = stencilWriteMaterial;
             }
 
-            materials.Add(outlineMaterial);
+            materials[nextFreeIdx] = outlineMaterial;
 
-            meshRenderer.materials = materials.ToArray();
+            meshRenderer.materials = materials;
         }
 
         /// <summary>


### PR DESCRIPTION
## Overview
MeshOutline would create a List<T> of a specific size, add to it, triggering a Resize and then do a ToArray.  This was noticeable in the profiler when trying to reduce allocations.  The following change removes the list, and instead allocates an array with the final size upfront.



