### PR TITLE
Unity 6 Render Graph API Compilation Fixes

### DIFF
--- a/com.microsoft.mrtk.graphicstools.shadergraph.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.shadergraph.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.shadergraph.unity",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "displayName": "MRTK Graphics Tools Shader Graph",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity Shader Graph.",
   "documentationUrl": "https://aka.ms/mrtk3graphics",

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/ScreenshotUtilities.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/ScreenshotUtilities.cs
@@ -87,7 +87,7 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
                 if (camera == null)
                 {
 #if UNITY_6000_0_OR_NEWER
-					camera = GameObject.FindFirstObjectByType<Camera>();
+                    camera = GameObject.FindFirstObjectByType<Camera>();
 #else
                     camera = GameObject.FindObjectOfType<Camera>();
 #endif

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/ScreenshotUtilities.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Utilities/ScreenshotUtilities.cs
@@ -86,8 +86,8 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
 
                 if (camera == null)
                 {
-#if UNITY_2023_1_OR_NEWER
-                    camera = GameObject.FindFirstObjectByType<Camera>();
+#if UNITY_6000_0_OR_NEWER
+					camera = GameObject.FindFirstObjectByType<Camera>();
 #else
                     camera = GameObject.FindObjectOfType<Camera>();
 #endif

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicBlurRenderPass.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicBlurRenderPass.cs
@@ -57,9 +57,9 @@ namespace Microsoft.MixedReality.GraphicsTools
         private Vector4 info = Vector4.zero;
 
 #if UNITY_6000_0_OR_NEWER
-		[System.Obsolete]
+        [System.Obsolete]
 #endif
-		public override void Configure(CommandBuffer cmd, RenderTextureDescriptor cameraTextureDescriptor)
+        public override void Configure(CommandBuffer cmd, RenderTextureDescriptor cameraTextureDescriptor)
         {
             int width = cameraTextureDescriptor.width / downSample;
             int height = cameraTextureDescriptor.height / downSample;
@@ -114,9 +114,9 @@ namespace Microsoft.MixedReality.GraphicsTools
 #endif
 
 #if UNITY_6000_0_OR_NEWER
-		[System.Obsolete]
+        [System.Obsolete]
 #endif
-		public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
             CommandBuffer cmd = CommandBufferPool.Get(profilerLabel);
             cmd.Clear();

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicBlurRenderPass.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicBlurRenderPass.cs
@@ -56,7 +56,10 @@ namespace Microsoft.MixedReality.GraphicsTools
 
         private Vector4 info = Vector4.zero;
 
-        public override void Configure(CommandBuffer cmd, RenderTextureDescriptor cameraTextureDescriptor)
+#if UNITY_6000_0_OR_NEWER
+		[System.Obsolete]
+#endif
+		public override void Configure(CommandBuffer cmd, RenderTextureDescriptor cameraTextureDescriptor)
         {
             int width = cameraTextureDescriptor.width / downSample;
             int height = cameraTextureDescriptor.height / downSample;
@@ -110,7 +113,10 @@ namespace Microsoft.MixedReality.GraphicsTools
 
 #endif
 
-        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+#if UNITY_6000_0_OR_NEWER
+		[System.Obsolete]
+#endif
+		public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
             CommandBuffer cmd = CommandBufferPool.Get(profilerLabel);
             cmd.Clear();

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicLayer.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Scripts/AcrylicLayer.cs
@@ -4,7 +4,9 @@
 #if GT_USE_URP
 using System;
 using UnityEngine;
+#if !UNITY_6000_0_OR_NEWER
 using UnityEngine.Experimental.Rendering.Universal;
+#endif
 using UnityEngine.Profiling;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Scripts/MagnifierManager.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Scripts/MagnifierManager.cs
@@ -4,7 +4,9 @@
 #if GT_USE_URP
 using System.Collections.Generic;
 using UnityEngine;
+#if !UNITY_6000_0_OR_NEWER
 using UnityEngine.Experimental.Rendering.Universal;
+#endif
 using UnityEngine.Rendering.Universal;
 
 namespace Microsoft.MixedReality.GraphicsTools

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/ClearRenderTargetPass.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/ClearRenderTargetPass.cs
@@ -20,10 +20,13 @@ namespace Microsoft.MixedReality.GraphicsTools
             renderPassEvent = settings.RenderPassEvent;
         }
 
-        /// <summary>
-        /// Queues a ClearRenderTarget command based on the pass settings.
-        /// </summary>
-        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+		/// <summary>
+		/// Queues a ClearRenderTarget command based on the pass settings.
+		/// </summary>
+#if UNITY_6000_0_OR_NEWER
+		[System.Obsolete]
+#endif
+		public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
             CommandBuffer cmd = CommandBufferPool.Get();
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/ClearRenderTargetPass.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/ClearRenderTargetPass.cs
@@ -20,13 +20,13 @@ namespace Microsoft.MixedReality.GraphicsTools
             renderPassEvent = settings.RenderPassEvent;
         }
 
-		/// <summary>
-		/// Queues a ClearRenderTarget command based on the pass settings.
-		/// </summary>
+        /// <summary>
+        /// Queues a ClearRenderTarget command based on the pass settings.
+        /// </summary>
 #if UNITY_6000_0_OR_NEWER
-		[System.Obsolete]
+        [System.Obsolete]
 #endif
-		public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
             CommandBuffer cmd = CommandBufferPool.Get();
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/DrawFullscreenPass.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/DrawFullscreenPass.cs
@@ -34,11 +34,11 @@ namespace Microsoft.MixedReality.GraphicsTools
             profilerTag = tag;
         }
 
-		/// <inheritdoc/>
+        /// <inheritdoc/>
 #if UNITY_6000_0_OR_NEWER
-		[System.Obsolete]
+        [System.Obsolete]
 #endif
-		public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
+        public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
         {
             RenderTextureDescriptor blitTargetDescriptor = renderingData.cameraData.cameraTargetDescriptor;
             blitTargetDescriptor.depthBufferBits = 0;
@@ -72,11 +72,11 @@ namespace Microsoft.MixedReality.GraphicsTools
             }
         }
 
