### PR TITLE
Updating the test projects Asset Store Validation package to v0.5.1

### DIFF
--- a/GraphicsToolsUnityProject/Packages/manifest.json
+++ b/GraphicsToolsUnityProject/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.microsoft.mrtk.graphicstools.shadergraph.unity": "file:../../com.microsoft.mrtk.graphicstools.shadergraph.unity",
     "com.microsoft.mrtk.graphicstools.unity": "file:../../com.microsoft.mrtk.graphicstools.unity",
-    "com.unity.asset-store-validation": "0.2.1",
+    "com.unity.asset-store-validation": "0.5.1",
     "com.unity.ide.visualstudio": "2.0.17",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.inputsystem": "1.4.4",

--- a/GraphicsToolsUnityProject/Packages/packages-lock.json
+++ b/GraphicsToolsUnityProject/Packages/packages-lock.json
@@ -15,7 +15,7 @@
       "dependencies": {}
     },
     "com.unity.asset-store-validation": {
-      "version": "0.2.1",
+      "version": "0.5.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
## Overview
Updating the test projects Asset Store Validation package to v0.5.1. This is the min version needed to publish to the Unity UPM Asset Store


## Verification
Ran package validation.

1. From test app's package manage, find and select "MRTK Graphics Tools"
2. Click the drop-down arrow next to "Validate" button.
3. Select "Asset Store standard"
4. Click "Validate" button
5. Validate the results have no errors (click "View Result")
    1. You can ignore the "Error: There is no publisher linked to this account." failure

![image](https://github.com/microsoft/MixedReality-GraphicsTools-Unity/assets/36461279/95f9afa9-2ab9-406e-897d-331123a94e39)

