### PR TITLE
Improve Intermediate Texture Mode Logic for Magnification

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Microsoft.MixedReality.GraphicsTools.Editor.asmdef
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Microsoft.MixedReality.GraphicsTools.Editor.asmdef
@@ -10,7 +10,7 @@
     ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Scripts/MagnifierManager.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Scripts/MagnifierManager.cs
@@ -104,6 +104,7 @@ namespace Microsoft.MixedReality.GraphicsTools
 #endif
         private LayerMask previousOpaqueLayerMask;
         private LayerMask previousTransparentLayerMask;
+        private IntermediateTextureMode previousIntermediateTextureMode;
 
         private void Reset()
         {
@@ -121,7 +122,13 @@ namespace Microsoft.MixedReality.GraphicsTools
 
                 if (rendererData != null)
                 {
+                    // Previously, URP would force rendering to go through an intermediate renderer if the Renderer had any Renderer Features active. On some platforms, this has
+                    // significant performance implications so we only want to enable this when we need it (which we do for magnification).
+                    previousIntermediateTextureMode = rendererData.intermediateTextureMode;
+                    rendererData.intermediateTextureMode = IntermediateTextureMode.Always;
+
                     CreateRendererFeatures();
+
                     initialized = true;
                 }
 
@@ -151,6 +158,9 @@ namespace Microsoft.MixedReality.GraphicsTools
                     rendererData.opaqueLayerMask = previousOpaqueLayerMask;
                     rendererData.transparentLayerMask = previousTransparentLayerMask;
                 }
+
+                // Reset the intermediate texture mode.
+                rendererData.intermediateTextureMode = previousIntermediateTextureMode;
 
                 rendererData.SetDirty();
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Microsoft.MixedReality.GraphicsTools.asmdef
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Microsoft.MixedReality.GraphicsTools.asmdef
@@ -9,7 +9,7 @@
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
-    "overrideReferences": false,
+    "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/DrawFullscreenFeature.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/DrawFullscreenFeature.cs
@@ -7,6 +7,9 @@ using UnityEngine.Rendering.Universal;
 
 namespace Microsoft.MixedReality.GraphicsTools
 {
+    /// <summary>
+    /// Does the buffer come from the camera or custom type.
+    /// </summary>
     public enum BufferType
     {
         CameraColor,
@@ -15,14 +18,14 @@ namespace Microsoft.MixedReality.GraphicsTools
 
     /// <summary>
     /// Forked from: https://github.com/Unity-Technologies/UniversalRenderingExamples/tree/master/Assets/Scripts/Runtime/RenderPasses
-    /// Performs fullscreen blit via a custom Render Pass
+    /// Performs a fullscreen blit via a custom render feature.
     /// </summary>
     public class DrawFullscreenFeature : ScriptableRendererFeature
     {
-        [System.Serializable]
         /// <summary>
-        /// Class <c>Settings</c> outlines controls for the Render Feature
+        /// Render feature configuration settings.
         /// </summary>
+        [System.Serializable]
         public class Settings
         {
             public RenderPassEvent renderPassEvent = RenderPassEvent.AfterRenderingOpaques;
@@ -33,45 +36,34 @@ namespace Microsoft.MixedReality.GraphicsTools
             public BufferType DestinationType = BufferType.CameraColor;
             public string SourceTextureId = "_SourceTexture";
             public string DestinationTextureId = "_DestinationTexture";
+            public FilterMode FilterMode = FilterMode.Point;
             public bool RestoreCameraColorTarget = true;
         }
 
         /// <summary>
-        /// Defines a new Settings class
+        /// Render feature configuration settings.
         /// </summary>
         public Settings settings = new Settings();
+
         private DrawFullscreenPass blitPass;
 
-        /// <summary>
-        /// Method <c>Create</c> creates the render pass.
-        /// </summary>
+        /// <inheritdoc/>
         public override void Create()
         {
             blitPass = new DrawFullscreenPass(name);
-            blitPass.FilterMode = FilterMode.Bilinear;
         }
 
-        /// <summary>
-        /// Method <c>AddRenderPasses</c> calls the custom render pass.
-        /// </summary>
+        /// <inheritdoc/>
         public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
         {
             if (settings.BlitMaterial == null)
             {
-                Debug.LogWarningFormat("Missing Blit Material. {0} blit pass will not execute. Check for missing reference in the assigned renderer.", GetType().Name);
+                Debug.LogWarningFormat($"{nameof(DrawFullscreenFeature)} is missing a blit material and will not be queued.");
                 return;
             }
 
             blitPass.renderPassEvent = settings.renderPassEvent;
             blitPass.Settings = settings;
-
-            // Previously, URP would force rendering to go through an intermediate renderer if the Renderer had any Renderer Features active. On some platforms, this has
-            // significant performance implications. Due to that, Renderer Features are now expected to declare their inputs using ScriptableRenderPass.ConfigureInput.
-            // This information is used to decide automatically whether rendering via an intermediate texture is necessary.
-            if (settings.SourceType == BufferType.CameraColor)
-            {
-                blitPass.ConfigureInput(ScriptableRenderPassInput.Color);
-            }
 
             renderer.EnqueuePass(blitPass);
         }

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "msftFeatureCategory": "MRTK3",

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
## Overview

Previously the `MagnfierManager` would call [ConfigureInput(ScriptableRenderPassInput.Color);](https://github.com/microsoft/MixedReality-GraphicsTools-Unity/blob/96743038a313c93322c935d99d2deb18e831aa2d/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/DrawFullscreenFeature.cs#L73C26-L73C26) to ensure the camera color buffer could be blitted. This worked... but incurred an exta unnessacary [CopyColor ](https://docs.unity3d.com/Packages/com.unity.render-pipelines.universal@13.1/api/UnityEngine.Rendering.Universal.Internal.CopyColorPass.html) pass and caused rendering artifacts in some XR setups.

To fix this the `MagnfierManager` now set the `rendererData.intermediateTextureMode = IntermediateTextureMode.Always;` when enabled then resets the intermediateTextureMode when disabled. This allows the DrawFullscreenPass to blit from the camera color buffer without adding a CopyColorPass.

This PR also includes some minor clean up to DrawFullscreenFeature and Pass.

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
