### PR TITLE
Magnifier Material Polish

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/CHANGELOG.md
+++ b/com.microsoft.mrtk.graphicstools.unity/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.6.7] - 2024-01-18
+
+### Changed
+
+- Added rounder corner support to the magnifier shader and sample.
+
 ## [0.6.6] - 2023-12-01
 
 ### Added

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Shaders/CanvasBackplateAcrylic.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Shaders/CanvasBackplateAcrylic.shader
@@ -117,7 +117,7 @@ SubShader {
     #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
 
     #include "UnityCG.cginc"
-    #include "../../../Shaders/GraphicsToolsCommon.hlsl"
+    #include "Packages/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsCommon.hlsl"
 
 CBUFFER_START(UnityPerMaterial)
     half4 _Base_Color_;

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Materials/Magnifier.mat
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Materials/Magnifier.mat
@@ -15,14 +15,16 @@ MonoBehaviour:
   version: 4
 --- !u!21 &2100000
 Material:
-  serializedVersion: 6
+  serializedVersion: 8
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Magnifier
   m_Shader: {fileID: 4800000, guid: 708bca655443cdd41b94ee29b5572b6e, type: 3}
-  m_ShaderKeywords: 
+  m_ValidKeywords:
+  - _ROUND_CORNERS
+  m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -31,96 +33,11 @@ Material:
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
-    m_TexEnvs:
-    - _BaseMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _BumpMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _DetailAlbedoMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _DetailMask:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _DetailNormalMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MetallicGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _OcclusionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _ParallaxMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _SpecGlossMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - unity_Lightmaps:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - unity_LightmapsInd:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - unity_ShadowMasks:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
+    m_TexEnvs: []
+    m_Ints: []
     m_Floats:
-    - Magnification: 0.5
-    - _AlphaClip: 0
-    - _Blend: 0
-    - _BumpScale: 1
-    - _ClearCoatMask: 0
-    - _ClearCoatSmoothness: 0
-    - _Cull: 2
-    - _Cutoff: 0.5
-    - _DetailAlbedoMapScale: 1
-    - _DetailNormalMapScale: 1
-    - _DstBlend: 0
-    - _EnvironmentReflections: 1
-    - _GlossMapScale: 0
-    - _Glossiness: 0
-    - _GlossyReflections: 0
-    - _Magnification: 0.5
-    - _Metallic: 0
-    - _OcclusionStrength: 1
-    - _Parallax: 0.005
-    - _QueueOffset: 0
-    - _ReceiveShadows: 1
-    - _Smoothness: 0.5
-    - _SmoothnessTextureChannel: 0
-    - _SpecularHighlights: 1
-    - _SrcBlend: 1
-    - _Surface: 0
-    - _WorkflowMode: 1
-    - _ZWrite: 1
-    m_Colors:
-    - Center: {r: 0.5, g: 0.5, b: 0, a: 0}
-    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
-    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+    - _RoundCornerMargin: 0.05
+    - _RoundCornerRadius: 0.05
+    - _RoundCorners: 1
+    m_Colors: []
   m_BuildTextureStacks: []

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Shaders/Magnifier.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Shaders/Magnifier.shader
@@ -5,6 +5,9 @@ Shader "Graphics Tools/Magnifier"
 {
     Properties
     {
+        [Toggle(_ROUND_CORNERS)] _RoundCorners("Round Corners", Float) = 1.0
+        _RoundCornerRadius("Round Corner Radius", Float) = 0.05
+        _RoundCornerMargin("Round Corner Margin", Float) = 0.005
     }
     SubShader
     {
@@ -17,6 +20,7 @@ Shader "Graphics Tools/Magnifier"
         {
             "RenderType" = "Transparent"
             "Queue" = "Transparent"
+            "DisableBatching" = "True"
         }
 
         Pass
@@ -24,16 +28,31 @@ Shader "Graphics Tools/Magnifier"
             ZTest Always
             Cull Off
             ZWrite Off
+            Blend SrcAlpha OneMinusSrcAlpha, One One
 
             HLSLPROGRAM
             #pragma vertex vert
             #pragma fragment frag
 
+            #define _URP
+            #define _TRANSPARENT
+            #define _EDGE_SMOOTHING_AUTOMATIC
+
+            #pragma shader_feature_local _ROUND_CORNERS
+
             #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsCommon.hlsl"
+
+            CBUFFER_START(UnityPerMaterial)
+                float _RoundCornerRadius;
+                float _RoundCornerMargin;
+            CBUFFER_END
 
             struct appdata
             {
                 float4 vertex : POSITION;
+                half3 normal : NORMAL;
+                float2 uv0 : TEXCOORD0;
 
                 UNITY_VERTEX_INPUT_INSTANCE_ID
             };
@@ -41,6 +60,8 @@ Shader "Graphics Tools/Magnifier"
             struct v2f
             {
                 float4 vertex : SV_POSITION;
+                float2 uv0 : TEXCOORD0;
+                float3 scale : TEXCOORD3;
 
                 UNITY_VERTEX_OUTPUT_STEREO
             };
@@ -63,17 +84,38 @@ Shader "Graphics Tools/Magnifier"
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
                 o.vertex = TransformObjectToHClip(v.vertex.xyz);
+                o.uv0 = v.uv0;
+                o.scale = GTGetWorldScale();
 
                 return o;
             }
 
             half4 frag(v2f i) : SV_Target
             {
+                // Rounded corner clipping.
+#if defined(_ROUND_CORNERS)
+                half2 distanceToEdge;
+                distanceToEdge.x = abs(i.uv0.x - 0.5h) * 2.0h;
+                distanceToEdge.y = abs(i.uv0.y - 0.5h) * 2.0h;
+
+                float2 halfScale = i.scale.xy * 0.5;
+                float2 cornerPosition = distanceToEdge * halfScale;
+                float cornerCircleRadius = max(_RoundCornerRadius, GT_MIN_CORNER_VALUE);
+                float2 cornerCircleDistance = halfScale - _RoundCornerMargin - cornerCircleRadius;
+                float roundCornerClip = GTRoundCorners(cornerPosition, cornerCircleDistance, cornerCircleRadius, 0.0);
+#endif // _ROUND_CORNERS
+
                 float2 normalizedScreenSpaceUV = GetNormalizedScreenSpaceUV(i.vertex);
                 float2 normalizedScreenSpaceUVStereo = UnityStereoTransformScreenSpaceTex(normalizedScreenSpaceUV);
                 float2 zoomedUv = ZoomIn(normalizedScreenSpaceUVStereo, MagnifierMagnification, MagnifierCenter.xy);
 
-                return SAMPLE_TEXTURE2D_X(MagnifierTexture, samplerMagnifierTexture, zoomedUv);
+                half4 output = SAMPLE_TEXTURE2D_X(MagnifierTexture, samplerMagnifierTexture, zoomedUv);
+
+#if defined(_ROUND_CORNERS)
+                output.a = roundCornerClip;
+#endif // _ROUND_CORNERS
+
+                return output;
             }
            ENDHLSL
         }

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Shaders/Magnifier.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Shaders/Magnifier.shader
@@ -51,7 +51,6 @@ Shader "Graphics Tools/Magnifier"
             struct appdata
             {
                 float4 vertex : POSITION;
-                half3 normal : NORMAL;
                 float2 uv0 : TEXCOORD0;
 
                 UNITY_VERTEX_INPUT_INSTANCE_ID

--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/Magnifier/Magnifier.unity
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/Magnifier/Magnifier.unity
@@ -178,6 +178,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: FlyCamera
       objectReference: {fileID: 0}
+    - target: {fileID: 2605718042319707034, guid: d2eb3a9405371294bb1453b4af85960e, type: 3}
+      propertyPath: m_ClearFlags
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d2eb3a9405371294bb1453b4af85960e, type: 3}
 --- !u!20 &473039062 stripped
@@ -228,6 +232,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_MoveRepeatDelay: 0.5
   m_MoveRepeatRate: 0.1
   m_XRTrackingOrigin: {fileID: 0}
@@ -244,6 +249,7 @@ MonoBehaviour:
   m_TrackedDeviceOrientationAction: {fileID: 1025543830046995696, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
   m_DeselectOnBackgroundClick: 1
   m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
 --- !u!114 &551594404
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,6 +275,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2
@@ -299,6 +306,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1298507361}
   - {fileID: 1522697104}
@@ -341,7 +349,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_Version: 1
   m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
 --- !u!108 &957735293
 Light:
   m_ObjectHideFlags: 0
@@ -414,6 +429,7 @@ Transform:
   m_LocalRotation: {x: 0.40821788, y: 0.23456976, z: -0.10938167, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -582,6 +598,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -630,6 +647,7 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 1}
   m_LocalScale: {x: 0.44704, y: 0.5588, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 656687269}
   m_RootOrder: 1
@@ -727,7 +745,8 @@ Transform:
   m_GameObject: {fileID: 1837192617}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.05, y: 1.1, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2055136616}
   m_RootOrder: 0