-		/// <inheritdoc/>
+        /// <inheritdoc/>
 #if UNITY_6000_0_OR_NEWER
-		[System.Obsolete]
+        [System.Obsolete]
 #endif
-		public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
             CommandBuffer cmd = CommandBufferPool.Get(profilerTag);
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/DrawFullscreenPass.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/DrawFullscreenPass.cs
@@ -34,8 +34,11 @@ namespace Microsoft.MixedReality.GraphicsTools
             profilerTag = tag;
         }
 
-        /// <inheritdoc/>
-        public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
+		/// <inheritdoc/>
+#if UNITY_6000_0_OR_NEWER
+		[System.Obsolete]
+#endif
+		public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
         {
             RenderTextureDescriptor blitTargetDescriptor = renderingData.cameraData.cameraTargetDescriptor;
             blitTargetDescriptor.depthBufferBits = 0;
@@ -69,8 +72,11 @@ namespace Microsoft.MixedReality.GraphicsTools
             }
         }
 
-        /// <inheritdoc/>
-        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+		/// <inheritdoc/>
+#if UNITY_6000_0_OR_NEWER
+		[System.Obsolete]
+#endif
+		public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
         {
             CommandBuffer cmd = CommandBufferPool.Get(profilerTag);
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/FlyCameraController.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/FlyCameraController.cs
@@ -95,8 +95,8 @@ namespace Microsoft.MixedReality.GraphicsTools
         /// </summary>
         private void Start()
         {
-#if UNITY_2023_1_OR_NEWER
-            SubsystemManager.GetSubsystems(xrDisplaySubsystems);
+#if UNITY_6000_0_OR_NEWER
+			SubsystemManager.GetSubsystems(xrDisplaySubsystems);
 #else
             SubsystemManager.GetInstances(xrDisplaySubsystems);
 #endif

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/FlyCameraController.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Utilities/FlyCameraController.cs
@@ -96,7 +96,7 @@ namespace Microsoft.MixedReality.GraphicsTools
         private void Start()
         {
 #if UNITY_6000_0_OR_NEWER
-			SubsystemManager.GetSubsystems(xrDisplaySubsystems);
+            SubsystemManager.GetSubsystems(xrDisplaySubsystems);
 #else
             SubsystemManager.GetInstances(xrDisplaySubsystems);
 #endif

--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/MaterialGallery/Scripts/MaterialMatrix.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/MaterialGallery/Scripts/MaterialMatrix.cs
@@ -53,12 +53,12 @@ namespace Microsoft.MixedReality.GraphicsTools.Samples.MaterialGallery
             if (useDefaultMaterial)
             {
 #if UNITY_6000_0_OR_NEWER
-				if (lastRenderPipelineAsset != GraphicsSettings.defaultRenderPipeline)
+                if (lastRenderPipelineAsset != GraphicsSettings.defaultRenderPipeline)
 #else
-				if (lastRenderPipelineAsset != GraphicsSettings.renderPipelineAsset)
+                if (lastRenderPipelineAsset != GraphicsSettings.renderPipelineAsset)
 #endif
-				{
-					BuildMatrix();
+                {
+                    BuildMatrix();
                 }
             }
         }
@@ -88,11 +88,11 @@ namespace Microsoft.MixedReality.GraphicsTools.Samples.MaterialGallery
             if (useDefaultMaterial)
             {
 #if UNITY_6000_0_OR_NEWER
-				lastRenderPipelineAsset = GraphicsSettings.defaultRenderPipeline;
+                lastRenderPipelineAsset = GraphicsSettings.defaultRenderPipeline;
 #else
-				lastRenderPipelineAsset = GraphicsSettings.renderPipelineAsset;
+                lastRenderPipelineAsset = GraphicsSettings.renderPipelineAsset;
 #endif
-				if (lastRenderPipelineAsset != null)
+                if (lastRenderPipelineAsset != null)
                 {
                     currentMaterial = lastRenderPipelineAsset.defaultMaterial;
                 }

--- a/com.microsoft.mrtk.graphicstools.unity/Samples~/MaterialGallery/Scripts/MaterialMatrix.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Samples~/MaterialGallery/Scripts/MaterialMatrix.cs
@@ -52,9 +52,13 @@ namespace Microsoft.MixedReality.GraphicsTools.Samples.MaterialGallery
             // Poll for when the render pipeline changes.
             if (useDefaultMaterial)
             {
-                if (lastRenderPipelineAsset != GraphicsSettings.renderPipelineAsset)
-                {
-                    BuildMatrix();
+#if UNITY_6000_0_OR_NEWER
+				if (lastRenderPipelineAsset != GraphicsSettings.defaultRenderPipeline)
+#else
+				if (lastRenderPipelineAsset != GraphicsSettings.renderPipelineAsset)
+#endif
+				{
+					BuildMatrix();
                 }
             }
         }
@@ -83,9 +87,12 @@ namespace Microsoft.MixedReality.GraphicsTools.Samples.MaterialGallery
 
             if (useDefaultMaterial)
             {
-                lastRenderPipelineAsset = GraphicsSettings.renderPipelineAsset;
-
-                if (lastRenderPipelineAsset != null)
+#if UNITY_6000_0_OR_NEWER
+				lastRenderPipelineAsset = GraphicsSettings.defaultRenderPipeline;
+#else
+				lastRenderPipelineAsset = GraphicsSettings.renderPipelineAsset;
+#endif
+				if (lastRenderPipelineAsset != null)
                 {
                     currentMaterial = lastRenderPipelineAsset.defaultMaterial;
                 }

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "documentationUrl": "https://aka.ms/mrtk3graphics",


### PR DESCRIPTION
## Overview
Fixes APIs deprecated in Unity 6. Unity is in the process of deprecating the existing custom render pass system for "render graph"
[Unity - Manual: Compatibility Mode in URP (unity3d.com)](https://docs.unity3d.com/6000.0/Documentation/Manual/urp/compatibility-mode.html) As a quick fix to get compiling/working again we are using compatibility mode. In the future we will make a task to port over to the new render graph system.

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
