### PR TITLE
2022 Blit Fix

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
## Overview

This PR introduces a forked version of DrawFullscreenPass that works in Unity 2022. Unity 2022 requires the use of RTHandle when working with camera targets. Unity 2021 doesn't have RTHandle based camera targets (hence the need to fork the code). The 2022 code is a lot smaller which is one good thing about this update.

Before:
![image](https://github.com/microsoft/MixedReality-GraphicsTools-Unity/assets/13305729/d7e85504-b832-4f1d-8334-c7b72a99651d)

After:
![image](https://github.com/microsoft/MixedReality-GraphicsTools-Unity/assets/13305729/783c8b04-d082-4b1d-9a9b-41b731dd17a1)



## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
