### PR TITLE
Invalid characters have been removed so that the package can be import properly in  MaterialRestorer.cs

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/MaterialRestorer.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/MaterialRestorer.cs
@@ -81,7 +81,7 @@ namespace Microsoft.MixedReality.GraphicsTools
 #if UNITY_2021_2_OR_NEWER
                             AssetDatabase.SaveAssetIfDirty(material);
 #else
- AssetDatabase.SaveAssets();
+ AssetDatabase.SaveAssets();
 #endif
  }
                         else

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/MaterialRestorer.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/MaterialRestorer.cs
@@ -57,13 +57,13 @@ namespace Microsoft.MixedReality.GraphicsTools
         }
 
         /// <summary>
-        /// Call this method to restore a material to the state in time it was called with AddMaterialSnapshot. 
-        /// This only works with material assets.
-        /// </summary>
-        public static void Restore(Material material)
+ /// Call this method to restore a material to the state in time it was called with AddMaterialSnapshot.
+ /// This only works with material assets.
+ /// </summary>
+ public static void Restore(Material material)
         {
 #if UNITY_EDITOR
-            if (material != null)
+ if (material != null)
             {
                 MaterialSnapshot materialRef;
                 if (materialsToRestore.TryGetValue(material, out materialRef))
@@ -74,16 +74,16 @@ namespace Microsoft.MixedReality.GraphicsTools
                     {
                         if (AssetDatabase.TryGetGUIDAndLocalFileIdentifier(material.GetInstanceID(), out string guid, out long _) && !new GUID(guid).Empty())
                         {
-                            // Restore to the original material snapshot.
-                            material.CopyPropertiesFromMaterial(materialRef.Snapshot);
+ // Restore to the original material snapshot.
+ material.CopyPropertiesFromMaterial(materialRef.Snapshot);
 
                             // SaveAssetIfDirty does not exist in 2021.1.10f1.
 #if UNITY_2021_2_OR_NEWER
                             AssetDatabase.SaveAssetIfDirty(material);
 #else
-                            AssetDatabase.SaveAssets();
+ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£°ï£° AssetDatabase.SaveAssets();
 #endif
-                        }
+ }
                         else
                         {
                             Debug.LogError($"Failed to restore material \"{material.name}\" because the material is no longer in the asset database.");
@@ -94,6 +94,6 @@ namespace Microsoft.MixedReality.GraphicsTools
                 }
             }
 #endif
-        }
+ }
     }
 }


### PR DESCRIPTION
## Overview
Remove invalid characters in MaterialRestorer.cs

based #168 

## Changes
- Fixes: #168  .

com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/MaterialRestorer.cs


## Verification

This fix eliminates the invalid character error.

There may be character codes and environments.
I have run it on two environments, Windows 11 desktop and Laptop, and have confirmed that it resolves the error in both environments.

