### PR TITLE
Shader Graph Updates and Fixes

### DIFF
--- a/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Includes/ScalableCommon.hlsl
+++ b/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Includes/ScalableCommon.hlsl
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#ifndef GT_SCALABLE_COMMON
+#define GT_SCALABLE_COMMON
+
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderVariablesFunctions.hlsl"
+
+half3 GTAlphaModulate(half3 albedo, half alpha)
+{
+#if UNITY_VERSION >= 202200
+	return AlphaModulate(albedo, alpha);
+#else
+	// Fake alpha for multiply blend by lerping albedo towards 1 (white) using alpha.
+	// Manual adjustment for "lighter" multiply effect (similar to "premultiplied alpha")
+	// would be painting whiter pixels in the texture.
+	// This emulates that procedure in shader, so it should be applied to the base/source color.
+#if defined(_ALPHAMODULATE_ON)
+	return lerp(half3(1.0, 1.0, 1.0), albedo, alpha);
+#else
+	return albedo;
+#endif
+#endif
+}
+
+#endif // GT_SCALABLE_COMMON

--- a/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Includes/ScalableCommon.hlsl.meta
+++ b/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Includes/ScalableCommon.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 89b740bcf647a014e8129466d4bb45e9
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Includes/ScalableForwardPass.hlsl
+++ b/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Includes/ScalableForwardPass.hlsl
@@ -17,6 +17,8 @@ PackedVaryings vert(Attributes input)
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/LODCrossFade.hlsl"
 #endif
 
