### PR TITLE
Ensure MaterialInstance copies all properties from source

### DIFF
--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/MaterialInstance.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/MaterialInstance.cs
@@ -51,6 +51,7 @@ namespace Microsoft.MixedReality.GraphicsTools
             }
 
             Material output = new Material(source);
+            output.CopyPropertiesFromMaterial(source);
             output.name += InstancePostfix;
 
             return output;


### PR DESCRIPTION
## Overview
Added a call to `output.CopyPropertiesFromMaterial(source)` in the `Instance` method of `MaterialInstance.cs`. This ensures that the newly created `output` material inherits all properties from the `source` material, maintaining consistency between them.

## Changes
- Fixes: #221 

## Verification
> This optional section is a place where you can detail the specific type of verification
> you want from reviewers. For example, if you want reviewers to checkout the PR locally
> and validate the functionality of specific scenarios, provide instructions
> on the specific scenarios and what you want verified.
>
> If there are specific areas of concern or question feel free to highlight them here so
> that reviewers can watch out for those issues.
>
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
