### PR TITLE
Add alpha blend property for 2022

### DIFF
--- a/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Targets/GraphicsToolsUniversalLitSubTarget.cs
+++ b/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Targets/GraphicsToolsUniversalLitSubTarget.cs
@@ -122,10 +122,10 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
             var universalRPType = typeof(UnityEngine.Rendering.Universal.UniversalRenderPipelineAsset);
             if (!context.HasCustomEditorForRenderPipeline(universalRPType))
             {
-                var gui = typeof(ShaderGraphLitGUI);
+                var gui = typeof(GraphicsToolsShaderGraphLitGUI);
 #if HAS_VFX_GRAPH
                 if (TargetsVFX())
-                    gui = typeof(VFXShaderGraphLitGUI);
+                    gui = typeof(GraphicsToolsVFXShaderGraphLitGUI);
 #endif
                 context.AddCustomEditorForRenderPipeline(gui.FullName, universalRPType);
             }
@@ -219,6 +219,8 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
                 collector.AddFloatProperty(Property.BlendModePreserveSpecular, blendModePreserveSpecular ? 1.0f : 0.0f);
                 collector.AddFloatProperty(Property.SrcBlend, 1.0f);    // always set by material inspector, ok to have incorrect values here
                 collector.AddFloatProperty(Property.DstBlend, 0.0f);    // always set by material inspector, ok to have incorrect values here
+                collector.AddFloatProperty(GraphicsToolsCoreRenderStates.Property.SrcBlendAlpha, 1.0f);    // always set by material inspector, ok to have incorrect values here
+                collector.AddFloatProperty(GraphicsToolsCoreRenderStates.Property.DstBlendAlpha, 1.0f);    // always set by material inspector, ok to have incorrect values here
                 collector.AddToggleProperty(Property.ZWrite, (target.surfaceType == SurfaceType.Opaque));
                 collector.AddFloatProperty(Property.ZWriteControl, (float)target.zWriteControl);
                 collector.AddFloatProperty(Property.ZTest, (float)target.zTestMode);    // ztest mode is designed to directly pass as ztest

--- a/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Targets/GraphicsToolsUniversalUnlitSubTarget.cs
+++ b/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Targets/GraphicsToolsUniversalUnlitSubTarget.cs
@@ -73,10 +73,10 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
             var universalRPType = typeof(UnityEngine.Rendering.Universal.UniversalRenderPipelineAsset);
             if (!context.HasCustomEditorForRenderPipeline(universalRPType))
             {
-                var gui = typeof(ShaderGraphUnlitGUI);
+                var gui = typeof(GraphicsToolsShaderGraphUnlitGUI);
 #if HAS_VFX_GRAPH
                 if (TargetsVFX())
-                    gui = typeof(VFXShaderGraphUnlitGUI);
+                    gui = typeof(GraphicsToolsVFXShaderGraphUnlitGUI);
 #endif
                 context.AddCustomEditorForRenderPipeline(gui.FullName, universalRPType);
             }
@@ -133,6 +133,8 @@ namespace UnityEditor.Rendering.Universal.ShaderGraph
                 collector.AddFloatProperty(Property.AlphaClip, target.alphaClip ? 1.0f : 0.0f);
                 collector.AddFloatProperty(Property.SrcBlend, 1.0f);    // always set by material inspector
                 collector.AddFloatProperty(Property.DstBlend, 0.0f);    // always set by material inspector
+                collector.AddFloatProperty(GraphicsToolsCoreRenderStates.Property.SrcBlendAlpha, 1.0f);    // always set by material inspector, ok to have incorrect values here
+                collector.AddFloatProperty(GraphicsToolsCoreRenderStates.Property.DstBlendAlpha, 1.0f);    // always set by material inspector, ok to have incorrect values here
                 collector.AddToggleProperty(Property.ZWrite, (target.surfaceType == SurfaceType.Opaque));
                 collector.AddFloatProperty(Property.ZWriteControl, (float)target.zWriteControl);
                 collector.AddFloatProperty(Property.ZTest, (float)target.zTestMode);    // ztest mode is designed to directly pass as ztest

--- a/com.microsoft.mrtk.graphicstools.shadergraph.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.shadergraph.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.shadergraph.unity",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "displayName": "MRTK Graphics Tools Shader Graph",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity Shader Graph.",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
## Overview
This fixes a bug where the Unlit subtarget was using the wrong shader GUI and not installing the SrcBlendAlpha and DstBlendAlpha properties in 2022.

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
