### PR TITLE
Clear dictionary before editor exit playmode, fix for disabled domain reload

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshSmoother.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshSmoother.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -153,6 +154,15 @@ namespace Microsoft.MixedReality.GraphicsTools
                     processedMeshes.Remove(sharedMesh);
                 }
             }
+        }
+
+        /// <summary>
+        /// Clean up dictionary before quit play mode if enabled Reload Domain
+        /// More information: https://docs.unity3d.com/Manual/DomainReloading.html
+        /// </summary>
+        private void OnApplicationQuit()
+        {
+            processedMeshes.Clear();
         }
 
         #endregion MonoBehaviour Implementation


### PR DESCRIPTION
## Overview
If Editor is set with disabled Reload Domain, the static field isn't cleared after exit playmode.
Documentation: https://docs.unity3d.com/Manual/DomainReloading.html

## Changes
- Fixes: Add clear Dictionary in component MeshSmoother before application quit


## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
