### PR TITLE
MeshOutlineHierarchy renderer exclusion feature

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/BaseMeshOutlineInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/BaseMeshOutlineInspector.cs
@@ -92,7 +92,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             { "_StencilOperation", new MaterialValue((float)UnityEngine.Rendering.StencilOp.Replace, true) },
         };
 
-        private void OnEnable()
+        protected virtual void OnEnable()
         {
             instance = target as BaseMeshOutline;
             m_Script = serializedObject.FindProperty("m_Script");

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/MeshOutlineHierarchyInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/MeshOutlineHierarchyInspector.cs
@@ -1,7 +1,7 @@
-using System.Collections;
-using System.Collections.Generic;
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using UnityEditor;
-using UnityEngine;
 
 namespace Microsoft.MixedReality.GraphicsTools.Editor
 {

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/MeshOutlineHierarchyInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/MeshOutlineHierarchyInspector.cs
@@ -1,0 +1,57 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.GraphicsTools.Editor
+{
+    /// <summary>
+    /// A custom inspector for MeshOutlineHierarchy.
+    /// </summary>
+    [CustomEditor(typeof(MeshOutlineHierarchy), true), CanEditMultipleObjects]
+    public class MeshOutlineHierarchyInspector : BaseMeshOutlineInspector
+    {
+        private SerializedProperty exclusionMode;
+        private SerializedProperty exclusionString;
+        private SerializedProperty exclusionTag;
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            exclusionMode = serializedObject.FindProperty(nameof(exclusionMode));
+            exclusionString = serializedObject.FindProperty(nameof(exclusionString));
+            exclusionTag = serializedObject.FindProperty(nameof(exclusionTag));
+        }
+
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            EditorGUI.BeginChangeCheck();
+
+            EditorGUILayout.PropertyField(exclusionMode);
+
+            var exclusionModeValue = (MeshOutlineHierarchy.ExclusionMode)exclusionMode.enumValueIndex;
+            switch (exclusionModeValue)
+            {
+                case MeshOutlineHierarchy.ExclusionMode.None:
+                default:
+                    break;
+                case MeshOutlineHierarchy.ExclusionMode.NameStartsWith:
+                    exclusionString.stringValue = EditorGUILayout.TextField("Start String", exclusionString.stringValue);
+                    break;
+                case MeshOutlineHierarchy.ExclusionMode.NameContains:
+                    exclusionString.stringValue = EditorGUILayout.TextField("Search String", exclusionString.stringValue);
+                    break;
+                case MeshOutlineHierarchy.ExclusionMode.Tag:
+                    exclusionTag.stringValue = EditorGUILayout.TagField("Tag", exclusionTag.stringValue);
+                    break;
+            }
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                serializedObject.ApplyModifiedProperties();
+            }
+        }
+    }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/MeshOutlineHierarchyInspector.cs.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Inspectors/MeshOutlineHierarchyInspector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bbead8b7207b83140a97768a91c5ed73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshOutlineHierarchy.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshOutlineHierarchy.cs
@@ -13,6 +13,19 @@ namespace Microsoft.MixedReality.GraphicsTools
     [DisallowMultipleComponent, AddComponentMenu("Scripts/GraphicsTools/MeshOutlineHierarchy")]
     public class MeshOutlineHierarchy : BaseMeshOutline
     {
+        public enum ExclusionMode
+        {
+            None,
+            Tag,
+            NameStartsWith,
+            NameContains,
+        }
+
+        [Tooltip("Whether and how to exclude child objects from the outline hierarchy.")]
+        [SerializeField] private ExclusionMode exclusionMode = ExclusionMode.None;
+        [Tooltip("The string used to exclude child objects.")]
+        [SerializeField] private string exclusionString = string.Empty;
+
         private List<MeshOutline> meshOutlines = null;
 
         #region MonoBehaviour Implementation
@@ -110,6 +123,31 @@ namespace Microsoft.MixedReality.GraphicsTools
 
         private void AddMeshOutline(Renderer target)
         {
+            switch (exclusionMode)
+            {
+                case ExclusionMode.None:
+                default:
+                    break;
+                case ExclusionMode.NameStartsWith:
+                    if (target.name.StartsWith(exclusionString))
+                    {
+                        return;
+                    }
+                    break;
+                case ExclusionMode.NameContains:
+                    if (target.name.Contains(exclusionString))
+                    {
+                        return;
+                    }
+                    break;
+                case ExclusionMode.Tag:
+                    if (target.CompareTag(exclusionString))
+                    {
+                        return;
+                    }
+                    break;
+            }
+
             var meshOutline = target.gameObject.EnsureComponent<MeshOutline>();
             meshOutline.CopyFrom(this);
             meshOutlines.Add(meshOutline);

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshOutlineHierarchy.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/MeshOutline/MeshOutlineHierarchy.cs
@@ -22,9 +22,9 @@ namespace Microsoft.MixedReality.GraphicsTools
         }
 
         [Tooltip("Whether and how to exclude child objects from the outline hierarchy.")]
-        [SerializeField] private ExclusionMode exclusionMode = ExclusionMode.None;
-        [Tooltip("The string used to exclude child objects.")]
-        [SerializeField] private string exclusionString = string.Empty;
+        [SerializeField, HideInInspector] private ExclusionMode exclusionMode = ExclusionMode.None;
+        [SerializeField, HideInInspector] private string exclusionString = string.Empty;
+        [SerializeField, HideInInspector] private string exclusionTag = "Untagged";
 
         private List<MeshOutline> meshOutlines = null;
 
@@ -141,7 +141,7 @@ namespace Microsoft.MixedReality.GraphicsTools
                     }
                     break;
                 case ExclusionMode.Tag:
-                    if (target.CompareTag(exclusionString))
+                    if (target.CompareTag(exclusionTag))
                     {
                         return;
                     }


### PR DESCRIPTION
## Overview
Sometimes it's desirable to exclude renderers from MeshOutlineHierarchy when an entire object is being highlighted.

<img width="341" alt="Exclusion" src="https://github.com/microsoft/MixedReality-GraphicsTools-Unity/assets/9789716/67c6a1f1-3a58-44fe-b0fb-48ab85233325">

## Changes
- Fixes: #176.
- Adds the ability to exclude child objects from MeshOutlineHierarchy by name or tag.
- Adds a custom inspector for MeshOutlineHierarchy  which extends BaseMeshOutlineInspector.