+#include "ScalableCommon.hlsl"
+
 void InitializeInputData(Varyings input, SurfaceDescription surfaceDescription, out InputData inputData)  
 {  
     inputData = (InputData)0;  
@@ -76,7 +78,7 @@ void frag(
     #endif
 
     #if defined(_ALPHAMODULATE_ON)
-        surfaceDescription.BaseColor = AlphaModulate(surfaceDescription.BaseColor, alpha);
+        surfaceDescription.BaseColor = GTAlphaModulate(surfaceDescription.BaseColor, alpha);
     #endif
 
     #if defined(_DBUFFER)
@@ -100,7 +102,7 @@ void frag(
 
 #else
 
-#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderVariablesFunctions.hlsl"
+#include "ScalableCommon.hlsl"
 
 void InitializeInputData(Varyings input, SurfaceDescription surfaceDescription, out InputData inputData)
 {
@@ -237,7 +239,7 @@ void frag(
         surface.clearCoatSmoothness = saturate(surfaceDescription.CoatSmoothness);
     #endif
 
-    surface.albedo = AlphaModulate(surface.albedo, surface.alpha);
+    surface.albedo = GTAlphaModulate(surface.albedo, surface.alpha);
 
 #ifdef _DBUFFER
     ApplyDecalToSurfaceData(unpacked.positionCS, surface, inputData);

--- a/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Includes/ScalableForwardPass.hlsl
+++ b/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Includes/ScalableForwardPass.hlsl
@@ -1,8 +1,103 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+PackedVaryings vert(Attributes input)
+{
+    Varyings output = (Varyings)0;
+    output = BuildVaryings(input);
+    PackedVaryings packedOutput = (PackedVaryings)0;
+    packedOutput = PackVaryings(output);
+    return packedOutput;
+}
+  
 #if defined(MATERIAL_QUALITY_LOW)
-#include "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/UnlitPass.hlsl"
+
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+#if defined(LOD_FADE_CROSSFADE)
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/LODCrossFade.hlsl"
+#endif
+
+void InitializeInputData(Varyings input, SurfaceDescription surfaceDescription, out InputData inputData)  
+{  
+    inputData = (InputData)0;  
+    
+    inputData.positionWS = input.positionWS;  
+    inputData.normalWS = input.normalWS; 
+    inputData.viewDirectionWS = half3(0, 0, 1);
+    inputData.shadowCoord = 0;
+    inputData.fogCoord = 0; 
+    inputData.vertexLighting = half3(0, 0, 0);
+    #if defined(LIGHTMAP_ON)
+        inputData.bakedGI = SampleLightmap(input.staticLightmapUV, input.positionWS, inputData.normalWS);
+    #else
+        inputData.bakedGI = half3(1, 1, 1);
+    #endif
+        inputData.normalizedScreenSpaceUV = GetNormalizedScreenSpaceUV(input.positionCS);  
+        inputData.shadowMask = half4(1, 1, 1, 1);
+  
+    #if defined(DEBUG_DISPLAY) 
+        #if defined(LIGHTMAP_ON)  
+            inputData.staticLightmapUV = input.staticLightmapUV;  
+        #else  
+            inputData.vertexSH = input.sh;  
+        #endif  
+    #endif  
+}  
+
+void frag(  
+    PackedVaryings packedInput,  
+    out half4 outColor : SV_Target0  
+#ifdef _WRITE_RENDERING_LAYERS  
+    , out float4 outRenderingLayers : SV_Target1  
+#endif  
+)  
+{  
+    Varyings unpacked = UnpackVaryings(packedInput);  
+    UNITY_SETUP_INSTANCE_ID(unpacked);  
+    UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(unpacked);  
+    SurfaceDescription surfaceDescription = BuildSurfaceDescription(unpacked);  
+  
+    #if defined(_SURFACE_TYPE_TRANSPARENT)  
+        bool isTransparent = true;  
+    #else  
+        bool isTransparent = false;  
+    #endif  
+  
+    #if defined(_ALPHATEST_ON)  
+        half alpha = AlphaDiscard(surfaceDescription.Alpha, surfaceDescription.AlphaClipThreshold);  
+    #elif defined(_SURFACE_TYPE_TRANSPARENT)  
+        half alpha = surfaceDescription.Alpha;  
+    #else  
+        half alpha = half(1.0);  
+    #endif  
+
+    #if defined(LOD_FADE_CROSSFADE) && USE_UNITY_CROSSFADE
+        LODFadeCrossFade(unpacked.positionCS);
+    #endif
+
+    #if defined(_ALPHAMODULATE_ON)
+        surfaceDescription.BaseColor = AlphaModulate(surfaceDescription.BaseColor, alpha);
+    #endif
+
+    #if defined(_DBUFFER)
+        ApplyDecalToBaseColor(unpacked.positionCS, surfaceDescription.BaseColor);
+    #endif
+  
+    InputData inputData;  
+    InitializeInputData(unpacked, surfaceDescription, inputData);  
+  
+    half4 albedo = float4(surfaceDescription.BaseColor, saturate(alpha));  
+    half3 normalTS = half3(0, 0, 1);
+    half4 finalColor = UniversalFragmentBakedLit(inputData, albedo.rgb, alpha, normalTS);
+    finalColor.a = OutputAlpha(finalColor.a, isTransparent);
+    outColor = finalColor;  
+
+    #ifdef _WRITE_RENDERING_LAYERS  
+        uint renderingLayers = GetMeshRenderingLayer();  
+        outRenderingLayers = float4(EncodeMeshRenderingLayer(renderingLayers), 0, 0, 0);  
+    #endif  
+} 
+
 #else
 
 #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ShaderVariablesFunctions.hlsl"
@@ -60,15 +155,6 @@ void InitializeInputData(Varyings input, SurfaceDescription surfaceDescription, 
     inputData.vertexSH = input.sh;
     #endif
     #endif
-}
-
-PackedVaryings vert(Attributes input)
-{
-    Varyings output = (Varyings)0;
-    output = BuildVaryings(input);
-    PackedVaryings packedOutput = (PackedVaryings)0;
-    packedOutput = PackVaryings(output);
-    return packedOutput;
 }
 
 void frag(

--- a/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Includes/ScalableGBufferPass.hlsl
+++ b/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/Includes/ScalableGBufferPass.hlsl
@@ -4,6 +4,9 @@
 #if defined(MATERIAL_QUALITY_LOW)
 #include "Packages/com.unity.render-pipelines.universal/Editor/ShaderGraph/Includes/UnlitGBufferPass.hlsl"
 #else 
+
+#include "ScalableCommon.hlsl"
+
 void InitializeInputData(Varyings input, SurfaceDescription surfaceDescription, out InputData inputData)
 {
     inputData = (InputData)0;
@@ -150,7 +153,7 @@ FragmentOutput frag(PackedVaryings packedInput)
     surface.clearCoatMask       = 0;
     surface.clearCoatSmoothness = 1;
 
-    surface.albedo = AlphaModulate(surface.albedo, surface.alpha);
+    surface.albedo = GTAlphaModulate(surface.albedo, surface.alpha);
 
     Light mainLight = GetMainLight(inputData.shadowCoord, inputData.positionWS, inputData.shadowMask);
     MixRealtimeAndBakedGI(mainLight, inputData.normalWS, inputData.bakedGI, inputData.shadowMask);

--- a/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/ShaderGUI/GraphicsToolsShaderGraphLitGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/ShaderGUI/GraphicsToolsShaderGraphLitGUI.cs
@@ -47,5 +47,47 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             DoPopup(SrcBlendAlphaLabel, SrcBlendAlpha, names);
             DoPopup(DstBlendAlphaLabel, DstBlendAlpha, names);
         }
+
+        /// <summary>
+        /// Ensure that the alpha blending properties are maintained.
+        /// </summary>
+        public override void ValidateMaterial(Material material)
+        {
+            // We must cache the values of SrcBlendAlpha and DstBlendAlpha because base.ValidateMaterial() will overwrite them with it's own default values.
+            float prevSrcBlendAlpha;
+
+            if (SrcBlendAlpha != null)
+            {
+                prevSrcBlendAlpha = SrcBlendAlpha.floatValue;
+            }
+            else if (material.HasProperty(GraphicsToolsCoreRenderStates.Property.SrcBlendAlpha))
+            {
+                prevSrcBlendAlpha = material.GetFloat(GraphicsToolsCoreRenderStates.Property.SrcBlendAlpha);
+            }
+            else
+            {
+                prevSrcBlendAlpha = 1.0f;
+            }
+
+            float prevDstBlendAlpha;
+
+            if (DstBlendAlpha != null)
+            {
+                prevDstBlendAlpha = DstBlendAlpha.floatValue;
+            }
+            else if (material.HasProperty(GraphicsToolsCoreRenderStates.Property.DstBlendAlpha))
+            {
+                prevDstBlendAlpha = material.GetFloat(GraphicsToolsCoreRenderStates.Property.DstBlendAlpha);
+            }
+            else
+            {
+                prevDstBlendAlpha = 1.0f;
+            }
+
+            base.ValidateMaterial(material);
+
+            material.SetFloat(GraphicsToolsCoreRenderStates.Property.SrcBlendAlpha, prevSrcBlendAlpha);
+            material.SetFloat(GraphicsToolsCoreRenderStates.Property.DstBlendAlpha, prevDstBlendAlpha);
+        }
     }
 }

--- a/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/ShaderGUI/GraphicsToolsShaderGraphUnlitGUI.cs
+++ b/com.microsoft.mrtk.graphicstools.shadergraph.unity/Editor/ShaderGUI/GraphicsToolsShaderGraphUnlitGUI.cs
@@ -47,5 +47,47 @@ namespace Microsoft.MixedReality.GraphicsTools.Editor
             DoPopup(SrcBlendAlphaLabel, SrcBlendAlpha, names);
             DoPopup(DstBlendAlphaLabel, DstBlendAlpha, names);
         }
+
+        /// <summary>
+        /// Ensure that the alpha blending properties are maintained.
+        /// </summary>
+        public override void ValidateMaterial(Material material)
+        {
+            // We must cache the values of SrcBlendAlpha and DstBlendAlpha because base.ValidateMaterial() will overwrite them with it's own default values.
+            float prevSrcBlendAlpha;
+
+            if (SrcBlendAlpha != null)
+            {
+                prevSrcBlendAlpha = SrcBlendAlpha.floatValue;
+            }
+            else if (material.HasProperty(GraphicsToolsCoreRenderStates.Property.SrcBlendAlpha))
+            {
+                prevSrcBlendAlpha = material.GetFloat(GraphicsToolsCoreRenderStates.Property.SrcBlendAlpha);
+            }
+            else
+            {
+                prevSrcBlendAlpha = 1.0f;
+            }
+
+            float prevDstBlendAlpha;
+
+            if (DstBlendAlpha != null)
+            {
+                prevDstBlendAlpha = DstBlendAlpha.floatValue;
+            }
+            else if (material.HasProperty(GraphicsToolsCoreRenderStates.Property.DstBlendAlpha))
+            {
+                prevDstBlendAlpha = material.GetFloat(GraphicsToolsCoreRenderStates.Property.DstBlendAlpha);
+            }
+            else
+            {
+                prevDstBlendAlpha = 1.0f;
+            }
+
+            base.ValidateMaterial(material);
+
+            material.SetFloat(GraphicsToolsCoreRenderStates.Property.SrcBlendAlpha, prevSrcBlendAlpha);
+            material.SetFloat(GraphicsToolsCoreRenderStates.Property.DstBlendAlpha, prevDstBlendAlpha);
+        }
     }
 }

--- a/com.microsoft.mrtk.graphicstools.shadergraph.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.shadergraph.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.shadergraph.unity",
-  "version": "0.8.1",
+  "version": "0.8.7",
   "displayName": "MRTK Graphics Tools Shader Graph",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity Shader Graph.",
   "documentationUrl": "https://aka.ms/mrtk3graphics",

--- a/com.microsoft.mrtk.graphicstools.unity/Editor/Experimental/AreaLight/AreaLightInspector.cs
+++ b/com.microsoft.mrtk.graphicstools.unity/Editor/Experimental/AreaLight/AreaLightInspector.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.﻿
+// Licensed under the MIT License.
 
 using UnityEditor;
 using UnityEngine;

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardProgram.hlsl
@@ -273,10 +273,8 @@ Varyings VertexStage(Attributes input)
 #if defined(_UV_SCREEN)
     output.uvScreen = ComputeScreenPos(output.position);
     // Flip vertical UV for orthographic projections (if not already flipped) to ensure the image is not upside down.
-#if defined(UNITY_UV_STARTS_AT_TOP)
-    output.uvScreen.y = unity_OrthoParams.w ? (1.0 - output.uvScreen.y) : output.uvScreen.y;
-#else
-    output.uvScreen.y = unity_OrthoParams.w ? output.uvScreen.y : (1.0 - output.uvScreen.y);
+#if !UNITY_UV_STARTS_AT_TOP
+    output.uvScreen.y = 1.0 - output.uvScreen.y;
 #endif
 #elif (_BLUR_TEXTURE_PREBAKED_BACKGROUND)
     output.uvBackgroundRect = float2((vertexPosition.x - _BlurBackgroundRect.x) / (_BlurBackgroundRect.z - _BlurBackgroundRect.x), 

--- a/com.microsoft.mrtk.graphicstools.unity/package.json
+++ b/com.microsoft.mrtk.graphicstools.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.microsoft.mrtk.graphicstools.unity",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "displayName": "MRTK Graphics Tools",
   "description": "Graphics tools and components for developing Mixed Reality applications in Unity.",
   "documentationUrl": "https://aka.ms/mrtk3graphics",


### PR DESCRIPTION
## Overview

- Fixed a bug where source and destination blend alpha were not maintained when "Allow Material override" was checked.
- Fixed a Unity 2021 shader compilation error.
- Acrylic bug fix, UNITY_UV_STARTS_AT_TOP is always defined, so the previous check was incorrect. unity_OrthoParams.w was just another way to check if the UV was flipped. So, simplifying the check.
- @vmoras6699 changed the scalable shader graph target's unlit low shader path to use baked lit.

## Verification
> As a reviewer, it is possible to check out this change locally by using the following
> commands (substituting {PR_ID} with the ID of this pull request):
>
> git fetch origin pull/{PR_ID}/head:name_of_local_branch
>
> git checkout name_of_local_branch
