### PR TITLE
Replace filter width function with built-in fwidth

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsCommon.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsCommon.hlsl
@@ -151,8 +151,7 @@ inline float GTPointVsRoundedBox(in float2 position, in float2 cornerCircleDista
 
 inline float FilterDistance(in float distance)
 {
-    float2 filterWidth = length(float2(ddx(distance), ddy(distance)));
-    float pixelDistance = distance / length(filterWidth);
+    float pixelDistance = distance / fwidth(distance);
 
 #if defined(_INDEPENDENT_CORNERS) || defined(_UI_CLIP_RECT_ROUNDED_INDEPENDENT)
     // To avoid artifacts at discontinuities in the SDF distance increase the pixel width.


### PR DESCRIPTION
## Overview

A number of functions rely on calculating the filter width for antialiasing. This update replaces the current implementation with an HLSL built-in and avoids overestimating the width using length().

Additionally, may be faster as we avoid 2 calls to length() per pixel.

## Verification

Pictures of original, new method, and the pixel difference.
<img width="1874" alt="original" src="https://github.com/microsoft/MixedReality-GraphicsTools-Unity/assets/538256/69b604bd-24a0-4e24-86ce-3df42173e3eb">
<img width="1874" alt="fix" src="https://github.com/microsoft/MixedReality-GraphicsTools-Unity/assets/538256/e976462a-eaa3-4704-abb1-11a94fb00bf5">
![diff](https://github.com/microsoft/MixedReality-GraphicsTools-Unity/assets/538256/b8b65852-e963-4ecd-952d-bed3013248e0)
