### PR TITLE
Remove Extra Color Copy from the Acrylic System

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicBlurFeature.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicBlurFeature.cs
@@ -79,7 +79,6 @@ namespace Microsoft.MixedReality.GraphicsTools
         {
             if (targetCamera == null || renderingData.cameraData.camera == targetCamera)
             {
-                pass.ConfigureInput(ScriptableRenderPassInput.Color);
                 renderer.EnqueuePass(pass);
                 rendered = true;
             }

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Scripts/MagnifierManager.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Scripts/MagnifierManager.cs
@@ -3,10 +3,8 @@
 
 #if GT_USE_URP
 using System.Collections.Generic;
-using System.Reflection;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering.Universal;
-using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;
 
 namespace Microsoft.MixedReality.GraphicsTools
@@ -118,7 +116,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         {
             if (!initialized)
             {
-                InitializeRendererData();
+                rendererData = URPUtility.GetRendererData(rendererIndex);
 
                 if (rendererData != null)
                 {
@@ -171,25 +169,6 @@ namespace Microsoft.MixedReality.GraphicsTools
         public void ApplyMagnification()
         {
             Shader.SetGlobalFloat(MagnificationPropertyName, 1.0f - Magnification);
-        }
-
-        private void InitializeRendererData()
-        {
-            var pipeline = ((UniversalRenderPipelineAsset)GraphicsSettings.currentRenderPipeline);
-
-            if (pipeline == null)
-            {
-                Debug.LogWarning("Universal Render Pipeline not found");
-            }
-            else
-            {
-                FieldInfo propertyInfo = pipeline.GetType().GetField("m_RendererDataList", BindingFlags.Instance | BindingFlags.NonPublic);
-#if UNITY_2021_2_OR_NEWER
-                rendererData = ((ScriptableRendererData[])propertyInfo?.GetValue(pipeline))?[rendererIndex] as UniversalRendererData;
-#else
-                rendererData = ((ScriptableRendererData[])propertyInfo?.GetValue(pipeline))?[rendererIndex] as ForwardRendererData;
-#endif
-            }
         }
 
         private void CreateRendererFeatures()

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/URPUtility.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/URPUtility.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if GT_USE_URP
+using System.Reflection;
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+namespace Microsoft.MixedReality.GraphicsTools
+{
+    /// <summary>
+    /// URP utility class for commonly used constants, types and convenience methods.
+    /// </summary>
+    public static class URPUtility
+    {
+        /// <summary>
+        /// The universal render pipeline can have multiple renders, this method returns the 
+        /// ScriptableRendererData (features and settings) for a renderer at a given index.
+        /// 
+        /// Note, this data is not public so our only resort is brittle reflection to access 
+        /// the data programmatically.
+        /// </summary>
+#if UNITY_2021_2_OR_NEWER
+        public static UniversalRendererData GetRendererData(int rendererIndex)
+#else
+        public static ForwardRendererData GetRendererData(int rendererIndex)
+#endif
+        {
+            var pipeline = GraphicsSettings.currentRenderPipeline as UniversalRenderPipelineAsset;
+
+            if (pipeline != null)
+            {
+                var propertyInfo = pipeline.GetType().GetField("m_RendererDataList", BindingFlags.Instance | BindingFlags.NonPublic);
+
+                if (propertyInfo != null)
+                {
+                    var renderers = propertyInfo.GetValue(pipeline) as ScriptableRendererData[];
+
+                    if (renderers != null)
+                    {
+                        if (rendererIndex < renderers.Length)
+                        {
+#if UNITY_2021_2_OR_NEWER
+                            return renderers[rendererIndex] as UniversalRendererData;
+#else
+                            return renderers[rendererIndex] as ForwardRendererData;
+#endif
+                        }
+                        else
+                        {
+                            Debug.LogError($"GetRendererData failed because rendererIndex is out of range. {renderers.Length} renderer(s) exist but index {rendererIndex} requested.");
+                        }
+                    }
+                    else
+                    {
+                        Debug.LogError("GetRendererData failed because Unity changed the internals of m_RendererDataList. Please file a bug!");
+                    }
+                }
+                else
+                {
+                    Debug.LogError("GetRendererData failed because Unity changed the internals of UniversalRenderPipelineAsset. Please file a bug!");
+                }
+            }
+            else
+            {
+                Debug.LogWarning("GetRendererData failed because the current pipeline is not set or not a UniversalRenderPipelineAsset");
+            }
+
+            return null;
+        }
+    }
+}
+#endif // GT_USE_URP

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/URPUtility.cs.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/URPUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5dfd98dee2c029e499595fd507ce8dbd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
## Overview
Previously the [AcrylicBlurFeature.cs](https://github.com/microsoft/MixedReality-GraphicsTools-Unity/compare/main...Cameron-Micka:user/cameron-micka/acrylic-fixes?expand=1#diff-69d00b0014dd4b5a9bfcd1fd6c5e6abb3ad0a14d543dcc95d82306acabd4f1e2) would call [ConfigureInput(ScriptableRenderPassInput.Color);](https://github.com/microsoft/MixedReality-GraphicsTools-Unity/blob/96743038a313c93322c935d99d2deb18e831aa2d/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/DrawFullscreenFeature.cs#L73C26-L73C26) to ensure the camera color buffer could be blitted. This worked... but incurred an extra unnessacary [CopyColor ](https://docs.unity3d.com/Packages/com.unity.render-pipelines.universal@13.1/api/UnityEngine.Rendering.Universal.Internal.CopyColorPass.html) pass.

To fix this the [AcrylicLayerManager.cs](https://github.com/microsoft/MixedReality-GraphicsTools-Unity/compare/main...Cameron-Micka:user/cameron-micka/acrylic-fixes?expand=1#diff-38bf997c7b3d2203e194f21236362a27045434b6e58402e3c335d27489556537) now sets the rendererData.intermediateTextureMode to IntermediateTextureMode.Always when in use.

This PR also moves the reflection logic to a common `GetRendererData` utility method and does extra safety and indexing checks. 

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