@@ -743,6 +762,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
@@ -808,8 +828,9 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2055136615}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.2, z: 1.3}
-  m_LocalScale: {x: 0.8, y: 0.4, z: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.3}
+  m_LocalScale: {x: 1, y: 0.6, z: 1}
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1837192618}
   m_Father: {fileID: 691126601}
@@ -830,6 +851,10 @@ MonoBehaviour:
   magnification: 0.7
   magnificationPropertyName: MagnifierMagnification
   rendererIndex: 0
+  AutoAddDrawFullscreenFeature: 1
+  inLensMode: 0
+  targetDrawFullscreenFeatureName: 
+  targetDrawFullscreenFeatureAddMode: 0
   drawFullscreenSettings:
     renderPassEvent: 500
     BlitMaterial: {fileID: 2100000, guid: aee43c1cf28a72e48ae850053692e23e, type: 2}
@@ -839,7 +864,11 @@ MonoBehaviour:
     DestinationType: 1
     SourceTextureId: 
     DestinationTextureId: MagnifierTexture
+    FilterMode: 1
     RestoreCameraColorTarget: 1
+  AutoAddRenderObjectsFeature: 1
+  targetDrawObjectsFeatureName: 
+  targetDrawObjectsFeatureAddMode: 0
   renderObjectsSettings:
     passTag: 
     Event: 500
@@ -878,6 +907,7 @@ MeshRenderer:
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1

--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/Magnifier/Materials/MagnifierBorder.mat
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/Magnifier/Materials/MagnifierBorder.mat
@@ -15,16 +15,24 @@ MonoBehaviour:
   version: 5
 --- !u!21 &2100000
 Material:
-  serializedVersion: 6
+  serializedVersion: 8
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: MagnifierBorder
   m_Shader: {fileID: 4800000, guid: c331f6c43a2ef0945864cb668f2653c9, type: 3}
-  m_ShaderKeywords: _ALPHABLEND_ON _BORDER_LIGHT _BORDER_LIGHT_OPAQUE _BORDER_LIGHT_REPLACES_ALBEDO
-    _BORDER_LIGHT_USES_GRADIENT _DISABLE_ALBEDO_MAP _EDGE_SMOOTHING_AUTOMATIC _GRADIENT_FOUR_POINT
-    _ROUND_CORNERS _SPECULAR_HIGHLIGHTS _SPECULAR_SETUP _USE_WORLD_SCALE
+  m_ValidKeywords:
+  - _ALPHABLEND_ON
+  - _BORDER_LIGHT_OPAQUE
+  - _BORDER_LIGHT_REPLACES_ALBEDO
+  - _BORDER_LIGHT_USES_GRADIENT
+  - _DISABLE_ALBEDO_MAP
+  - _ROUND_CORNERS
+  - _SPECULAR_HIGHLIGHTS
+  - _USE_WORLD_SCALE
+  m_InvalidKeywords:
+  - _SPECULAR_SETUP
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -110,6 +118,7 @@ Material:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    m_Ints: []
     m_Floats:
     - _AlbedoAlphaMode: 0
     - _AlbedoAssignedAtRuntime: 0
@@ -121,7 +130,7 @@ Material:
     - _BlurMode: 0
     - _BlurTextureIntensity: 1
     - _BorderColorMode: 3
-    - _BorderLight: 1
+    - _BorderLight: 0
     - _BorderLightOpaque: 1
     - _BorderLightOpaqueAlpha: 0.5
     - _BorderLightReplacesAlbedo: 1
@@ -142,8 +151,8 @@ Material:
     - _DirectionalLight: 0
     - _DstBlend: 10
     - _DstBlendAlpha: 1
-    - _EdgeSmoothingMode: 1
-    - _EdgeSmoothingValue: 0.002
+    - _EdgeSmoothingMode: 0
+    - _EdgeSmoothingValue: 0.05
     - _EnableChannelMap: 0
     - _EnableEmission: 0
     - _EnableHoverColorOverride: 0
@@ -166,7 +175,7 @@ Material:
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _GradientAngle: 45
-    - _GradientMode: 2
+    - _GradientMode: 0
     - _HoverLight: 0
     - _IndependentCorners: 0
     - _InnerGlow: 0
@@ -192,8 +201,8 @@ Material:
     - _RenderQueueOverride: -1
     - _RimLight: 0
     - _RimPower: 0.25
-    - _RoundCornerMargin: 0.01
-    - _RoundCornerRadius: 0.01
+    - _RoundCornerMargin: 0.05
+    - _RoundCornerRadius: 0.05
     - _RoundCorners: 1
     - _RoundCornersHideInterior: 0
     - _Smoothness: 0.5
@@ -226,7 +235,7 @@ Material:
     - _BlurBackgroundRect: {r: 0, g: 0, b: 1, a: 1}
     - _BorderColor: {r: 1, g: 1, b: 1, a: 0}
     - _ClippingBorderColor: {r: 1, g: 0.19999996, b: 0, a: 1}
-    - _Color: {r: 0, g: 0, b: 0, a: 0}
+    - _Color: {r: 0, g: 0, b: 0, a: 0.5019608}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _EmissiveColor: {r: 0, g: 0, b: 0, a: 1}
     - _EnvironmentColorX: {r: 1, g: 0, b: 0, a: 1}

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "documentationUrl": "https://aka.ms/mrtk3graphics",


### PR DESCRIPTION
The magnifier shader now supports rounded corners. Updated the sample too:
![image](https://github.com/microsoft/MixedReality-GraphicsTools-Unity/assets/13305729/3c60bdb6-66b2-44fd-8d4d-665e957c2572)


(Also found and fixed a small include bug in the acrylic shader.)

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
