### PR TITLE
Add non-SRP versions for all compatible shaders with automated generation and update (#234)

### DIFF
--- a/GraphicsToolsUnityProject/Assets/NonSrpShaderAssetGenerator.cs
+++ b/GraphicsToolsUnityProject/Assets/NonSrpShaderAssetGenerator.cs
@@ -1,0 +1,78 @@
+#define PATCHING_ACTIVE
+using UnityEngine;
+using UnityEditor;
+using System.IO;
+using System.Text.RegularExpressions;
+
+public class NonSrpShaderAssetGenerator : AssetPostprocessor
+{
+
+    static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
+    {
+        Debug.Log("Processing assets");
+#if PATCHING_ACTIVE
+        bool assetDBDirty = false;
+        foreach (string str in importedAssets)
+        {
+            if (str.EndsWith(".shader") && !str.EndsWith("NonSrp.shader"))
+            {
+                string resultFile = copyAndPatchShader(str);
+                if (resultFile != null)
+                {
+                    assetDBDirty = true;
+                }
+                
+            }   
+        }
+        if (assetDBDirty) { AssetDatabase.Refresh(); }
+#endif
+    }
+
+    static string copyAndPatchShader(string path)
+    {
+        if (!File.Exists(path)) { return null; }
+
+        bool isPatched = false;
+        
+        string shaderText = File.ReadAllText(path);
+        string sourceDirectory = Path.GetDirectoryName(path);
+        string targetDirectory = sourceDirectory + "/NonSRP";
+
+        // Only work with shaders from GraficsTools
+        string nameDeclaration = Regex.Match(shaderText, " *Shader *\"Graphics Tools\\/.*\"").Value;
+        if (nameDeclaration.Length <= 0 ) { return null; }
+
+        string outputPath = sourceDirectory + "/" + Path.GetFileNameWithoutExtension(path) +"NonSrp" +  Path.GetExtension(path);
+               
+        // Put "_NON_SRP" befor StandardProgram include (in Standard and StandardCanvas)
+        MatchCollection matchesStandardProgram = Regex.Matches(shaderText, "(?<tab> *)(#include_with_pragmas \"GraphicsToolsStandardProgram.hlsl\")");
+        if (matchesStandardProgram.Count > 0)
+        {
+            string tab = matchesStandardProgram[1].Groups["tab"].Value;
+            shaderText = Regex.Replace(shaderText, matchesStandardProgram[0].Value,  tab + "#define _NON_SRP\r\n" + matchesStandardProgram[0].Value);
+            isPatched = true;
+        }
+
+        // Remove CBUFFER statements
+        MatchCollection matchCBuff = Regex.Matches(shaderText, " *(CBUFFER_START\\(UnityPerMaterial\\))| *(CBUFFER_END)");
+        if (matchCBuff.Count > 0)
+        {
+            shaderText = Regex.Replace(shaderText, " *(CBUFFER_START\\(UnityPerMaterial\\))| *(CBUFFER_END)", "");
+            isPatched = true;
+        }
+
+        // Rename shader, put it under NonSrp directory, write to file
+        if (isPatched)
+        {
+            Match shaderDirAndName = Regex.Match(nameDeclaration, "(?<dir>.*\\/)(?<name>.*)\"");
+            string newNameDeclaration = shaderDirAndName.Groups["dir"].Value + "Non-SRP/" + shaderDirAndName.Groups["name"].Value + "NonSrp\"" ;
+            shaderText = Regex.Replace(shaderText, nameDeclaration, newNameDeclaration);
+            
+            File.WriteAllText(outputPath, shaderText);
+            return outputPath;
+        }
+        else { return null; }
+
+    }
+
+}

--- a/GraphicsToolsUnityProject/Assets/NonSrpShaderAssetGenerator.cs
+++ b/GraphicsToolsUnityProject/Assets/NonSrpShaderAssetGenerator.cs
@@ -1,5 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 #define PATCHING_ACTIVE
-using UnityEngine;
 using UnityEditor;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -9,7 +10,6 @@ public class NonSrpShaderAssetGenerator : AssetPostprocessor
 
     static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
     {
-        Debug.Log("Processing assets");
 #if PATCHING_ACTIVE
         bool assetDBDirty = false;
         foreach (string str in importedAssets)
@@ -21,7 +21,6 @@ public class NonSrpShaderAssetGenerator : AssetPostprocessor
                 {
                     assetDBDirty = true;
                 }
-                
             }   
         }
         if (assetDBDirty) { AssetDatabase.Refresh(); }
@@ -38,12 +37,12 @@ public class NonSrpShaderAssetGenerator : AssetPostprocessor
         string sourceDirectory = Path.GetDirectoryName(path);
         string targetDirectory = sourceDirectory + "/NonSRP";
 
-        // Only work with shaders from GraficsTools
+        // Only work with shaders from Graphics Tools
         string nameDeclaration = Regex.Match(shaderText, " *Shader *\"Graphics Tools\\/.*\"").Value;
         if (nameDeclaration.Length <= 0 ) { return null; }
-
-        string outputPath = sourceDirectory + "/" + Path.GetFileNameWithoutExtension(path) +"NonSrp" +  Path.GetExtension(path);
-               
+        
+        string outputPath = Path.Combine( sourceDirectory, Path.GetFileNameWithoutExtension(path) +"NonSrp" +  Path.GetExtension(path));
+        
         // Put "_NON_SRP" befor StandardProgram include (in Standard and StandardCanvas)
         MatchCollection matchesStandardProgram = Regex.Matches(shaderText, "(?<tab> *)(#include_with_pragmas \"GraphicsToolsStandardProgram.hlsl\")");
         if (matchesStandardProgram.Count > 0)

--- a/GraphicsToolsUnityProject/Assets/NonSrpShaderAssetGenerator.cs.meta
+++ b/GraphicsToolsUnityProject/Assets/NonSrpShaderAssetGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 849100b863b8cdb468b052d0f91313d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Shaders/CanvasBackplateAcrylicNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Shaders/CanvasBackplateAcrylicNonSrp.shader
@@ -1,0 +1,1030 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Experimental/Acrylic/Non-SRP/Canvas BackplateNonSrp" {
+
+Properties {
+
+    [Header(Round Rect)]
+        _Base_Color_("Base Color", Color) = (0,0,0,1)
+        [Toggle(_LINE_DISABLED_)] _Line_Disabled_("Line Disabled", Float) = 0
+        _Line_Width_("Line Width", Range(0,10)) = 1
+        _Line_Color_("Line Color", Color) = (0,0,0,1)
+        _Filter_Width_("Filter Width", Range(0,4)) = 1
+     
+    [Header(Line Highlight)]
+        _Rate_("Rate", Range(0,1)) = 0
+        _Highlight_Color_("Highlight Color", Color) = (0.98,0.98,0.98,1)
+        _Highlight_Width_("Highlight Width", Range(0,2)) = 0.25
+        _Highlight_Transform_("Highlight Transform", Vector) = (1, 1, 0, 0)
+        _Highlight_("Highlight", Range(0,1)) = 1
+     
+    [Header(Iridescence)]
+        [Toggle(_IRIDESCENCE_ENABLE_)] _Iridescence_Enable_("Iridescence Enable", Float) = 1
+        _Iridescence_Intensity_("Iridescence Intensity", Range(0,1)) = 0
+        _Iridescence_Edge_Intensity_("Iridescence Edge Intensity", Range(0,1)) = 0.56
+        _Iridescence_Tint_("Iridescence Tint", Color) = (1,1,1,1)
+        [NoScaleOffset] _Iridescent_Map_("Iridescent Map", 2D) = "" {}
+        _Frequency_("Frequency", Range(0,10)) = 1
+        _Vertical_Offset_("Vertical Offset", Range(0,2)) = 0
+        _Orthographic_Distance_("Orthographic Distance", Float) = 400
+     
+    [Header(Gradient)]
+        [Toggle(_GRADIENT_DISABLED_)] _Gradient_Disabled_("Gradient Disabled", Float) = 0
+        _Gradient_Color_("Gradient Color", Color) = (0.631373,0.631373,0.631373,1)
+        _Top_Left_("Top Left", Color) = (1,0.690196,0.976471,1)
+        _Top_Right_("Top Right", Color) = (0.0,0.33,0.88,1)
+        _Bottom_Left_("Bottom Left", Color) = (0.0,0.33,0.88,1)
+        _Bottom_Right_("Bottom Right", Color) = (1,1,1,1)
+        [Toggle(_EDGE_ONLY_)] _Edge_Only_("Edge Only", Float) = 0
+        _Line_Gradient_Blend_("Line Gradient Blend", Range(0,1)) = 0.36
+     
+    [Header(Fade)]
+        _Fade_Out_("Fade Out", Range(0,1)) = 1
+     
+    [Header(Blur Textures)]
+        [Toggle(_BLUR_TEXTURE_ENABLE_)] _Blur_Texture_Enable_("Blur Texture Enable", Float) = 1
+        [Toggle(_BLUR_TEXTURE_2_ENABLE_)] _Blur_Texture_2_Enable_("Blur Texture 2 Enable", Float) = 0
+        _Blur_Texture_Intensity_("Blur Texture Intensity", Range(0,1)) = 1.0
+        _Blur_Edge_Intensity_("Blur Edge Intensity", Range(0,1)) = 0.0
+        _Fallback_Color_("Fallback Color", Color) = (0,0,0,1)
+     
+    [Header(Color Texture)]
+        [Toggle(_NOISE_ENABLE_)] _Noise_Enable_("Noise Enable", Float) = 0
+        _Noise_("Noise", Range(0,1)) = 0.05
+        _Noise_Frequency_("Noise Frequency", Range(0,10)) = 1.0
+        [NoScaleOffset] _Noise_Texture_("Noise Texture", 2D) = "" {}
+     
+    [Header(Occlusion)]
+        _Occluded_Intensity_("Occluded Intensity", Range(0,1)) = 1
+        _Occluded_Blur_Intensity_("Occluded Blur Intensity", Range(0,1)) = 0
+        _Occluded_Blur_Edge_Intensity_("Occluded Blur Edge Intensity", Range(0,1)) = 0.0
+        [NoScaleOffset] _OccludedTex("OccludedTex", 2D) = "" {}
+        _OccludedColor("OccludedColor", Color) = (0,0.5,1,1)
+        _GridScale("GridScale", Float) = 0.02
+     
+    [Header(Antialiasing)]
+        [Toggle(_SMOOTH_EDGES_)] _Smooth_Edges_("Smooth Edges", Float) = 0
+     
+
+    [Header(Blending)]
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0  // "Zero"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+
+    [Header(Depth)]
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
+
+    [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
+    [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.
+    [HideInInspector] _ClipRectRadii("Clip Rect Radii", Vector) = (10.0, 10.0, 10.0, 10.0) // Added to avoid SRP warnings.
+}
+
+SubShader {
+    Tags{ "RenderType" = "Opaque" }
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+    CGINCLUDE
+
+    #pragma target 4.0
+    #pragma shader_feature_local _ _IRIDESCENCE_ENABLE_
+    #pragma shader_feature_local _ _LINE_DISABLED_
+    #pragma shader_feature_local _ _GRADIENT_DISABLED_
+    #pragma shader_feature_local _ _EDGE_ONLY_
+    #pragma shader_feature_local _ _NOISE_ENABLE_
+    #pragma shader_feature_local _ _SMOOTH_EDGES_
+
+    #pragma multi_compile_local _ _BLUR_TEXTURE_ENABLE_
+    #pragma multi_compile_local _ _BLUR_TEXTURE_2_ENABLE_
+
+    #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
+    #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+
+    #include "UnityCG.cginc"
+    #include "../../../Shaders/GraphicsToolsCommon.hlsl"
+
+
+    half4 _Base_Color_;
+    //bool _Line_Disabled_;
+    float _Line_Width_;
+    half4 _Line_Color_;
+    half _Filter_Width_;
+    float _Rate_;
+    half4 _Highlight_Color_;
+    half _Highlight_Width_;
+    float4 _Highlight_Transform_;
+    half _Highlight_;
+    //bool _Iridescence_Enable_;
+    float _Iridescence_Intensity_;
+    float _Iridescence_Edge_Intensity_;
+    half4 _Iridescence_Tint_;
+    sampler2D _Iridescent_Map_;
+    half _Frequency_;
+    half _Vertical_Offset_;
+    float _Orthographic_Distance_;
+    //bool _Gradient_Disabled_;
+    half4 _Gradient_Color_;
+    half4 _Top_Left_;
+    half4 _Top_Right_;
+    half4 _Bottom_Left_;
+    half4 _Bottom_Right_;
+    //bool _Edge_Only_;
+    half _Line_Gradient_Blend_;
+    float _Fade_Out_;
+    //bool _Blur_Texture_Enable_;
+    //bool _Blur_Texture_2_Enable_;
+    half _Blur_Texture_Intensity_;
+    half _Blur_Edge_Intensity_;
+    half4 _Fallback_Color_;
+    //bool _Noise_Enable_;
+    float _Noise_;
+    float _Noise_Frequency_;
+    sampler2D _Noise_Texture_;
+    half _Occluded_Intensity_;
+    half _Occluded_Blur_Intensity_;
+    half _Occluded_Blur_Edge_Intensity_;
+    sampler2D _OccludedTex;
+    half4 _OccludedColor;
+    float _GridScale;
+    //bool _Smooth_Edges_;
+    // #if defined(UNITY_UI_CLIP_RECT)
+    float4 _ClipRect;
+    // #if defined(_UI_CLIP_RECT_ROUNDED) || defined(_UI_CLIP_RECT_ROUNDED_INDEPENDENT)
+    float4 _ClipRectRadii;
+
+
+
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        half3 normal : NORMAL;
+        float2 uv0 : TEXCOORD0;
+        float2 uv2 : TEXCOORD2;
+        float2 uv3 : TEXCOORD3;
+        float4 tangent : TANGENT;
+        float4 color : COLOR;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+#ifdef UNITY_UI_CLIP_RECT
+        float3 posLocal : TEXCOORD8;
+#endif
+        half4 normalWorld : TEXCOORD5;
+        float2 uv : TEXCOORD0;
+        float3 posWorld : TEXCOORD7;
+        float4 tangent : TANGENT;
+        float4 binormal : TEXCOORD6;
+        float4 vertexColor : COLOR;
+        float4 extra1 : TEXCOORD4;
+        float4 extra2 : TEXCOORD3;
+        float4 extra3 : TEXCOORD2;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    UNITY_DECLARE_SCREENSPACE_TEXTURE(_blurTexture);
+    UNITY_DECLARE_SCREENSPACE_TEXTURE(_blurTexture2);
+    
+    //BLOCK_BEGIN Round_Rect_Vertex 30
+
+    void Round_Rect_Vertex_B30(
+        float2 UV,
+        float Radius,
+        float Anisotropy,
+        out float2 Rect_UV,
+        out float4 Rect_Parms,
+        out float2 Scale_XY,
+        out float2 Line_UV    )
+    {
+        Scale_XY = float2(Anisotropy,1.0);
+        Line_UV = (UV - float2(0.5,0.5));
+        Rect_UV = Line_UV * Scale_XY;
+        Rect_Parms.xy = Scale_XY*0.5-float2(Radius,Radius);
+        Rect_Parms.z = 0.0;
+        Rect_Parms.w = 0.0;
+        
+    }
+    //BLOCK_END Round_Rect_Vertex
+
+    //BLOCK_BEGIN ScreenPosition 101
+
+    void ScreenPosition_B101(
+        float3 Position,
+        out float3 ScreenPos    )
+    {
+        float4 screenPos = ComputeScreenPos(mul(UNITY_MATRIX_VP, float4(Position, 1)));
+        #if !UNITY_UV_STARTS_AT_TOP
+                screenPos.y = 1.0 - screenPos.y;
+        #endif
+        ScreenPos = float3(screenPos.x,screenPos.y,screenPos.w);
+    }
+    //BLOCK_END ScreenPosition
+
+    //BLOCK_BEGIN Gradient 79
+
+    void Gradient_B79(
+        half4 Gradient_Color,
+        half4 Top_Left,
+        half4 Top_Right,
+        half4 Bottom_Left,
+        half4 Bottom_Right,
+        half2 UV,
+        out half3 Result    )
+    {
+        half3 top = Top_Left.rgb + (Top_Right.rgb - Top_Left.rgb)*UV.x;
+        half3 bottom = Bottom_Left.rgb + (Bottom_Right.rgb - Bottom_Left.rgb)*UV.x;
+        Result = Gradient_Color.rgb * (bottom + (top - bottom)*UV.y);
+        
+    }
+    //BLOCK_END Gradient
+
+    //BLOCK_BEGIN Line_Vertex 35
+
+    void Line_Vertex_B35(
+        float2 Scale_XY,
+        float2 UV,
+        float Time,
+        float Rate,
+        float4 Highlight_Transform,
+        out float4 Line_Vertex    )
+    {
+        float angle2 = (Rate*Time) * 2.0 * 3.1416;
+        float sinAngle2 = sin(angle2);
+        float cosAngle2 = cos(angle2);
+        float2 xformUV = UV * Highlight_Transform.xy + Highlight_Transform.zw;
+        Line_Vertex.x = 0.0;
+        Line_Vertex.y = 0.0;
+        Line_Vertex.z = cosAngle2*xformUV.x-sinAngle2*xformUV.y;
+        Line_Vertex.w = 0.0; //sinAngle2*xformUV.x+cosAngle2*xformUV.y;
+    }
+    //BLOCK_END Line_Vertex
+
+    //BLOCK_BEGIN RelativeOrAbsoluteDetail 45
+
+    void RelativeOrAbsoluteDetail_B45(
+        float Nominal_Radius,
+        float Nominal_LineWidth,
+        bool Absolute_Measurements,
+        float Height,
+        out float Radius,
+        out float Line_Width    )
+    {
+        float scale = Absolute_Measurements ? 1.0/Height : 1.0;
+        Radius = Nominal_Radius * scale;
+        Line_Width = Nominal_LineWidth * scale;
+    }
+    //BLOCK_END RelativeOrAbsoluteDetail
+
+    //BLOCK_BEGIN Edge_AA_Vertex 57
+
+    void Edge_AA_Vertex_B57(
+        float3 Position_World,
+        float3 Normal_Object,
+        float3 Eye,
+        float3 Tangent,
+        out float Gradient1,
+        out float Gradient2    )
+    {
+        float3 I = (Eye-Position_World);
+        float3 T = UnityObjectToWorldNormal(Tangent);
+        float g = (dot(T,I)<=0.0) ? 0.0 : 1.0;
+        if (Normal_Object.z==0) { // edge
+            Gradient1 = Tangent.z>0.0 ? g : 1.0;
+            Gradient2 = Tangent.z>0.0 ? 1.0 : g;
+        } else {
+            Gradient1 = (unity_OrthoParams.w) ? (Tangent.z==0 ? 0 : 1) : g;
+            Gradient2 = 1.0;
+        }
+    }
+    //BLOCK_END Edge_AA_Vertex
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        // Object_To_World_Pos (#28)
+        float3 Pos_World_Q28=(mul(UNITY_MATRIX_M, float4(vertInput.vertex.xyz*float3(float2(1,1).x, float2(1,1).y, 1.0), 1)));
+
+        // Object_To_World_Dir (#31)
+        float3 Nrm_World_Q31;
+        #if defined(_IRIDESCENCE_ENABLE_)
+          Nrm_World_Q31 = normalize((mul((float3x3)UNITY_MATRIX_M, vertInput.normal)));
+          
+        #else
+          Nrm_World_Q31 = float3(0,0,1);
+        #endif
+
+        float3 ScreenPos_Q101;
+        ScreenPosition_B101(Pos_World_Q28,ScreenPos_Q101);
+
+        // To_XY (#26)
+        float X_Q26;
+        float Y_Q26;
+        X_Q26 = vertInput.uv3.x;
+        Y_Q26 = vertInput.uv3.y;
+
+        half3 Result_Q79;
+        #if defined(_EDGE_ONLY_)
+          Gradient_B79(_Gradient_Color_,_Top_Left_,_Top_Right_,_Bottom_Left_,_Bottom_Right_,vertInput.uv0,Result_Q79);
+        #else
+          Result_Q79 = half3(0,0,0);
+        #endif
+
+        // Permutation_To_Bool (#78)
+        bool Bool_Q78;
+        #if defined(_GRADIENT_DISABLED_)
+          Bool_Q78 = true;
+        #else
+          Bool_Q78 = false;
+        #endif
+
+        // Iridescence_View_Origin (#107)
+        float3 Ir_Eye_Q107 = (unity_OrthoParams.w) ? (mul(UNITY_MATRIX_M, float4(float3(0,0,-_Orthographic_Distance_), 1))) : _WorldSpaceCameraPos;
+
+        // To_XY (#23)
+        float X_Q23;
+        float Y_Q23;
+        X_Q23 = vertInput.uv0.x;
+        Y_Q23 = vertInput.uv0.y;
+
+        // To_XYZ (#62)
+        float X_Q62;
+        float Y_Q62;
+        float Z_Q62;
+        X_Q62=vertInput.vertex.xyz.x;
+        Y_Q62=vertInput.vertex.xyz.y;
+        Z_Q62=vertInput.vertex.xyz.z;
+        
+        float Gradient1_Q57;
+        float Gradient2_Q57;
+        #if defined(_SMOOTH_EDGES_)
+          Edge_AA_Vertex_B57(Pos_World_Q28,vertInput.normal,_WorldSpaceCameraPos,vertInput.tangent,Gradient1_Q57,Gradient2_Q57);
+        #else
+          Gradient1_Q57 = 1;
+          Gradient2_Q57 = 1;
+        #endif
+
+        // To_XY (#24)
+        float X_Q24;
+        float Y_Q24;
+        X_Q24 = vertInput.uv2.x;
+        Y_Q24 = vertInput.uv2.y;
+
+        // To_RGBA (#124)
+        float R_Q124;
+        float G_Q124;
+        float B_Q124;
+        float A_Q124;
+        R_Q124=vertInput.color.r; G_Q124=vertInput.color.g; B_Q124=vertInput.color.b; A_Q124=vertInput.color.a;
+
+        // Conditional_Vec3 (#80)
+        float3 Result_Q80 = Bool_Q78 ? float3(0,0,0) : Result_Q79;
+
+        // From_XYZW (#56)
+        float4 Vec4_Q56 = float4(X_Q62, Y_Q62, Gradient1_Q57, Gradient2_Q57);
+
+        // Divide (#18)
+        float Anisotropy_Q18 = X_Q24 / Y_Q24;
+
+        // Multiply (#125)
+        float Product_Q125 = A_Q124 * _Fade_Out_;
+
+        float Radius_Q45;
+        float Line_Width_Q45;
+        RelativeOrAbsoluteDetail_B45(0.0,_Line_Width_,true,Y_Q24,Radius_Q45,Line_Width_Q45);
+
+        float2 Rect_UV_Q30;
+        float4 Rect_Parms_Q30;
+        float2 Scale_XY_Q30;
+        float2 Line_UV_Q30;
+        Round_Rect_Vertex_B30(vertInput.uv0,X_Q26,Anisotropy_Q18,Rect_UV_Q30,Rect_Parms_Q30,Scale_XY_Q30,Line_UV_Q30);
+
+        // From_Rgb_A (#58)
+        float4 Result_Q58;
+        Result_Q58.rgb = Ir_Eye_Q107;
+        Result_Q58.a = Product_Q125;
+
+        // From_XYZW (#22)
+        float4 Vec4_Q22 = float4(X_Q23, Y_Q23, X_Q26, Line_Width_Q45);
+
+        float4 Line_Vertex_Q35;
+        #if defined(_LINE_DISABLED_)
+          Line_Vertex_Q35 = float4(0,0,0,0);
+        #else
+          Line_Vertex_B35(Scale_XY_Q30,Line_UV_Q30,_Time.y,_Rate_,_Highlight_Transform_,Line_Vertex_Q35);
+        #endif
+
+        // Add4 (#29)
+        float4 Sum4_Q29 = Rect_Parms_Q30 + Line_Vertex_Q35;
+
+        float3 Position = Pos_World_Q28;
+        float3 Normal = Nrm_World_Q31;
+        float2 UV = Rect_UV_Q30;
+        float3 Tangent = Result_Q80;
+        float3 Binormal = ScreenPos_Q101;
+        float4 Color = Result_Q58;
+        float4 Extra1 = Sum4_Q29;
+        float4 Extra2 = Vec4_Q22;
+        float4 Extra3 = Vec4_Q56;
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+#ifdef UNITY_UI_CLIP_RECT
+        o.posLocal = vertInput.vertex.xyz;
+#endif
+        o.posWorld = Position;
+        o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
+        o.uv = UV;
+        o.tangent.xyz = Tangent; o.tangent.w=1.0;
+        o.binormal.xyz = Binormal; o.binormal.w=1.0;
+        o.vertexColor = Color;
+        o.extra1=Extra1;
+        o.extra2=Extra2;
+        o.extra3=Extra3;
+
+        return o;
+    }
+
+    ENDCG
+
+    Pass
+    {
+        Name "Default"
+    ZWrite[_ZWrite]
+    ZTest[_ZTest]
+
+        CGPROGRAM
+        #pragma vertex vert
+        #pragma fragment frag
+
+    //BLOCK_BEGIN Smooth_Edges 55
+
+    void Smooth_Edges_B55(
+        half Filter_Width,
+        half4 Rect_Parms,
+        out half Inside_Rect    )
+    {
+        float g = min(Rect_Parms.z,Rect_Parms.w);
+        float dgrad = max(fwidth(g)*Filter_Width,0.001);
+        Inside_Rect = saturate(g/dgrad);
+    }
+    //BLOCK_END Smooth_Edges
+
+    //BLOCK_BEGIN Round_Rect_Fragment 68
+
+    void Round_Rect_Fragment_B68(
+        half Radius,
+        half Line_Width,
+        half Filter_Width,
+        float2 UV,
+        float4 Rect_Parms,
+        out half InLine    )
+    {
+        half d = length(max(abs(UV)-Rect_Parms.xy,0.0));
+        half dx = max(fwidth(d)*Filter_Width,0.001);
+        InLine = saturate((d+dx*0.5-max(Radius-Line_Width,d-dx*0.5))/dx);
+        
+    }
+    //BLOCK_END Round_Rect_Fragment
+
+    //BLOCK_BEGIN Iridescence 89
+
+    void Iridescence_B89(
+        half3 Position,
+        half3 Normal,
+        half2 UV,
+        half3 Eye,
+        half4 Tint,
+        sampler2D Texture,
+        half Frequency,
+        half Vertical_Offset,
+        out half3 Color    )
+    {
+        
+        half3 i = normalize(Position-Eye);
+        half3 r = reflect(i,Normal);
+        half x = dot(i,r);
+        
+        half2 xy;
+        xy.x = frac((x*Frequency+1.0)*0.5 + UV.y*Vertical_Offset);
+        xy.y = 0.5;
+        
+        Color = tex2D(Texture,xy).rgb;
+        Color *= Tint.rgb;
+    }
+    //BLOCK_END Iridescence
+
+    //BLOCK_BEGIN Line_Fragment 34
+
+    void Line_Fragment_B34(
+        half4 Base_Color,
+        half4 Highlight_Color,
+        half Highlight_Width,
+        half4 Line_Vertex,
+        half Highlight,
+        out half4 Line_Color    )
+    {
+        half k2 = 1.0-saturate(abs(Line_Vertex.z/Highlight_Width));
+        Line_Color = lerp(Base_Color,Highlight_Color,float4(Highlight*k2,Highlight*k2,Highlight*k2,Highlight*k2));
+    }
+    //BLOCK_END Line_Fragment
+
+    //BLOCK_BEGIN Gradient 67
+
+    void Gradient_B67(
+        half4 Gradient_Color,
+        half4 Top_Left,
+        half4 Top_Right,
+        half4 Bottom_Left,
+        half4 Bottom_Right,
+        half2 UV,
+        out half3 Gradient    )
+    {
+        half3 top = Top_Left.rgb + (Top_Right.rgb - Top_Left.rgb)*UV.x;
+        half3 bottom = Bottom_Left.rgb + (Bottom_Right.rgb - Bottom_Left.rgb)*UV.x;
+        Gradient = Gradient_Color.rgb * (bottom + (top - bottom)*UV.y);
+    }
+    //BLOCK_END Gradient
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+    #ifdef UNITY_UI_CLIP_RECT
+        clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
+    #endif
+        UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(fragInput);
+        half4 result;
+
+        half Inside_Rect_Q55;
+        #if defined(_SMOOTH_EDGES_)
+          Smooth_Edges_B55(1,fragInput.extra3,Inside_Rect_Q55);
+        #else
+          Inside_Rect_Q55 = 1.0;
+        #endif
+
+        // To_RGBA (#102)
+        float R_Q102;
+        float G_Q102;
+        float B_Q102;
+        float A_Q102;
+        R_Q102=fragInput.vertexColor.r; G_Q102=fragInput.vertexColor.g; B_Q102=fragInput.vertexColor.b; A_Q102=fragInput.vertexColor.a;
+
+        // To_XYZW (#19)
+        float X_Q19;
+        float Y_Q19;
+        float Z_Q19;
+        float W_Q19;
+        X_Q19=fragInput.extra2.x;
+        Y_Q19=fragInput.extra2.y;
+        Z_Q19=fragInput.extra2.z;
+        W_Q19=fragInput.extra2.w;
+
+        half4 Line_Color_Q34;
+        #if defined(_LINE_DISABLED_)
+          Line_Color_Q34 = half4(0,0,0,1);
+        #else
+          Line_Fragment_B34(_Line_Color_,_Highlight_Color_,_Highlight_Width_,fragInput.extra1,_Highlight_,Line_Color_Q34);
+        #endif
+
+        // From_XYZ (#105)
+        float3 Vec3_Q105 = float3(R_Q102,G_Q102,B_Q102);
+
+        // Color_Texture (#38)
+        half Result_Q38;
+        #if defined(_NOISE_ENABLE_)
+          Result_Q38 = 1.0 - _Noise_ * tex2D(_Noise_Texture_, fragInput.uv * _Noise_Frequency_).r;
+        #else
+          Result_Q38 = 1.0;
+        #endif
+
+        // Permutation_To_Bool (#70)
+        bool Bool_Q70;
+        #if defined(_GRADIENT_DISABLED_)
+          Bool_Q70 = true;
+        #else
+          Bool_Q70 = false;
+        #endif
+
+        // From_XY (#20)
+        float2 Vec2_Q20 = float2(X_Q19,Y_Q19);
+
+        // ScreenUV (#64)
+        float2 ScreenUV_Q64;
+        ScreenUV_Q64 = fragInput.binormal.xyz.xy/fragInput.binormal.xyz.z;
+        
+        // Multiply (#103)
+        half Product_Q103 = Inside_Rect_Q55 * A_Q102;
+
+        half InLine_Q68;
+        #if defined(_LINE_DISABLED_)
+          InLine_Q68 = 0.0;
+        #else
+          Round_Rect_Fragment_B68(Z_Q19,W_Q19,_Filter_Width_,fragInput.uv,fragInput.extra1,InLine_Q68);
+        #endif
+
+        half3 Color_Q89;
+        #if defined(_IRIDESCENCE_ENABLE_)
+          Iridescence_B89(fragInput.posWorld,fragInput.normalWorld.xyz,fragInput.uv,Vec3_Q105,_Iridescence_Tint_,_Iridescent_Map_,_Frequency_,_Vertical_Offset_,Color_Q89);
+        #else
+          Color_Q89 = half3(0,0,0);
+        #endif
+
+        // Scale3 (#75)
+        half3 Result_Q75 = _Iridescence_Intensity_ * Color_Q89;
+
+        half3 Gradient_Q67;
+        #if defined(_EDGE_ONLY_)
+          Gradient_Q67 = half3(0,0,0);
+        #else
+          Gradient_B67(_Gradient_Color_,_Top_Left_,_Top_Right_,_Bottom_Left_,_Bottom_Right_,Vec2_Q20,Gradient_Q67);
+        #endif
+
+        // Color_Texture (#42)
+        half4 Color_Q42;
+        half Used_Q42;
+        #if defined(_BLUR_TEXTURE_ENABLE_)
+          Color_Q42 = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_blurTexture, ScreenUV_Q64);
+          Used_Q42 = 1.0;
+        #else
+          Color_Q42 = half4(0,0,0,0);
+          Used_Q42 = 0;
+        #endif
+
+        // Color_Texture (#44)
+        half4 Color_Q44;
+        half Used_Q44;
+        #if defined(_BLUR_TEXTURE_2_ENABLE_)
+          Color_Q44 = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_blurTexture2, ScreenUV_Q64);
+          Used_Q44 = 1.0;
+        #else
+          Color_Q44 = half4(0,0,0,0);
+          Used_Q44 = 0.0;
+        #endif
+
+        // Add_Colors (#76)
+        half3 Interior_Gradient_Q76;
+        half3 Edge_Gradient_Q76;
+        Interior_Gradient_Q76 = Bool_Q70 ? half3(0,0,0) : Gradient_Q67.rgb;
+        Edge_Gradient_Q76 = Bool_Q70 ? half3(0,0,0) : fragInput.tangent.xyz + Gradient_Q67.rgb;
+
+        // Add_Colors (#37)
+        half4 Sum_Q37 = Color_Q42 + Color_Q44;
+
+        // Max (#39)
+        half MaxAB_Q39=max(Used_Q42,Used_Q44);
+
+        // Mix_Colors (#77)
+        half3 Color_At_T_Q77 = Line_Color_Q34.rgb + (Edge_Gradient_Q76-Line_Color_Q34.rgb)*_Line_Gradient_Blend_;
+
+        // Add3 (#71)
+        half3 Sum3_Q71 = Interior_Gradient_Q76 + Result_Q75;
+
+        // Mix_Colors (#88)
+        half3 Color_At_T_Q88 = lerp(_Fallback_Color_.rgb, Sum_Q37.rgb,float4( MaxAB_Q39, MaxAB_Q39, MaxAB_Q39, MaxAB_Q39));
+
+        // Add_Scaled_Color (#74)
+        half3 Sum_Q74 = Color_At_T_Q77 + _Iridescence_Edge_Intensity_ * Color_Q89;
+
+        // Add_Colors (#73)
+        half3 Base_And_Iridescent_Q73 = _Base_Color_.rgb + Sum3_Q71;
+
+        // Scale3 (#87)
+        half3 Result_Q87 = Result_Q38 * Color_At_T_Q88;
+
+        // Scale3 (#86)
+        half3 Result_Q86 = _Blur_Edge_Intensity_ * Result_Q87;
+
+        // Scale3 (#84)
+        half3 Result_Q84 = _Blur_Texture_Intensity_ * Result_Q87;
+
+        // Add3 (#85)
+        half3 Sum3_Q85 = Sum_Q74 + Result_Q86;
+
+        // Add3 (#83)
+        half3 Sum3_Q83 = Base_And_Iridescent_Q73 + Result_Q84;
+
+        // Mix3 (#72)
+        half3 V_T_Q72 = lerp(Sum3_Q83,Sum3_Q85,float3(InLine_Q68,InLine_Q68,InLine_Q68));
+
+        // Set_Alpha (#69)
+        half4 Result_Q69 = half4(V_T_Q72, 1);
+
+        // Scale_Color (#61)
+        half4 Result_Q61 = Product_Q103 * Result_Q69;
+
+        float4 Out_Color = Result_Q61;
+        float Clip_Threshold = 0.001;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+
+    Pass
+    {
+        Name "Occluded"
+        Tags { "LightMode" = "UIOccluded" }
+        ZTest Greater
+
+        CGPROGRAM
+        #pragma vertex vert
+        #pragma fragment secondFragment
+
+        //BLOCK_BEGIN Smooth_Edges 55
+
+        void Smooth_Edges_B55(
+            half Filter_Width,
+            half4 Rect_Parms,
+            out half Inside_Rect        )
+        {
+            float g = min(Rect_Parms.z,Rect_Parms.w);
+            float dgrad = max(fwidth(g)*Filter_Width,0.001);
+            Inside_Rect = saturate(g/dgrad);
+        }
+        //BLOCK_END Smooth_Edges
+
+        //BLOCK_BEGIN Round_Rect_Fragment 68
+
+        void Round_Rect_Fragment_B68(
+            half Radius,
+            half Line_Width,
+            half Filter_Width,
+            float2 UV,
+            float4 Rect_Parms,
+            out half InLine        )
+        {
+            half d = length(max(abs(UV)-Rect_Parms.xy,0.0));
+            half dx = max(fwidth(d)*Filter_Width,0.001);
+            InLine = saturate((d+dx*0.5-max(Radius-Line_Width,d-dx*0.5))/dx);
+            
+        }
+        //BLOCK_END Round_Rect_Fragment
+
+        //BLOCK_BEGIN Iridescence 89
+
+        void Iridescence_B89(
+            half3 Position,
+            half3 Normal,
+            half2 UV,
+            half3 Eye,
+            half4 Tint,
+            sampler2D Texture,
+            half Frequency,
+            half Vertical_Offset,
+            out half3 Color        )
+        {
+            
+            half3 i = normalize(Position-Eye);
+            half3 r = reflect(i,Normal);
+            half x = dot(i,r);
+            
+            half2 xy;
+            xy.x = frac((x*Frequency+1.0)*0.5 + UV.y*Vertical_Offset);
+            xy.y = 0.5;
+            
+            Color = tex2D(Texture,xy).rgb;
+            Color *= Tint.rgb;
+        }
+        //BLOCK_END Iridescence
+
+        //BLOCK_BEGIN Line_Fragment 34
+
+        void Line_Fragment_B34(
+            half4 Base_Color,
+            half4 Highlight_Color,
+            half Highlight_Width,
+            half4 Line_Vertex,
+            half Highlight,
+            out half4 Line_Color        )
+        {
+            half k2 = 1.0-saturate(abs(Line_Vertex.z/Highlight_Width));
+            Line_Color = lerp(Base_Color,Highlight_Color,float4(Highlight*k2,Highlight*k2,Highlight*k2,Highlight*k2));
+        }
+        //BLOCK_END Line_Fragment
+
+        //BLOCK_BEGIN Gradient 67
+
+        void Gradient_B67(
+            half4 Gradient_Color,
+            half4 Top_Left,
+            half4 Top_Right,
+            half4 Bottom_Left,
+            half4 Bottom_Right,
+            half2 UV,
+            out half3 Gradient        )
+        {
+            half3 top = Top_Left.rgb + (Top_Right.rgb - Top_Left.rgb)*UV.x;
+            half3 bottom = Bottom_Left.rgb + (Bottom_Right.rgb - Bottom_Left.rgb)*UV.x;
+            Gradient = Gradient_Color.rgb * (bottom + (top - bottom)*UV.y);
+        }
+        //BLOCK_END Gradient
+
+
+        half4 secondFragment(VertexOutput fragInput) : SV_Target
+        {
+    #ifdef UNITY_UI_CLIP_RECT
+        clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
+    #endif
+        UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(fragInput);
+        half4 result;
+
+        half Inside_Rect_Q55;
+        #if defined(_SMOOTH_EDGES_)
+          Smooth_Edges_B55(1,fragInput.extra3,Inside_Rect_Q55);
+        #else
+          Inside_Rect_Q55 = 1.0;
+        #endif
+
+        // To_RGBA (#102)
+        float R_Q102;
+        float G_Q102;
+        float B_Q102;
+        float A_Q102;
+        R_Q102=fragInput.vertexColor.r; G_Q102=fragInput.vertexColor.g; B_Q102=fragInput.vertexColor.b; A_Q102=fragInput.vertexColor.a;
+
+        // To_XYZW (#19)
+        float X_Q19;
+        float Y_Q19;
+        float Z_Q19;
+        float W_Q19;
+        X_Q19=fragInput.extra2.x;
+        Y_Q19=fragInput.extra2.y;
+        Z_Q19=fragInput.extra2.z;
+        W_Q19=fragInput.extra2.w;
+
+        // To_XYZW (#63)
+        float X_Q63;
+        float Y_Q63;
+        float Z_Q63;
+        float W_Q63;
+        X_Q63=fragInput.extra3.x;
+        Y_Q63=fragInput.extra3.y;
+        Z_Q63=fragInput.extra3.z;
+        W_Q63=fragInput.extra3.w;
+
+        half4 Line_Color_Q34;
+        #if defined(_LINE_DISABLED_)
+          Line_Color_Q34 = half4(0,0,0,1);
+        #else
+          Line_Fragment_B34(_Line_Color_,_Highlight_Color_,_Highlight_Width_,fragInput.extra1,_Highlight_,Line_Color_Q34);
+        #endif
+
+        // From_XYZ (#105)
+        float3 Vec3_Q105 = float3(R_Q102,G_Q102,B_Q102);
+
+        // Permutation_To_Bool (#70)
+        bool Bool_Q70;
+        #if defined(_GRADIENT_DISABLED_)
+          Bool_Q70 = true;
+        #else
+          Bool_Q70 = false;
+        #endif
+
+        // ScreenUV (#64)
+        float2 ScreenUV_Q64;
+        ScreenUV_Q64 = fragInput.binormal.xyz.xy/fragInput.binormal.xyz.z;
+        
+        // From_XY (#20)
+        float2 Vec2_Q20 = float2(X_Q19,Y_Q19);
+
+        // Multiply (#116)
+        half Product_Q116 = Inside_Rect_Q55 * A_Q102;
+
+        half InLine_Q68;
+        #if defined(_LINE_DISABLED_)
+          InLine_Q68 = 0.0;
+        #else
+          Round_Rect_Fragment_B68(Z_Q19,W_Q19,_Filter_Width_,fragInput.uv,fragInput.extra1,InLine_Q68);
+        #endif
+
+        // From_XY (#49)
+        float2 Vec2_Q49 = float2(X_Q63,Y_Q63);
+
+        half3 Color_Q89;
+        #if defined(_IRIDESCENCE_ENABLE_)
+          Iridescence_B89(fragInput.posWorld,fragInput.normalWorld.xyz,fragInput.uv,Vec3_Q105,_Iridescence_Tint_,_Iridescent_Map_,_Frequency_,_Vertical_Offset_,Color_Q89);
+        #else
+          Color_Q89 = half3(0,0,0);
+        #endif
+
+        // Scale3 (#75)
+        half3 Result_Q75 = _Iridescence_Intensity_ * Color_Q89;
+
+        // Color_Texture (#42)
+        half4 Color_Q42;
+        half Used_Q42;
+        #if defined(_BLUR_TEXTURE_ENABLE_)
+          Color_Q42 = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_blurTexture, ScreenUV_Q64);
+          Used_Q42 = 1.0;
+        #else
+          Color_Q42 = half4(0,0,0,0);
+          Used_Q42 = 0;
+        #endif
+
+        // Color_Texture (#44)
+        half4 Color_Q44;
+        half Used_Q44;
+        #if defined(_BLUR_TEXTURE_2_ENABLE_)
+          Color_Q44 = UNITY_SAMPLE_SCREENSPACE_TEXTURE(_blurTexture2, ScreenUV_Q64);
+          Used_Q44 = 1.0;
+        #else
+          Color_Q44 = half4(0,0,0,0);
+          Used_Q44 = 0.0;
+        #endif
+
+        half3 Gradient_Q67;
+        #if defined(_EDGE_ONLY_)
+          Gradient_Q67 = half3(0,0,0);
+        #else
+          Gradient_B67(_Gradient_Color_,_Top_Left_,_Top_Right_,_Bottom_Left_,_Bottom_Right_,Vec2_Q20,Gradient_Q67);
+        #endif
+
+        // Scale2 (#50)
+        float2 Result_Q50 = Vec2_Q49 * _GridScale;
+
+        // Add_Colors (#37)
+        half4 Sum_Q37 = Color_Q42 + Color_Q44;
+
+        // Max (#39)
+        half MaxAB_Q39=max(Used_Q42,Used_Q44);
+
+        // Add_Colors (#76)
+        half3 Interior_Gradient_Q76;
+        half3 Edge_Gradient_Q76;
+        Interior_Gradient_Q76 = Bool_Q70 ? half3(0,0,0) : Gradient_Q67.rgb;
+        Edge_Gradient_Q76 = Bool_Q70 ? half3(0,0,0) : fragInput.tangent.xyz + Gradient_Q67.rgb;
+
+        // Color_Texture (#95)
+        half4 Color_Q95 = tex2D(_OccludedTex,Result_Q50);
+
+        // Mix_Colors (#88)
+        half3 Color_At_T_Q88 = lerp(_Fallback_Color_.rgb, Sum_Q37.rgb,float4( MaxAB_Q39, MaxAB_Q39, MaxAB_Q39, MaxAB_Q39));
+
+        // Add3 (#71)
+        half3 Sum3_Q71 = Interior_Gradient_Q76 + Result_Q75;
+
+        // Mix_Colors (#77)
+        half3 Color_At_T_Q77 = Line_Color_Q34.rgb + (Edge_Gradient_Q76-Line_Color_Q34.rgb)*_Line_Gradient_Blend_;
+
+        // Multiply_Colors (#96)
+        half3 Product_Q96 = _OccludedColor.rgb * Color_Q95.rgb;
+
+        // Add_Colors (#73)
+        half3 Base_And_Iridescent_Q73 = _Base_Color_.rgb + Sum3_Q71;
+
+        // Add_Scaled_Color (#74)
+        half3 Sum_Q74 = Color_At_T_Q77 + _Iridescence_Edge_Intensity_ * Color_Q89;
+
+        // Add_Scaled_Color (#82)
+        half3 Sum_Q82 = Base_And_Iridescent_Q73 + _Occluded_Blur_Intensity_ * Color_At_T_Q88;
+
+        // Add_Scaled_Color (#92)
+        half3 Sum_Q92 = Sum_Q74 + _Occluded_Blur_Edge_Intensity_ * Color_At_T_Q88;
+
+        // Mix3 (#91)
+        half3 V_T_Q91 = lerp(Sum_Q82,Sum_Q92,float3(InLine_Q68,InLine_Q68,InLine_Q68));
+
+        // Scale3 (#97)
+        half3 Result_Q97 = _Occluded_Intensity_ * V_T_Q91;
+
+        // Add3 (#94)
+        half3 Sum3_Q94 = Result_Q97 + Product_Q96;
+
+        // Set_Alpha (#93)
+        half4 Result_Q93 = half4(Sum3_Q94, 1);
+
+        // Scale_Color (#51)
+        half4 Result_Q51 = Product_Q116 * Result_Q93;
+
+        half4 Out_Color = Result_Q51;
+
+
+        result = Out_Color;
+        return result;
+        }
+        ENDCG
+    }
+
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Shaders/CanvasBackplateAcrylicNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Acrylic/Shaders/CanvasBackplateAcrylicNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 8d1af643ad4cfb74080ddd7920824807
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Shaders/MagnifierNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Shaders/MagnifierNonSrp.shader
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Non-SRP/MagnifierNonSrp"
+{
+    Properties
+    {
+        [Toggle(_ROUND_CORNERS)] _RoundCorners("Round Corners", Float) = 1.0
+        _RoundCornerRadius("Round Corner Radius", Float) = 0.05
+        _RoundCornerMargin("Round Corner Margin", Float) = 0.005
+    }
+    SubShader
+    {
+        PackageRequirements
+        {
+            "com.unity.render-pipelines.universal": "12.1.0"
+        }
+
+        Tags
+        {
+            "RenderType" = "Transparent"
+            "Queue" = "Transparent"
+            "DisableBatching" = "True"
+        }
+
+        Pass
+        {
+            ZTest Always
+            Cull Off
+            ZWrite Off
+            Blend SrcAlpha OneMinusSrcAlpha, One One
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #define _URP
+            #define _TRANSPARENT
+            #define _EDGE_SMOOTHING_AUTOMATIC
+
+            #pragma shader_feature_local _ROUND_CORNERS
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Packages/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsCommon.hlsl"
+
+
+                float _RoundCornerRadius;
+                float _RoundCornerMargin;
+
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv0 : TEXCOORD0;
+
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv0 : TEXCOORD0;
+                float3 scale : TEXCOORD3;
+
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            half MagnifierMagnification;
+            float4 MagnifierCenter;
+
+            TEXTURE2D_X(MagnifierTexture);
+            SAMPLER(samplerMagnifierTexture);
+
+            float2 ZoomIn(float2 uv, float zoomAmount, float2 zoomCenter)
+            {
+                return ((uv - zoomCenter) * zoomAmount) + zoomCenter;
+            }
+
+            v2f vert(appdata v)
+            {
+                v2f o = (v2f)0;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                o.vertex = TransformObjectToHClip(v.vertex.xyz);
+                o.uv0 = v.uv0;
+                o.scale = GTGetWorldScale();
+
+                return o;
+            }
+
+            half4 frag(v2f i) : SV_Target
+            {
+                // Rounded corner clipping.
+#if defined(_ROUND_CORNERS)
+                half2 distanceToEdge;
+                distanceToEdge.x = abs(i.uv0.x - 0.5h) * 2.0h;
+                distanceToEdge.y = abs(i.uv0.y - 0.5h) * 2.0h;
+
+                float2 halfScale = i.scale.xy * 0.5;
+                float2 cornerPosition = distanceToEdge * halfScale;
+                float cornerCircleRadius = max(_RoundCornerRadius, GT_MIN_CORNER_VALUE);
+                float2 cornerCircleDistance = halfScale - _RoundCornerMargin - cornerCircleRadius;
+                float roundCornerClip = GTRoundCorners(cornerPosition, cornerCircleDistance, cornerCircleRadius, 0.0);
+#endif // _ROUND_CORNERS
+
+                float2 normalizedScreenSpaceUV = GetNormalizedScreenSpaceUV(i.vertex);
+                float2 normalizedScreenSpaceUVStereo = UnityStereoTransformScreenSpaceTex(normalizedScreenSpaceUV);
+                float2 zoomedUv = ZoomIn(normalizedScreenSpaceUVStereo, MagnifierMagnification, MagnifierCenter.xy);
+
+                half4 output = SAMPLE_TEXTURE2D_X(MagnifierTexture, samplerMagnifierTexture, zoomedUv);
+
+#if defined(_ROUND_CORNERS)
+                output.a = roundCornerClip;
+#endif // _ROUND_CORNERS
+
+                return output;
+            }
+           ENDHLSL
+        }
+    }
+
+    Fallback "Hidden/InternalErrorShader"
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Shaders/MagnifierNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Experimental/Magnifier/Shaders/MagnifierNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 22b4e22877b0c314daa1f4e3c69dfed6
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBackplateNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBackplateNonSrp.shader
@@ -1,0 +1,883 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Canvas/Non-SRP/BackplateNonSrp" {
+
+Properties {
+
+    [Header(Round Rect)]
+        _Base_Color_("Base Color", Color) = (0,0,0,1)
+        [Toggle(_LINE_DISABLED_)] _Line_Disabled_("Line Disabled", Float) = 0
+        _Line_Width_("Line Width", Range(0,10)) = 1
+        _Line_Color_("Line Color", Color) = (0,0,0,1)
+        _Filter_Width_("Filter Width", Range(0,4)) = 1
+     
+    [Header(Line Highlight)]
+        _Rate_("Rate", Range(0,1)) = 0
+        _Highlight_Color_("Highlight Color", Color) = (0.98,0.98,0.98,1)
+        _Highlight_Width_("Highlight Width", Range(0,2)) = 0.25
+        _Highlight_Transform_("Highlight Transform", Vector) = (1, 1, 0, 0)
+        _Highlight_("Highlight", Range(0,1)) = 1
+     
+    [Header(Iridescence)]
+        [Toggle(_IRIDESCENCE_ENABLE_)] _Iridescence_Enable_("Iridescence Enable", Float) = 1
+        _Iridescence_Intensity_("Iridescence Intensity", Range(0,1)) = 0
+        _Iridescence_Edge_Intensity_("Iridescence Edge Intensity", Range(0,1)) = 0.56
+        _Iridescence_Tint_("Iridescence Tint", Color) = (1,1,1,1)
+        [NoScaleOffset] _Iridescent_Map_("Iridescent Map", 2D) = "" {}
+        _Frequency_("Frequency", Range(0,10)) = 1
+        _Vertical_Offset_("Vertical Offset", Range(0,2)) = 0
+        _Orthographic_Distance_("Orthographic Distance", Float) = 400
+     
+    [Header(Gradient)]
+        [Toggle(_GRADIENT_DISABLED_)] _Gradient_Disabled_("Gradient Disabled", Float) = 0
+        _Gradient_Color_("Gradient Color", Color) = (0.631373,0.631373,0.631373,1)
+        _Top_Left_("Top Left", Color) = (1,0.690196,0.976471,1)
+        _Top_Right_("Top Right", Color) = (0.0,0.33,0.88,1)
+        _Bottom_Left_("Bottom Left", Color) = (0.0,0.33,0.88,1)
+        _Bottom_Right_("Bottom Right", Color) = (1,1,1,1)
+        [Toggle(_EDGE_ONLY_)] _Edge_Only_("Edge Only", Float) = 0
+        _Line_Gradient_Blend_("Line Gradient Blend", Range(0,1)) = 0.36
+     
+    [Header(Fade)]
+        _Fade_Out_("Fade Out", Range(0,1)) = 1
+     
+    [Header(Antialiasing)]
+        [Toggle(_SMOOTH_EDGES_)] _Smooth_Edges_("Smooth Edges", Float) = 0
+     
+    [Header(Occlusion)]
+        _Occluded_Intensity_("Occluded Intensity", Range(0,1)) = 1
+        [NoScaleOffset] _OccludedTex("OccludedTex", 2D) = "" {}
+        _OccludedColor("OccludedColor", Color) = (0,0.5,1,1)
+        _GridScale("GridScale", Float) = 0.02
+     
+
+    [Header(Blending)]
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0  // "Zero"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+
+    [Header(Depth)]
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
+
+    [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
+    [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.
+    [HideInInspector] _ClipRectRadii("Clip Rect Radii", Vector) = (10.0, 10.0, 10.0, 10.0) // Added to avoid SRP warnings.
+}
+
+SubShader {
+    Tags{ "RenderType" = "Opaque" }
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+    CGINCLUDE
+
+    #pragma target 4.0
+    #pragma shader_feature_local _ _IRIDESCENCE_ENABLE_
+    #pragma shader_feature_local _ _LINE_DISABLED_
+    #pragma shader_feature_local _ _GRADIENT_DISABLED_
+    #pragma shader_feature_local _ _EDGE_ONLY_
+    #pragma shader_feature_local _ _SMOOTH_EDGES_
+
+    #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
+    #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+    //#pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    half4 _Base_Color_;
+    //bool _Line_Disabled_;
+    float _Line_Width_;
+    half4 _Line_Color_;
+    half _Filter_Width_;
+    float _Rate_;
+    half4 _Highlight_Color_;
+    half _Highlight_Width_;
+    float4 _Highlight_Transform_;
+    half _Highlight_;
+    //bool _Iridescence_Enable_;
+    half _Iridescence_Intensity_;
+    half _Iridescence_Edge_Intensity_;
+    half4 _Iridescence_Tint_;
+    sampler2D _Iridescent_Map_;
+    float _Frequency_;
+    float _Vertical_Offset_;
+    float _Orthographic_Distance_;
+    //bool _Gradient_Disabled_;
+    half4 _Gradient_Color_;
+    half4 _Top_Left_;
+    half4 _Top_Right_;
+    half4 _Bottom_Left_;
+    half4 _Bottom_Right_;
+    //bool _Edge_Only_;
+    half _Line_Gradient_Blend_;
+    float _Fade_Out_;
+    //bool _Smooth_Edges_;
+    half _Occluded_Intensity_;
+    sampler2D _OccludedTex;
+    half4 _OccludedColor;
+    float _GridScale;
+    // #if defined(UNITY_UI_CLIP_RECT)
+    float4 _ClipRect;
+    // #if defined(_UI_CLIP_RECT_ROUNDED) || defined(_UI_CLIP_RECT_ROUNDED_INDEPENDENT)
+    float4 _ClipRectRadii;
+
+
+
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        half3 normal : NORMAL;
+        float2 uv0 : TEXCOORD0;
+        float2 uv2 : TEXCOORD2;
+        float2 uv3 : TEXCOORD3;
+        float4 tangent : TANGENT;
+        float4 color : COLOR;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+#ifdef UNITY_UI_CLIP_RECT
+        float3 posLocal : TEXCOORD8;
+#endif
+        half4 normalWorld : TEXCOORD5;
+        float2 uv : TEXCOORD0;
+        float3 posWorld : TEXCOORD7;
+        float4 tangent : TANGENT;
+        float4 vertexColor : COLOR;
+        float4 extra1 : TEXCOORD4;
+        float4 extra2 : TEXCOORD3;
+        float4 extra3 : TEXCOORD2;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    //BLOCK_BEGIN Round_Rect_Vertex 31
+
+    void Round_Rect_Vertex_B31(
+        float2 UV,
+        float Radius,
+        float Anisotropy,
+        out float2 Rect_UV,
+        out float4 Rect_Parms,
+        out float2 Scale_XY,
+        out float2 Line_UV    )
+    {
+        Scale_XY = float2(Anisotropy,1.0);
+        Line_UV = (UV - float2(0.5,0.5));
+        Rect_UV = Line_UV * Scale_XY;
+        Rect_Parms.xy = Scale_XY*0.5-float2(Radius,Radius);
+        Rect_Parms.z = 0.0;
+        Rect_Parms.w = 0.0;
+        
+    }
+    //BLOCK_END Round_Rect_Vertex
+
+    //BLOCK_BEGIN Gradient 45
+
+    void Gradient_B45(
+        half4 Gradient_Color,
+        half4 Top_Left,
+        half4 Top_Right,
+        half4 Bottom_Left,
+        half4 Bottom_Right,
+        half2 UV,
+        out half3 Result    )
+    {
+        half3 top = Top_Left.rgb + (Top_Right.rgb - Top_Left.rgb)*UV.x;
+        half3 bottom = Bottom_Left.rgb + (Bottom_Right.rgb - Bottom_Left.rgb)*UV.x;
+        Result = Gradient_Color.rgb * (bottom + (top - bottom)*UV.y);
+        
+    }
+    //BLOCK_END Gradient
+
+    //BLOCK_BEGIN Line_Vertex 37
+
+    void Line_Vertex_B37(
+        float2 Scale_XY,
+        float2 UV,
+        float Time,
+        float Rate,
+        float4 Highlight_Transform,
+        out float4 Line_Vertex    )
+    {
+        float angle2 = (Rate*Time) * 2.0 * 3.1416;
+        float sinAngle2 = sin(angle2);
+        float cosAngle2 = cos(angle2);
+        float2 xformUV = UV * Highlight_Transform.xy + Highlight_Transform.zw;
+        Line_Vertex.x = 0.0;
+        Line_Vertex.y = 0.0;
+        Line_Vertex.z = cosAngle2*xformUV.x-sinAngle2*xformUV.y;
+        Line_Vertex.w = 0.0; //sinAngle2*xformUV.x+cosAngle2*xformUV.y;
+    }
+    //BLOCK_END Line_Vertex
+
+    //BLOCK_BEGIN RelativeOrAbsoluteDetail 28
+
+    void RelativeOrAbsoluteDetail_B28(
+        float Nominal_Radius,
+        float Nominal_LineWidth,
+        bool Absolute_Measurements,
+        float Height,
+        out float Radius,
+        out float Line_Width    )
+    {
+        float scale = Absolute_Measurements ? 1.0/Height : 1.0;
+        Radius = Nominal_Radius * scale;
+        Line_Width = Nominal_LineWidth * scale;
+        
+        
+    }
+    //BLOCK_END RelativeOrAbsoluteDetail
+
+    //BLOCK_BEGIN Edge_AA_Vertex 64
+
+    void Edge_AA_Vertex_B64(
+        float3 Position_World,
+        float3 Normal_Object,
+        float3 Eye,
+        float3 Tangent,
+        out float Gradient1,
+        out float Gradient2    )
+    {
+        float3 I = (Eye-Position_World);
+        float3 T = UnityObjectToWorldNormal(Tangent);
+        float g = (dot(T,I)<=0.0) ? 0.0 : 1.0;
+        if (Normal_Object.z==0) { // edge
+            Gradient1 = Tangent.z>0.0 ? g : 1.0;
+            Gradient2 = Tangent.z>0.0 ? 1.0 : g;
+        } else {
+            Gradient1 = (unity_OrthoParams.w) ? (Tangent.z==0 ? 0 : 1) : g;
+            Gradient2 = 1.0;
+        }
+    }
+    //BLOCK_END Edge_AA_Vertex
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        // Object_To_World_Pos (#29)
+        float3 Pos_World_Q29=(mul(UNITY_MATRIX_M, float4(vertInput.vertex.xyz*float3(float2(1,1).x, float2(1,1).y, 1.0), 1)));
+
+        // Object_To_World_Dir (#32)
+        float3 Nrm_World_Q32;
+        #if defined(_IRIDESCENCE_ENABLE_)
+          Nrm_World_Q32 = normalize((mul((float3x3)UNITY_MATRIX_M, vertInput.normal)));
+          
+        #else
+          Nrm_World_Q32 = float3(0,0,1);
+        #endif
+
+        // To_XY (#26)
+        float X_Q26;
+        float Y_Q26;
+        X_Q26 = vertInput.uv3.x;
+        Y_Q26 = vertInput.uv3.y;
+
+        half3 Result_Q45;
+        #if defined(_EDGE_ONLY_)
+          Gradient_B45(_Gradient_Color_,_Top_Left_,_Top_Right_,_Bottom_Left_,_Bottom_Right_,vertInput.uv0,Result_Q45);
+        #else
+          Result_Q45 = half3(0,0,0);
+        #endif
+
+        // Permutation_To_Bool (#47)
+        bool Bool_Q47;
+        #if defined(_GRADIENT_DISABLED_)
+          Bool_Q47 = true;
+        #else
+          Bool_Q47 = false;
+        #endif
+
+        // Iridescence_View_Origin (#84)
+        float3 Ir_Eye_Q84 = (unity_OrthoParams.w) ? (mul(UNITY_MATRIX_M, float4(float3(0,0,-_Orthographic_Distance_), 1))) : _WorldSpaceCameraPos;
+
+        // To_XY (#23)
+        float X_Q23;
+        float Y_Q23;
+        X_Q23 = vertInput.uv0.x;
+        Y_Q23 = vertInput.uv0.y;
+
+        // To_XYZ (#78)
+        float X_Q78;
+        float Y_Q78;
+        float Z_Q78;
+        X_Q78=vertInput.vertex.xyz.x;
+        Y_Q78=vertInput.vertex.xyz.y;
+        Z_Q78=vertInput.vertex.xyz.z;
+        
+        float Gradient1_Q64;
+        float Gradient2_Q64;
+        #if defined(_SMOOTH_EDGES_)
+          Edge_AA_Vertex_B64(Pos_World_Q29,vertInput.normal,_WorldSpaceCameraPos,vertInput.tangent,Gradient1_Q64,Gradient2_Q64);
+        #else
+          Gradient1_Q64 = 1;
+          Gradient2_Q64 = 1;
+        #endif
+
+        // To_XY (#24)
+        float X_Q24;
+        float Y_Q24;
+        X_Q24 = vertInput.uv2.x;
+        Y_Q24 = vertInput.uv2.y;
+
+        // To_RGBA (#100)
+        float R_Q100;
+        float G_Q100;
+        float B_Q100;
+        float A_Q100;
+        R_Q100=vertInput.color.r; G_Q100=vertInput.color.g; B_Q100=vertInput.color.b; A_Q100=vertInput.color.a;
+
+        // Conditional_Vec3 (#48)
+        float3 Result_Q48 = Bool_Q47 ? float3(0,0,0) : Result_Q45;
+
+        // From_XYZW (#59)
+        float4 Vec4_Q59 = float4(X_Q78, Y_Q78, Gradient1_Q64, Gradient2_Q64);
+
+        // Divide (#18)
+        float Anisotropy_Q18 = X_Q24 / Y_Q24;
+
+        // Multiply (#101)
+        float Product_Q101 = A_Q100 * _Fade_Out_;
+
+        float Radius_Q28;
+        float Line_Width_Q28;
+        RelativeOrAbsoluteDetail_B28(0.0,_Line_Width_,true,Y_Q24,Radius_Q28,Line_Width_Q28);
+
+        float2 Rect_UV_Q31;
+        float4 Rect_Parms_Q31;
+        float2 Scale_XY_Q31;
+        float2 Line_UV_Q31;
+        Round_Rect_Vertex_B31(vertInput.uv0,X_Q26,Anisotropy_Q18,Rect_UV_Q31,Rect_Parms_Q31,Scale_XY_Q31,Line_UV_Q31);
+
+        // From_Rgb_A (#85)
+        float4 Result_Q85;
+        Result_Q85.rgb = Ir_Eye_Q84;
+        Result_Q85.a = Product_Q101;
+
+        // From_XYZW (#22)
+        float4 Vec4_Q22 = float4(X_Q23, Y_Q23, X_Q26, Line_Width_Q28);
+
+        float4 Line_Vertex_Q37;
+        #if defined(_LINE_DISABLED_)
+          Line_Vertex_Q37 = float4(0,0,0,0);
+        #else
+          Line_Vertex_B37(Scale_XY_Q31,Line_UV_Q31,_Time.y,_Rate_,_Highlight_Transform_,Line_Vertex_Q37);
+        #endif
+
+        // Add4 (#30)
+        float4 Sum4_Q30 = Rect_Parms_Q31 + Line_Vertex_Q37;
+
+        float3 Position = Pos_World_Q29;
+        float3 Normal = Nrm_World_Q32;
+        float2 UV = Rect_UV_Q31;
+        float3 Tangent = Result_Q48;
+        float3 Binormal = float3(0,0,0);
+        float4 Color = Result_Q85;
+        float4 Extra1 = Sum4_Q30;
+        float4 Extra2 = Vec4_Q22;
+        float4 Extra3 = Vec4_Q59;
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+#ifdef UNITY_UI_CLIP_RECT
+        o.posLocal = vertInput.vertex.xyz;
+#endif
+        o.posWorld = Position;
+        o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
+        o.uv = UV;
+        o.tangent.xyz = Tangent; o.tangent.w=1.0;
+        o.vertexColor = Color;
+        o.extra1=Extra1;
+        o.extra2=Extra2;
+        o.extra3=Extra3;
+
+        return o;
+    }
+
+    ENDCG
+
+    Pass
+    {
+        Name "Default"
+    ZWrite[_ZWrite]
+    ZTest[_ZTest]
+
+        CGPROGRAM
+        #pragma vertex vert
+        #pragma fragment frag
+
+    //BLOCK_BEGIN Smooth_Edges 62
+
+    void Smooth_Edges_B62(
+        half Filter_Width,
+        half4 Rect_Parms,
+        out half Inside_Rect    )
+    {
+        float g = min(Rect_Parms.z,Rect_Parms.w);
+        float dgrad = max(fwidth(g)*Filter_Width,0.001);
+        Inside_Rect = saturate(g/dgrad);
+    }
+    //BLOCK_END Smooth_Edges
+
+    //BLOCK_BEGIN Round_Rect_Fragment 63
+
+    void Round_Rect_Fragment_B63(
+        half Radius,
+        half Line_Width,
+        half Filter_Width,
+        float2 UV,
+        float4 Rect_Parms,
+        out half InLine    )
+    {
+        half d = length(max(abs(UV)-Rect_Parms.xy,0.0));
+        half dx = max(fwidth(d)*Filter_Width,0.001);
+        InLine = saturate((d+dx*0.5-max(Radius-Line_Width,d-dx*0.5))/dx);
+        
+    }
+    //BLOCK_END Round_Rect_Fragment
+
+    //BLOCK_BEGIN Iridescence 77
+
+    void Iridescence_B77(
+        half3 Position,
+        half3 Normal,
+        half2 UV,
+        half3 Eye,
+        half4 Tint,
+        sampler2D Texture,
+        half Frequency,
+        half Vertical_Offset,
+        out half3 Color    )
+    {
+        half3 i = normalize(Position-Eye);
+        half3 r = reflect(i,Normal);
+        half x = dot(i,r);
+        
+        half2 xy;
+        xy.x = frac((x*Frequency+1.0)*0.5 + UV.y*Vertical_Offset);
+        xy.y = 0.5;
+        
+        Color = tex2D(Texture,xy).rgb;
+        Color *= Tint.rgb;
+    }
+    //BLOCK_END Iridescence
+
+    //BLOCK_BEGIN Line_Fragment 36
+
+    void Line_Fragment_B36(
+        half4 Base_Color,
+        half4 Highlight_Color,
+        half Highlight_Width,
+        half4 Line_Vertex,
+        half Highlight,
+        out half4 Line_Color    )
+    {
+        half k2 = 1.0-saturate(abs(Line_Vertex.z/Highlight_Width));
+        Line_Color = lerp(Base_Color,Highlight_Color,float4(Highlight*k2,Highlight*k2,Highlight*k2,Highlight*k2));
+    }
+    //BLOCK_END Line_Fragment
+
+    //BLOCK_BEGIN Gradient 57
+
+    void Gradient_B57(
+        half4 Gradient_Color,
+        half4 Top_Left,
+        half4 Top_Right,
+        half4 Bottom_Left,
+        half4 Bottom_Right,
+        half2 UV,
+        out half3 Gradient    )
+    {
+        half3 top = Top_Left.rgb + (Top_Right.rgb - Top_Left.rgb)*UV.x;
+        half3 bottom = Bottom_Left.rgb + (Bottom_Right.rgb - Bottom_Left.rgb)*UV.x;
+        Gradient = Gradient_Color.rgb * (bottom + (top - bottom)*UV.y);
+    }
+    //BLOCK_END Gradient
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+    #ifdef UNITY_UI_CLIP_RECT
+        clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
+    #endif
+        half4 result;
+
+        half Inside_Rect_Q62;
+        #if defined(_SMOOTH_EDGES_)
+          Smooth_Edges_B62(1,fragInput.extra3,Inside_Rect_Q62);
+        #else
+          Inside_Rect_Q62 = 1.0;
+        #endif
+
+        // To_RGBA (#96)
+        float R_Q96;
+        float G_Q96;
+        float B_Q96;
+        float A_Q96;
+        R_Q96=fragInput.vertexColor.r; G_Q96=fragInput.vertexColor.g; B_Q96=fragInput.vertexColor.b; A_Q96=fragInput.vertexColor.a;
+
+        // To_XYZW (#19)
+        float X_Q19;
+        float Y_Q19;
+        float Z_Q19;
+        float W_Q19;
+        X_Q19=fragInput.extra2.x;
+        Y_Q19=fragInput.extra2.y;
+        Z_Q19=fragInput.extra2.z;
+        W_Q19=fragInput.extra2.w;
+
+        half4 Line_Color_Q36;
+        #if defined(_LINE_DISABLED_)
+          Line_Color_Q36 = half4(0,0,0,1);
+        #else
+          Line_Fragment_B36(_Line_Color_,_Highlight_Color_,_Highlight_Width_,fragInput.extra1,_Highlight_,Line_Color_Q36);
+        #endif
+
+        // From_XYZ (#95)
+        float3 Vec3_Q95 = float3(R_Q96,G_Q96,B_Q96);
+
+        // Permutation_To_Bool (#46)
+        bool Bool_Q46;
+        #if defined(_GRADIENT_DISABLED_)
+          Bool_Q46 = true;
+        #else
+          Bool_Q46 = false;
+        #endif
+
+        // From_XY (#20)
+        float2 Vec2_Q20 = float2(X_Q19,Y_Q19);
+
+        // Multiply (#92)
+        half Product_Q92 = Inside_Rect_Q62 * A_Q96;
+
+        half InLine_Q63;
+        #if defined(_LINE_DISABLED_)
+          InLine_Q63 = 0.0;
+        #else
+          Round_Rect_Fragment_B63(Z_Q19,W_Q19,_Filter_Width_,fragInput.uv,fragInput.extra1,InLine_Q63);
+        #endif
+
+        half3 Color_Q77;
+        #if defined(_IRIDESCENCE_ENABLE_)
+          Iridescence_B77(fragInput.posWorld,fragInput.normalWorld.xyz,fragInput.uv,Vec3_Q95,_Iridescence_Tint_,_Iridescent_Map_,_Frequency_,_Vertical_Offset_,Color_Q77);
+        #else
+          Color_Q77 = half3(0,0,0);
+        #endif
+
+        // Scale3 (#52)
+        half3 Result_Q52 = _Iridescence_Intensity_ * Color_Q77;
+
+        half3 Gradient_Q57;
+        #if defined(_EDGE_ONLY_)
+          Gradient_Q57 = half3(0,0,0);
+        #else
+          Gradient_B57(_Gradient_Color_,_Top_Left_,_Top_Right_,_Bottom_Left_,_Bottom_Right_,Vec2_Q20,Gradient_Q57);
+        #endif
+
+        // Add_Colors (#58)
+        half3 Interior_Gradient_Q58;
+        half3 Edge_Gradient_Q58;
+        Interior_Gradient_Q58 = Bool_Q46 ? half3(0,0,0) : Gradient_Q57.rgb;
+        Edge_Gradient_Q58 = Bool_Q46 ? half3(0,0,0) : fragInput.tangent.xyz + Gradient_Q57.rgb;
+
+        // Mix_Colors (#49)
+        half3 Color_At_T_Q49 = Line_Color_Q36.rgb + (Edge_Gradient_Q58-Line_Color_Q36.rgb)*_Line_Gradient_Blend_;
+
+        // Add3 (#50)
+        half3 Sum3_Q50 = Interior_Gradient_Q58 + Result_Q52;
+
+        // Add_Scaled_Color (#53)
+        half3 Sum_Q53 = Color_At_T_Q49 + _Iridescence_Edge_Intensity_ * Color_Q77;
+
+        // Add_Colors (#51)
+        half3 Base_And_Iridescent_Q51 = _Base_Color_.rgb + Sum3_Q50;
+
+        // Mix3 (#54)
+        half3 V_T_Q54 = lerp(Base_And_Iridescent_Q51,Sum_Q53,float3(InLine_Q63,InLine_Q63,InLine_Q63));
+
+        // Set_Alpha (#55)
+        half4 Result_Q55 = half4(V_T_Q54, 1);
+
+        // Scale_Color (#60)
+        half4 Result_Q60 = Product_Q92 * Result_Q55;
+
+        half4 Out_Color = Result_Q60;
+        half Clip_Threshold = 0.001;
+        bool To_sRGB = false;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+
+    Pass
+    {
+        Name "Occluded"
+        Tags { "LightMode" = "UIOccluded" }
+        ZTest Greater
+
+        CGPROGRAM
+        #pragma vertex vert
+        #pragma fragment secondFragment
+
+        //BLOCK_BEGIN Smooth_Edges 62
+
+        void Smooth_Edges_B62(
+            half Filter_Width,
+            half4 Rect_Parms,
+            out half Inside_Rect        )
+        {
+            float g = min(Rect_Parms.z,Rect_Parms.w);
+            float dgrad = max(fwidth(g)*Filter_Width,0.001);
+            Inside_Rect = saturate(g/dgrad);
+        }
+        //BLOCK_END Smooth_Edges
+
+        //BLOCK_BEGIN Round_Rect_Fragment 63
+
+        void Round_Rect_Fragment_B63(
+            half Radius,
+            half Line_Width,
+            half Filter_Width,
+            float2 UV,
+            float4 Rect_Parms,
+            out half InLine        )
+        {
+            half d = length(max(abs(UV)-Rect_Parms.xy,0.0));
+            half dx = max(fwidth(d)*Filter_Width,0.001);
+            InLine = saturate((d+dx*0.5-max(Radius-Line_Width,d-dx*0.5))/dx);
+            
+        }
+        //BLOCK_END Round_Rect_Fragment
+
+        //BLOCK_BEGIN Iridescence 77
+
+        void Iridescence_B77(
+            half3 Position,
+            half3 Normal,
+            half2 UV,
+            half3 Eye,
+            half4 Tint,
+            sampler2D Texture,
+            half Frequency,
+            half Vertical_Offset,
+            out half3 Color        )
+        {
+            half3 i = normalize(Position-Eye);
+            half3 r = reflect(i,Normal);
+            half x = dot(i,r);
+            
+            half2 xy;
+            xy.x = frac((x*Frequency+1.0)*0.5 + UV.y*Vertical_Offset);
+            xy.y = 0.5;
+            
+            Color = tex2D(Texture,xy).rgb;
+            Color *= Tint.rgb;
+        }
+        //BLOCK_END Iridescence
+
+        //BLOCK_BEGIN Line_Fragment 36
+
+        void Line_Fragment_B36(
+            half4 Base_Color,
+            half4 Highlight_Color,
+            half Highlight_Width,
+            half4 Line_Vertex,
+            half Highlight,
+            out half4 Line_Color        )
+        {
+            half k2 = 1.0-saturate(abs(Line_Vertex.z/Highlight_Width));
+            Line_Color = lerp(Base_Color,Highlight_Color,float4(Highlight*k2,Highlight*k2,Highlight*k2,Highlight*k2));
+        }
+        //BLOCK_END Line_Fragment
+
+        //BLOCK_BEGIN Gradient 57
+
+        void Gradient_B57(
+            half4 Gradient_Color,
+            half4 Top_Left,
+            half4 Top_Right,
+            half4 Bottom_Left,
+            half4 Bottom_Right,
+            half2 UV,
+            out half3 Gradient        )
+        {
+            half3 top = Top_Left.rgb + (Top_Right.rgb - Top_Left.rgb)*UV.x;
+            half3 bottom = Bottom_Left.rgb + (Bottom_Right.rgb - Bottom_Left.rgb)*UV.x;
+            Gradient = Gradient_Color.rgb * (bottom + (top - bottom)*UV.y);
+        }
+        //BLOCK_END Gradient
+
+
+        half4 secondFragment(VertexOutput fragInput) : SV_Target
+        {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+    #ifdef UNITY_UI_CLIP_RECT
+        clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
+    #endif
+        half4 result;
+
+        half Inside_Rect_Q62;
+        #if defined(_SMOOTH_EDGES_)
+          Smooth_Edges_B62(1,fragInput.extra3,Inside_Rect_Q62);
+        #else
+          Inside_Rect_Q62 = 1.0;
+        #endif
+
+        // To_RGBA (#96)
+        float R_Q96;
+        float G_Q96;
+        float B_Q96;
+        float A_Q96;
+        R_Q96=fragInput.vertexColor.r; G_Q96=fragInput.vertexColor.g; B_Q96=fragInput.vertexColor.b; A_Q96=fragInput.vertexColor.a;
+
+        // To_XYZW (#19)
+        float X_Q19;
+        float Y_Q19;
+        float Z_Q19;
+        float W_Q19;
+        X_Q19=fragInput.extra2.x;
+        Y_Q19=fragInput.extra2.y;
+        Z_Q19=fragInput.extra2.z;
+        W_Q19=fragInput.extra2.w;
+
+        half4 Line_Color_Q36;
+        #if defined(_LINE_DISABLED_)
+          Line_Color_Q36 = half4(0,0,0,1);
+        #else
+          Line_Fragment_B36(_Line_Color_,_Highlight_Color_,_Highlight_Width_,fragInput.extra1,_Highlight_,Line_Color_Q36);
+        #endif
+
+        // From_XYZ (#95)
+        float3 Vec3_Q95 = float3(R_Q96,G_Q96,B_Q96);
+
+        // To_XYZW (#66)
+        float X_Q66;
+        float Y_Q66;
+        float Z_Q66;
+        float W_Q66;
+        X_Q66=fragInput.extra3.x;
+        Y_Q66=fragInput.extra3.y;
+        Z_Q66=fragInput.extra3.z;
+        W_Q66=fragInput.extra3.w;
+
+        // Permutation_To_Bool (#46)
+        bool Bool_Q46;
+        #if defined(_GRADIENT_DISABLED_)
+          Bool_Q46 = true;
+        #else
+          Bool_Q46 = false;
+        #endif
+
+        // From_XY (#20)
+        float2 Vec2_Q20 = float2(X_Q19,Y_Q19);
+
+        // Multiply (#98)
+        half Product_Q98 = Inside_Rect_Q62 * A_Q96;
+
+        half InLine_Q63;
+        #if defined(_LINE_DISABLED_)
+          InLine_Q63 = 0.0;
+        #else
+          Round_Rect_Fragment_B63(Z_Q19,W_Q19,_Filter_Width_,fragInput.uv,fragInput.extra1,InLine_Q63);
+        #endif
+
+        half3 Color_Q77;
+        #if defined(_IRIDESCENCE_ENABLE_)
+          Iridescence_B77(fragInput.posWorld,fragInput.normalWorld.xyz,fragInput.uv,Vec3_Q95,_Iridescence_Tint_,_Iridescent_Map_,_Frequency_,_Vertical_Offset_,Color_Q77);
+        #else
+          Color_Q77 = half3(0,0,0);
+        #endif
+
+        // From_XY (#67)
+        float2 Vec2_Q67 = float2(X_Q66,Y_Q66);
+
+        // Scale3 (#52)
+        half3 Result_Q52 = _Iridescence_Intensity_ * Color_Q77;
+
+        half3 Gradient_Q57;
+        #if defined(_EDGE_ONLY_)
+          Gradient_Q57 = half3(0,0,0);
+        #else
+          Gradient_B57(_Gradient_Color_,_Top_Left_,_Top_Right_,_Bottom_Left_,_Bottom_Right_,Vec2_Q20,Gradient_Q57);
+        #endif
+
+        // Scale2 (#73)
+        float2 Result_Q73 = Vec2_Q67 * _GridScale;
+
+        // Add_Colors (#58)
+        half3 Interior_Gradient_Q58;
+        half3 Edge_Gradient_Q58;
+        Interior_Gradient_Q58 = Bool_Q46 ? half3(0,0,0) : Gradient_Q57.rgb;
+        Edge_Gradient_Q58 = Bool_Q46 ? half3(0,0,0) : fragInput.tangent.xyz + Gradient_Q57.rgb;
+
+        // Color_Texture (#69)
+        half4 Color_Q69 = tex2D(_OccludedTex,Result_Q73);
+
+        // Mix_Colors (#49)
+        half3 Color_At_T_Q49 = Line_Color_Q36.rgb + (Edge_Gradient_Q58-Line_Color_Q36.rgb)*_Line_Gradient_Blend_;
+
+        // Add3 (#50)
+        half3 Sum3_Q50 = Interior_Gradient_Q58 + Result_Q52;
+
+        // Multiply_Colors (#72)
+        half3 Product_Q72 = _OccludedColor.rgb * Color_Q69.rgb;
+
+        // Add_Scaled_Color (#53)
+        half3 Sum_Q53 = Color_At_T_Q49 + _Iridescence_Edge_Intensity_ * Color_Q77;
+
+        // Add_Colors (#51)
+        half3 Base_And_Iridescent_Q51 = _Base_Color_.rgb + Sum3_Q50;
+
+        // Mix3 (#54)
+        half3 V_T_Q54 = lerp(Base_And_Iridescent_Q51,Sum_Q53,float3(InLine_Q63,InLine_Q63,InLine_Q63));
+
+        // Scale3 (#79)
+        half3 Result_Q79 = _Occluded_Intensity_ * V_T_Q54;
+
+        // Add3 (#75)
+        half3 Sum3_Q75 = Result_Q79 + Product_Q72;
+
+        // Set_Alpha (#71)
+        half4 Result_Q71 = half4(Sum3_Q75, 1);
+
+        // Scale_Color (#68)
+        half4 Result_Q68 = Product_Q98 * Result_Q71;
+
+        half4 Out_Color = Result_Q68;
+
+
+        result = Out_Color;
+        return result;
+        }
+        ENDCG
+    }
+
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBackplateNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBackplateNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 3b9c3f565dbd02043b54801a7927c501
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBeveledNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBeveledNonSrp.shader
@@ -1,0 +1,561 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Canvas/Non-SRP/BeveledNonSrp" {
+
+Properties {
+
+    [Header(Sun)]
+        _Sun_Intensity_("Sun Intensity", Range(0,2)) = 0.75
+        _Sun_Theta_("Sun Theta", Range(0,1)) = 0.73
+        _Sun_Phi_("Sun Phi", Range(0,1)) = 0.48
+        _Indirect_Diffuse_("Indirect Diffuse", Range(0,1)) = 0.51
+     
+    [Header(Diffuse And Specular)]
+        _Albedo_("Albedo", Color) = (1,1,1,1)
+        _Specular_("Specular", Range(0,5)) = 0
+        _Shininess_("Shininess", Range(0,10)) = 10
+        _Sharpness_("Sharpness", Range(0,1)) = 0
+        _Subsurface_("Subsurface", Range(0,1)) = 0
+     
+    [Header(Reflection)]
+        _Reflection_("Reflection", Range(0,2)) = 0
+        [Toggle(_FRESNEL_DISABLED_)] _Fresnel_Disabled_("Fresnel Disabled", Float) = 0
+        _Front_Reflect_("Front Reflect", Range(0,1)) = 0
+        _Edge_Reflect_("Edge Reflect", Range(0,1)) = 1
+        _Power_("Power", Range(0,10)) = 1
+     
+    [Header(Sky Environment)]
+        [Toggle(_SKY_ENABLED_)] _Sky_Enabled_("Sky Enabled", Float) = 1
+        _Sky_Color_("Sky Color", Color) = (0.866667,0.917647,1,1)
+        _Horizon_Color_("Horizon Color", Color) = (0.843137,0.87451,1,1)
+        _Ground_Color_("Ground Color", Color) = (0.603922,0.611765,0.764706,1)
+        _Horizon_Power_("Horizon Power", Range(0,10)) = 1
+     
+    [Header(Mapped Environment)]
+        [Toggle(_MAPPED_ENVIRONMENT_ENABLED_)] _Mapped_Environment_Enabled_("Mapped Environment Enabled", Float) = 0
+        [NoScaleOffset] _Reflection_Map_("Reflection Map", Cube) = "" {}
+        [NoScaleOffset] _Indirect_Environment_("Indirect Environment", Cube) = "" {}
+     
+    [Header(Decal Texture)]
+        [Toggle(_DECAL_ENABLE_)] _Decal_Enable_("Decal Enable", Float) = 0
+        [NoScaleOffset] _Decal_("Decal", 2D) = "" {}
+        _Decal_Scale_XY_("Decal Scale XY", Vector) = (1.5,1.5,0,0)
+        [Toggle] _Decal_Front_Only_("Decal Front Only", Float) = 1
+     
+    [Header(Iridescence)]
+        [Toggle(_IRIDESCENCE_ENABLED_)] _Iridescence_Enabled_("Iridescence Enabled", Float) = 0
+        _Iridescence_Intensity_("Iridescence Intensity", Range(0,1)) = 0
+        [NoScaleOffset] _Iridescence_Texture_("Iridescence Texture", 2D) = "" {}
+     
+    [Header(Depth)]
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+
+    [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
+    [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.
+    [HideInInspector] _ClipRectRadii("Clip Rect Radii", Vector) = (10.0, 10.0, 10.0, 10.0) // Added to avoid SRP warnings.
+}
+
+SubShader {
+    Tags{ "RenderType" = "Opaque" }
+    Blend Off
+    ZTest[_ZTest]
+    ZWrite[_ZWrite]
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+
+    Pass
+
+    {
+
+    CGPROGRAM
+
+    #pragma vertex vert
+    #pragma fragment frag
+    #pragma target 4.0
+    #pragma shader_feature_local _ _DECAL_ENABLE_
+    #pragma shader_feature_local _ _IRIDESCENCE_ENABLED_
+    #pragma shader_feature_local _ _SKY_ENABLED_
+    #pragma shader_feature_local _ _MAPPED_ENVIRONMENT_ENABLED_
+    #pragma shader_feature_local _ _FRESNEL_DISABLED_
+
+     #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
+     #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+     //#pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    half _Sun_Intensity_;
+    half _Sun_Theta_;
+    half _Sun_Phi_;
+    half _Indirect_Diffuse_;
+    half4 _Albedo_;
+    half _Specular_;
+    half _Shininess_;
+    half _Sharpness_;
+    half _Subsurface_;
+    half _Reflection_;
+    //bool _Fresnel_Disabled_;
+    half _Front_Reflect_;
+    half _Edge_Reflect_;
+    half _Power_;
+    //bool _Sky_Enabled_;
+    half4 _Sky_Color_;
+    half4 _Horizon_Color_;
+    half4 _Ground_Color_;
+    half _Horizon_Power_;
+    //bool _Mapped_Environment_Enabled_;
+    samplerCUBE _Reflection_Map_;
+    samplerCUBE _Indirect_Environment_;
+    //bool _Decal_Enable_;
+    sampler2D _Decal_;
+    float2 _Decal_Scale_XY_;
+    int _Decal_Front_Only_;
+    //bool _Iridescence_Enabled_;
+    float _Iridescence_Intensity_;
+    sampler2D _Iridescence_Texture_;
+    // #if defined(UNITY_UI_CLIP_RECT)
+    float4 _ClipRect;
+    // #if defined(_UI_CLIP_RECT_ROUNDED) || defined(_UI_CLIP_RECT_ROUNDED_INDEPENDENT)
+    float4 _ClipRectRadii;
+
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        half3 normal : NORMAL;
+        float2 uv0 : TEXCOORD0;
+        float2 uv2 : TEXCOORD2;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+#ifdef UNITY_UI_CLIP_RECT
+        float3 posLocal : TEXCOORD8;
+#endif
+        half4 normalWorld : TEXCOORD5;
+        float2 uv : TEXCOORD0;
+        float3 posWorld : TEXCOORD7;
+        float4 tangent : TANGENT;
+        float4 binormal : TEXCOORD6;
+        float4 extra1 : TEXCOORD4;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    //BLOCK_BEGIN Object_To_World_Pos 13
+
+    void Object_To_World_Pos_B13(
+        float3 Pos_Object,
+        out float3 Pos_World    )
+    {
+        Pos_World=(mul(UNITY_MATRIX_M, float4(Pos_Object, 1)));
+        
+    }
+    //BLOCK_END Object_To_World_Pos
+
+    //BLOCK_BEGIN Object_To_World_Normal 24
+
+    void Object_To_World_Normal_B24(
+        float3 Nrm_Object,
+        out float3 Nrm_World    )
+    {
+        Nrm_World=UnityObjectToWorldNormal(Nrm_Object);
+        
+    }
+    //BLOCK_END Object_To_World_Normal
+
+    //BLOCK_BEGIN Object_To_World_Dir 31
+
+    void Object_To_World_Dir_B31(
+        float3 Dir_Object,
+        out float3 Normal_World,
+        out float3 Normal_World_N,
+        out float Normal_Length    )
+    {
+        Normal_World = (mul((float3x3)UNITY_MATRIX_M, Dir_Object));
+        Normal_Length = length(Normal_World);
+        Normal_World_N = Normal_World / Normal_Length;
+    }
+    //BLOCK_END Object_To_World_Dir
+
+    //BLOCK_BEGIN To_XYZ 33
+
+    void To_XYZ_B33(
+        float3 Vec3,
+        out float X,
+        out float Y,
+        out float Z    )
+    {
+        X=Vec3.x;
+        Y=Vec3.y;
+        Z=Vec3.z;
+        
+    }
+    //BLOCK_END To_XYZ
+
+    //BLOCK_BEGIN SunDir 64
+
+    void SunDir_B64(
+        half Sun_Theta,
+        half Sun_Phi,
+        out half LightDirX,
+        out half LightDirY,
+        out half LightDirZ    )
+    {
+        half theta = Sun_Theta * 2.0 * 3.14159;
+        half phi = Sun_Phi * 3.14159;
+        LightDirX = cos(phi)*cos(theta);
+        LightDirY = sin(phi);
+        LightDirZ = cos(phi)*sin(theta);
+    }
+    //BLOCK_END SunDir
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        float3 Pos_World_Q13;
+        Object_To_World_Pos_B13(vertInput.vertex.xyz,Pos_World_Q13);
+
+        float3 Nrm_World_Q24;
+        Object_To_World_Normal_B24(vertInput.normal,Nrm_World_Q24);
+
+        // Tex_Coords (#56)
+        float2 XY_Q56;
+        XY_Q56 = (vertInput.uv0-float2(0.5,0.5))*_Decal_Scale_XY_*float2(vertInput.uv2.x/vertInput.uv2.y,1.0) + float2(0.5,0.5);
+        
+        // Object_To_World_Dir (#22)
+        float3 Tangent_World_Q22;
+        float3 Tangent_World_N_Q22;
+        float Tangent_Length_Q22;
+        Tangent_World_Q22 = (mul((float3x3)UNITY_MATRIX_M, float3(1,0,0)));
+        Tangent_Length_Q22 = length(Tangent_World_Q22);
+        Tangent_World_N_Q22 = Tangent_World_Q22 / Tangent_Length_Q22;
+
+        float3 Normal_World_Q31;
+        float3 Normal_World_N_Q31;
+        float Normal_Length_Q31;
+        Object_To_World_Dir_B31(float3(0,0,1),Normal_World_Q31,Normal_World_N_Q31,Normal_Length_Q31);
+
+        float X_Q33;
+        float Y_Q33;
+        float Z_Q33;
+        To_XYZ_B33(vertInput.vertex.xyz,X_Q33,Y_Q33,Z_Q33);
+
+        half LightDirX_Q64;
+        half LightDirY_Q64;
+        half LightDirZ_Q64;
+        SunDir_B64(_Sun_Theta_,_Sun_Phi_,LightDirX_Q64,LightDirY_Q64,LightDirZ_Q64);
+
+        // Facing (#69)
+        float Facing_Q69 = _Decal_Front_Only_ ? (vertInput.normal.z<0.0 ? 1.0 : 0.0) : 1.0;
+
+        // Subtract3 (#32)
+        float3 Difference_Q32 = float3(0,0,0) - Normal_World_N_Q31;
+
+        // From_RGBA (#26)
+        float4 Out_Color_Q26 = float4(X_Q33, Y_Q33, Z_Q33, 1);
+
+        // From_XYZW (#36)
+        float4 Vec4_Q36 = float4(LightDirX_Q64, LightDirY_Q64, LightDirZ_Q64, Facing_Q69);
+
+        float3 Position = Pos_World_Q13;
+        float3 Normal = Nrm_World_Q24;
+        float2 UV = XY_Q56;
+        float3 Tangent = Tangent_World_N_Q22;
+        float3 Binormal = Difference_Q32;
+        float4 Color = Out_Color_Q26;
+        float4 Extra1 = Vec4_Q36;
+        float4 Extra2 = float4(0,0,0,0);
+        float4 Extra3 = float4(0,0,0,0);
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+#ifdef UNITY_UI_CLIP_RECT
+        o.posLocal = vertInput.vertex.xyz;
+#endif
+        o.posWorld = Position;
+        o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
+        o.uv = UV;
+        o.tangent.xyz = Tangent; o.tangent.w=1.0;
+        o.binormal.xyz = Binormal; o.binormal.w=1.0;
+        o.extra1=Extra1;
+
+        return o;
+    }
+
+    //BLOCK_BEGIN Fragment_Main 68
+
+    void Fragment_Main_B68(
+        half Sun_Intensity,
+        half3 Normal,
+        half4 Albedo,
+        half Transmission,
+        half Fresnel_Reflect,
+        half Shininess,
+        half3 Incident,
+        half Indirect_Diffuse,
+        half Specular,
+        half Reflection,
+        half4 Reflection_Sample,
+        half4 Indirect_Sample,
+        half Sharpness,
+        half SSS,
+        half Subsurface,
+        half4 Iridescence,
+        half3 LightDir,
+        out half4 Result    )
+    {
+        half NdotL = max(dot(LightDir,Normal),0.0);
+        half3 R = reflect(Incident,Normal);
+        half RdotL = max(0.0,dot(R,LightDir));
+        half specular = pow(RdotL,Shininess);
+        specular = lerp(specular,smoothstep(0.495*Sharpness,1.0-0.495*Sharpness,specular),Sharpness);
+        Result = ((Sun_Intensity*NdotL + Indirect_Sample * Indirect_Diffuse)*(1.0 + SSS * Subsurface)) * Albedo * Transmission + (Sun_Intensity*specular*Specular + Fresnel_Reflect * Reflection*Reflection_Sample) + Iridescence;
+    }
+    //BLOCK_END Fragment_Main
+
+    //BLOCK_BEGIN Fast_Fresnel 66
+
+    void Fast_Fresnel_B66(
+        half Front_Reflect,
+        half Edge_Reflect,
+        half Power,
+        half3 Normal,
+        half3 Incident,
+        out half Transmit,
+        out half Reflect    )
+    {
+        half d = max(-dot(Incident,Normal),0);
+        Reflect = Front_Reflect+(Edge_Reflect-Front_Reflect)*pow(1-d,Power);
+        Transmit=1-Reflect;
+    }
+    //BLOCK_END Fast_Fresnel
+
+    //BLOCK_BEGIN SSS 41
+
+    void SSS_B41(
+        half3 ButtonN,
+        half3 Normal,
+        half3 Incident,
+        out half Result    )
+    {
+        half NdotI = abs(dot(Normal,Incident));
+        half BdotI = abs(dot(ButtonN,Incident));
+        Result = (abs(NdotI-BdotI));
+    }
+    //BLOCK_END SSS
+
+    //BLOCK_BEGIN Scale_Color 45
+
+    void Scale_Color_B45(
+        half4 Color,
+        half Scalar,
+        out half4 Result    )
+    {
+        Result = Scalar * Color;
+    }
+    //BLOCK_END Scale_Color
+
+    //BLOCK_BEGIN Sky_Environment 54
+
+    half4 SampleEnv_Bid54(half3 D, half4 S, half4 H, half4 G, half exponent)
+    {
+        half k = pow(abs(D.y),exponent);
+        half4 C;
+        if (D.y>0.0) {
+            C=lerp(H,S,float4(k,k,k,k));
+        } else {
+            C=lerp(H,G,float4(k,k,k,k));    
+        }
+        return C;
+    }
+    
+    void Sky_Environment_B54(
+        half3 Normal,
+        half3 Reflected,
+        half4 Sky_Color,
+        half4 Horizon_Color,
+        half4 Ground_Color,
+        half Horizon_Power,
+        out half4 Reflected_Color,
+        out half4 Indirect_Color    )
+    {
+        // main code goes here
+        Reflected_Color = SampleEnv_Bid54(Reflected,Sky_Color,Horizon_Color,Ground_Color,Horizon_Power);
+        Indirect_Color = lerp(Ground_Color,Sky_Color,float4(Normal.y*0.5+0.5,Normal.y*0.5+0.5,Normal.y*0.5+0.5,Normal.y*0.5+0.5));
+        
+    }
+    //BLOCK_END Sky_Environment
+
+    //BLOCK_BEGIN Remap_Range 50
+
+    void Remap_Range_B50(
+        half In_Min,
+        half In_Max,
+        half Out_Min,
+        half Out_Max,
+        half In,
+        out half Out    )
+    {
+        Out = lerp(Out_Min,Out_Max,clamp((In-In_Min)/(In_Max-In_Min),0,1));
+        
+    }
+    //BLOCK_END Remap_Range
+
+    //BLOCK_BEGIN Code 51
+
+    void Code_B51(
+        half X,
+        out half Result    )
+    {
+        Result = (acos(X)/3.14159-0.5)*2;
+    }
+    //BLOCK_END Code
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+#if defined(UNITY_UI_CLIP_RECT)
+        clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
+#endif
+        half4 result;
+
+        // Normalize3 (#62)
+        half3 Normalized_Q62 = normalize(fragInput.normalWorld.xyz);
+
+        // Incident3 (#61)
+        half3 Incident_Q61 = normalize(fragInput.posWorld - _WorldSpaceCameraPos);
+
+        half Result_Q41;
+        SSS_B41(fragInput.binormal.xyz,Normalized_Q62,Incident_Q61,Result_Q41);
+
+        // To_XYZW (#44)
+        half X_Q44;
+        half Y_Q44;
+        half Z_Q44;
+        half W_Q44;
+        X_Q44=fragInput.extra1.x;
+        Y_Q44=fragInput.extra1.y;
+        Z_Q44=fragInput.extra1.z;
+        W_Q44=fragInput.extra1.w;
+
+        // Color_Texture (#42)
+        half4 Color_Q42;
+        #if defined(_DECAL_ENABLE_)
+          Color_Q42 = tex2D(_Decal_,fragInput.uv);
+        #else
+          Color_Q42 = half4(0,0,0,0);
+        #endif
+
+        // Reflect (#60)
+        half3 Reflected_Q60 = reflect(Incident_Q61, Normalized_Q62);
+
+        // Normalize3 (#53)
+        half3 Normalized_Q53 = normalize(fragInput.tangent.xyz);
+
+        half Transmit_Q66;
+        half Reflect_Q66;
+        #if defined(_FRESNEL_DISABLED_)
+          Transmit_Q66 = 1.0;
+          Reflect_Q66 = 1.0;
+        #else
+          Fast_Fresnel_B66(_Front_Reflect_,_Edge_Reflect_,_Power_,Normalized_Q62,Incident_Q61,Transmit_Q66,Reflect_Q66);
+        #endif
+
+        // From_XYZ (#63)
+        half3 Vec3_Q63 = float3(X_Q44,Y_Q44,Z_Q44);
+
+        half4 Result_Q45;
+        Scale_Color_B45(Color_Q42,W_Q44,Result_Q45);
+
+        // Mapped_Environment (#58)
+        half4 Reflected_Color_Q58;
+        half4 Indirect_Diffuse_Q58;
+        #if defined(_MAPPED_ENVIRONMENT_ENABLED_)
+          Reflected_Color_Q58 = texCUBE(_Reflection_Map_,Reflected_Q60);
+          Indirect_Diffuse_Q58 = texCUBE(_Indirect_Environment_,Reflected_Q60);
+        #else
+          Reflected_Color_Q58 = half4(0,0,0,1);
+          Indirect_Diffuse_Q58 = half4(0,0,0,1);
+        #endif
+
+        half4 Reflected_Color_Q54;
+        half4 Indirect_Color_Q54;
+        #if defined(_SKY_ENABLED_)
+          Sky_Environment_B54(Normalized_Q62,Reflected_Q60,_Sky_Color_,_Horizon_Color_,_Ground_Color_,_Horizon_Power_,Reflected_Color_Q54,Indirect_Color_Q54);
+        #else
+          Reflected_Color_Q54 = half4(0,0,0,1);
+          Indirect_Color_Q54 = half4(0,0,0,1);
+        #endif
+
+        // DotProduct3 (#52)
+        half Dot_Q52 = dot(Incident_Q61, Normalized_Q53);
+
+        // Blend_Over (#46)
+        half4 Result_Q46 = Result_Q45 + (1.0 - Result_Q45.a) * _Albedo_;
+
+        // Add_Colors (#29)
+        half4 Sum_Q29 = Reflected_Color_Q58 + Reflected_Color_Q54;
+
+        // Add_Colors (#30)
+        half4 Sum_Q30 = Indirect_Diffuse_Q58 + Indirect_Color_Q54;
+
+        half Result_Q51;
+        Code_B51(Dot_Q52,Result_Q51);
+
+        half Out_Q50;
+        Remap_Range_B50(-1,1,0,1,Result_Q51,Out_Q50);
+
+        // From_XY (#49)
+        half2 Vec2_Q49 = float2(Out_Q50,0.5);
+
+        // Color_Texture (#48)
+        half4 Color_Q48;
+        #if defined(_IRIDESCENCE_ENABLED_)
+          Color_Q48 = tex2D(_Iridescence_Texture_,Vec2_Q49);
+        #else
+          Color_Q48 = half4(0,0,0,0);
+        #endif
+
+        // Scale_Color (#47)
+        half4 Result_Q47 = _Iridescence_Intensity_ * Color_Q48;
+
+        half4 Result_Q68;
+        Fragment_Main_B68(_Sun_Intensity_,Normalized_Q62,Result_Q46,Transmit_Q66,Reflect_Q66,_Shininess_,Incident_Q61,_Indirect_Diffuse_,_Specular_,_Reflection_,Sum_Q29,Sum_Q30,_Sharpness_,Result_Q41,_Subsurface_,Result_Q47,Vec3_Q63,Result_Q68);
+
+        // Set_Alpha (#57)
+        half4 Result_Q57 = Result_Q68; Result_Q57.a = 1;
+
+        float4 Out_Color = Result_Q57;
+        float Clip_Threshold = 0.001;
+        bool To_sRGB = false;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBeveledNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasBeveledNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d605c9af20fc450459b3b8d6577056a7
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasFrontplateNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasFrontplateNonSrp.shader
@@ -1,0 +1,786 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Canvas/Non-SRP/FrontplateNonSrp" {
+
+Properties {
+
+    [Header(Round Rect)]
+        _Radius_("Radius", Float) = 0.3125
+        _Line_Width_("Line Width", Float) = .031
+        [Toggle] _Relative_To_Height_("Relative To Height", Float) = 1
+        _Fixed_Unit_Multiplier_("Fixed Unit Multiplier", Float) = 1000
+        _Filter_Width_("Filter Width", Range(0,4)) = 1.5
+        _Edge_Color_("Edge Color", Color) = (0.53,0.53,0.53,1)
+     
+    [Header(Fade)]
+        _Fade_Out_("Fade Out", Range(0,1)) = 1
+     
+    [Header(Blob)]
+        [Toggle(_BLOB_ENABLE_)] _Blob_Enable_("Blob Enable", Float) = 0
+        _Blob_Position_("Blob Position", Vector) = (.5, 0, 0.2, 1)
+        _Blob_Intensity_("Blob Intensity", Range(0,3)) = 0.34
+        _Blob_Near_Size_("Blob Near Size", Range(0,1)) = 0.025
+        _Blob_Far_Size_("Blob Far Size", Range(0,1)) = 0.05
+        _Blob_Near_Distance_("Blob Near Distance", Range(0,1)) = 0
+        _Blob_Far_Distance_("Blob Far Distance", Range(0,1)) = 0.08
+        _Blob_Fade_Length_("Blob Fade Length", Range(0,1)) = 0.08
+        _Blob_Inner_Fade_("Blob Inner Fade", Range(0.001,1)) = 0.01
+        _Blob_Pulse_("Blob Pulse", Range(0,1)) = 0
+        _Blob_Fade_("Blob Fade", Range(0,1)) = 1
+        _Blob_Pulse_Max_Size_("Blob Pulse Max Size", Range(0,1)) = 0.05
+     
+    [Header(Blob 2)]
+        [Toggle(_BLOB_ENABLE_2_)] _Blob_Enable_2_("Blob Enable 2", Float) = 0
+        _Blob_Position_2_("Blob Position 2", Vector) = (0, 0, 0, 1)
+        _Blob_Near_Size_2_("Blob Near Size 2", Range(0,1)) = 0.025
+        _Blob_Inner_Fade_2_("Blob Inner Fade 2", Range(0,1)) = 0.1
+        _Blob_Pulse_2_("Blob Pulse 2", Range(0,1)) = 0
+        _Blob_Fade_2_("Blob Fade 2", Range(0,1)) = 1
+     
+    [Header(Gaze)]
+        _Gaze_Intensity_("Gaze Intensity", Range(0,1)) = 0.7
+        _Gaze_Focus_("Gaze Focus", Range(0,1)) = 0
+        [PerRendererData] _Pinched_("Pinched",Float) = 0.0
+     
+    [Header(Blob Texture)]
+        [NoScaleOffset] _Blob_Texture_("Blob Texture", 2D) = "" {}
+     
+    [Header(Selection)]
+        _Selection_Fuzz_("Selection Fuzz", Range(0,1)) = 0.5
+        _Selected_("Selected", Range(0,1)) = 0
+        _Selection_Fade_("Selection Fade", Range(0,1)) = 0
+        _Selection_Fade_Size_("Selection Fade Size", Range(0,1)) = 0.3
+        _Selected_Distance_("Selected Distance", Range(0,1)) = 0.08
+        _Selected_Fade_Length_("Selected Fade Length", Range(0,1)) = 0.08
+     
+    [Header(Proximity)]
+        _Proximity_Max_Intensity_("Proximity Max Intensity", Range(0,1)) = 0.45
+        _Proximity_Far_Distance_("Proximity Far Distance", Range(0,2)) = 0.16
+        _Proximity_Near_Radius_("Proximity Near Radius", Range(0,2)) = .03
+        _Proximity_Anisotropy_("Proximity Anisotropy", Range(0,1)) = 1
+     
+    [Header(Global)]
+        [Toggle] _Use_Global_Left_Index_("Use Global Left Index", Float) = 1
+        [Toggle] _Use_Global_Right_Index_("Use Global Right Index", Float) = 1
+     
+
+    [Header(Blending)]
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 1  // "One"
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+
+    [Header(Depth)]
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 0 // "Off"
+
+    [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
+    [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.
+    [HideInInspector] _ClipRectRadii("Clip Rect Radii", Vector) = (10.0, 10.0, 10.0, 10.0) // Added to avoid SRP warnings.
+}
+
+SubShader {
+    Tags { "RenderType" = "Transparent" "Queue" = "Transparent" }
+    Blend[_SrcBlend][_DstBlend]
+    Cull Off
+    ZWrite[_ZWrite]
+    ZTest[_ZTest]
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+
+    Pass
+
+    {
+
+    CGPROGRAM
+
+    #pragma vertex vert
+    #pragma fragment frag
+    #pragma target 4.0
+    #pragma shader_feature_local _ _BLOB_ENABLE_
+    #pragma shader_feature_local _ _BLOB_ENABLE_2_
+    #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
+    #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+    //#pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    float _Radius_;
+    float _Line_Width_;
+    int _Relative_To_Height_;
+    float _Fixed_Unit_Multiplier_;
+    float _Filter_Width_;
+    half4 _Edge_Color_;
+    half _Fade_Out_;
+    //bool _Blob_Enable_;
+    float3 _Blob_Position_;
+    float _Blob_Intensity_;
+    float _Blob_Near_Size_;
+    float _Blob_Far_Size_;
+    float _Blob_Near_Distance_;
+    float _Blob_Far_Distance_;
+    float _Blob_Fade_Length_;
+    float _Blob_Inner_Fade_;
+    float _Blob_Pulse_;
+    float _Blob_Fade_;
+    float _Blob_Pulse_Max_Size_;
+    //bool _Blob_Enable_2_;
+    float3 _Blob_Position_2_;
+    float _Blob_Near_Size_2_;
+    float _Blob_Inner_Fade_2_;
+    float _Blob_Pulse_2_;
+    float _Blob_Fade_2_;
+    float _Gaze_Intensity_;
+    float _Gaze_Focus_;
+    float _Pinched_;
+    sampler2D _Blob_Texture_;
+    float _Selection_Fuzz_;
+    float _Selected_;
+    float _Selection_Fade_;
+    float _Selection_Fade_Size_;
+    float _Selected_Distance_;
+    float _Selected_Fade_Length_;
+    half _Proximity_Max_Intensity_;
+    float _Proximity_Far_Distance_;
+    half _Proximity_Near_Radius_;
+    float _Proximity_Anisotropy_;
+    int _Use_Global_Left_Index_;
+    int _Use_Global_Right_Index_;
+    // #if defined(UNITY_UI_CLIP_RECT)
+    float4 _ClipRect;
+    // #if defined(_UI_CLIP_RECT_ROUNDED) || defined(_UI_CLIP_RECT_ROUNDED_INDEPENDENT)
+    float4 _ClipRectRadii;
+
+
+
+    float4 Global_Left_Index_Tip_Position;
+    float4 Global_Right_Index_Tip_Position;
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        half3 normal : NORMAL;
+        float2 uv0 : TEXCOORD0;
+        float2 uv2 : TEXCOORD2;
+        float4 tangent : TANGENT;
+        float4 color : COLOR;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+        float3 posWorld : TEXCOORD7;
+#ifdef UNITY_UI_CLIP_RECT
+        float3 posLocal : TEXCOORD8;
+#endif
+        half4 normalWorld : TEXCOORD5;
+        float2 uv : TEXCOORD0;
+        float4 tangent : TANGENT;
+        float4 binormal : TEXCOORD6;
+        float4 vertexColor : COLOR;
+        float4 extra1 : TEXCOORD4;
+        float4 extra2 : TEXCOORD3;
+        float4 extra3 : TEXCOORD2;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    //BLOCK_BEGIN Blob_Vertex 280
+
+    void Blob_Vertex_B280(
+        float3 Position,
+        float3 Normal,
+        float3 Tangent,
+        float3 Bitangent,
+        float3 Blob_Position,
+        float Intensity,
+        float Blob_Near_Size,
+        float Blob_Far_Size,
+        float Blob_Near_Distance,
+        float Blob_Far_Distance,
+        float2 UV,
+        float3 Face_Center,
+        float2 Face_Size,
+        float Blob_Fade_Length,
+        float Selection_Fade,
+        float Selection_Fade_Size,
+        float Inner_Fade,
+        float Blob_Pulse,
+        float Blob_Fade,
+        out float2 Out_UV,
+        out float3 Blob_Info    )
+    {
+        
+        float blobSize, fadeIn;
+        float3 Hit_Position;
+        Blob_Info = float3(0.0,0.0,0.0);
+        
+        float3 delta = Blob_Position - Face_Center;
+        float Hit_Distance = dot(delta, Normal);
+        Hit_Position = Blob_Position - Hit_Distance * Normal;
+        
+        float absD = abs(Hit_Distance);
+        float lerpVal = clamp((absD-Blob_Near_Distance)/(Blob_Far_Distance-Blob_Near_Distance),0.0,1.0);
+        fadeIn = 1.0-clamp((absD-Blob_Far_Distance)/Blob_Fade_Length,0.0,1.0);
+        
+        float innerFade = 1.0-clamp(-Hit_Distance/Inner_Fade,0.0,1.0);
+        
+        //compute blob size
+        float farClip = saturate(1.0-step(Blob_Far_Distance+Blob_Fade_Length,absD));
+        float size = lerp(Blob_Near_Size,Blob_Far_Size,lerpVal)*farClip;
+        blobSize = lerp(size,Selection_Fade_Size,Selection_Fade)*innerFade;
+        Blob_Info.x = lerpVal*0.5+0.5;
+            
+        Blob_Info.y = fadeIn*Intensity*(1.0-Selection_Fade)*Blob_Fade;
+        Blob_Info.x *= (1.0-Blob_Pulse);
+        
+        //compute blob position
+        float2 blobCenterXY = float2(dot(delta,Tangent),dot(delta,Bitangent));
+        
+        Out_UV = ((float2(UV.x-0.5,0.5-UV.y))*Face_Size-blobCenterXY)/max(blobSize,0.0001)*2.0;
+        
+    }
+    //BLOCK_END Blob_Vertex
+
+    //BLOCK_BEGIN Round_Rect_Vertex 278
+
+    void Round_Rect_Vertex_B278(
+        float2 UV,
+        float Radius,
+        float Anisotropy,
+        out float4 Rect_Parms    )
+    {
+        float2 Scale_XY = float2(Anisotropy,1.0);
+        Rect_Parms.xy = Scale_XY*0.5-float2(Radius,Radius);
+        Rect_Parms.zw = (UV - float2(0.5,0.5)) * Scale_XY;
+    }
+    //BLOCK_END Round_Rect_Vertex
+
+    //BLOCK_BEGIN Proximity_Vertex 296
+
+    float2 ProjectProximity(
+        float3 blobPosition,
+        float3 position,
+        float3 dir,
+        float3 xdir,
+        float3 ydir,
+        out float vdistance
+    )
+    {
+        float3 delta = blobPosition - position;
+        float2 xy = float2(dot(delta,xdir),dot(delta,ydir));
+        vdistance = abs(dot(delta,dir));
+        return xy;
+    }
+    
+    void Proximity_Vertex_B296(
+        float3 Blob_Position,
+        float3 Blob_Position_2,
+        float3 Position,
+        float Proximity_Far_Distance,
+        float Relative_Scale,
+        float Proximity_Anisotropy,
+        float3 Normal,
+        float3 Tangent,
+        float3 Binormal,
+        float Blob_Enable,
+        float Blob_Enable_2,
+        out float4 Extra,
+        out float Distance_Fade1,
+        out float Distance_Fade2    )
+    {
+        float distz1,distz2;
+        Extra.xy = ProjectProximity(Blob_Position,Position,Normal,Tangent*Proximity_Anisotropy,Binormal,distz1)/Relative_Scale;
+        Extra.zw = ProjectProximity(Blob_Position_2,Position,Normal,Tangent*Proximity_Anisotropy,Binormal,distz2)/Relative_Scale;
+        
+        Distance_Fade1 = (1.0 - saturate(distz1/Proximity_Far_Distance))*Blob_Enable;
+        Distance_Fade2 = (1.0 - saturate(distz2/Proximity_Far_Distance))*Blob_Enable_2;
+        
+    }
+    //BLOCK_END Proximity_Vertex
+
+    //BLOCK_BEGIN Blob_Vertex 286
+
+    void Blob_Vertex_B286(
+        float3 Position,
+        float3 Normal,
+        float3 Tangent,
+        float3 Bitangent,
+        float3 Blob_Position,
+        float Intensity,
+        float Blob_Near_Size,
+        float Blob_Far_Size,
+        float Blob_Near_Distance,
+        float Blob_Far_Distance,
+        float2 UV,
+        float3 Face_Center,
+        float2 Face_Size,
+        float Blob_Fade_Length,
+        float Selection_Fade,
+        float Selection_Fade_Size,
+        float Inner_Fade,
+        float Blob_Pulse,
+        float Blob_Fade,
+        out float4 Blob_Info    )
+    {
+        
+        float blobSize, fadeIn;
+        float3 Hit_Position;
+        
+        float3 delta = Blob_Position - Face_Center;
+        float Hit_Distance = dot(delta, Normal);
+        Hit_Position = Blob_Position - Hit_Distance * Normal;
+        
+        float absD = abs(Hit_Distance);
+        float lerpVal = clamp((absD-Blob_Near_Distance)/(Blob_Far_Distance-Blob_Near_Distance),0.0,1.0);
+        fadeIn = 1.0-clamp((absD-Blob_Far_Distance)/Blob_Fade_Length,0.0,1.0);
+        
+        float innerFade = 1.0-clamp(-Hit_Distance/Inner_Fade,0.0,1.0);
+        
+        //compute blob size
+        float farClip = saturate(1.0-step(Blob_Far_Distance+Blob_Fade_Length,absD));
+        float size = lerp(Blob_Near_Size,Blob_Far_Size,lerpVal)*farClip;
+        blobSize = lerp(size,Selection_Fade_Size,Selection_Fade)*innerFade;
+        Blob_Info.x = lerpVal*0.5+0.5;
+            
+        Blob_Info.y = fadeIn*Intensity*(1.0-Selection_Fade)*Blob_Fade;
+        Blob_Info.x *= (1.0-Blob_Pulse);
+        
+        //compute blob position
+        float2 blobCenterXY = float2(dot(delta,Tangent),dot(delta,Bitangent));
+        
+        Blob_Info.zw = ((float2(UV.x-0.5,0.5-UV.y))*Face_Size-blobCenterXY)/max(blobSize,0.0001)*2.0;
+        
+    }
+    //BLOCK_END Blob_Vertex
+
+    //BLOCK_BEGIN Proximity_Visibility 269
+
+    void Proximity_Visibility_B269(
+        float Selection,
+        float3 Proximity_Center,
+        float3 Proximity_Center_2,
+        float Proximity_Far_Distance,
+        float Proximity_Radius,
+        float3 Face_Center,
+        float3 Normal,
+        float2 Face_Size,
+        float Gaze,
+        out float Width    )
+    {
+        //make all edges invisible if no proximity or selection visible
+        float boxMaxSize = length(Face_Size)*0.5;
+        
+        float d1 = dot(Proximity_Center-Face_Center, Normal);
+        float3 blob1 = Proximity_Center - d1 * Normal;
+        
+        float d2 = dot(Proximity_Center_2-Face_Center, Normal);
+        float3 blob2 = Proximity_Center_2 - d2 * Normal;
+        
+        //float3 objectOriginInWorld = (mul(UNITY_MATRIX_M, float4(float3(0.0,0.0,0.0), 1)));
+        float3 delta1 = blob1 - Face_Center;
+        float3 delta2 = blob2 - Face_Center;
+        
+        float dist1 = dot(delta1,delta1);
+        float dist2 = dot(delta2,delta2);
+        
+        float nearestProxDist = sqrt(min(dist1,dist2));
+        
+        Width = (1.0 - step(boxMaxSize+Proximity_Radius,nearestProxDist))*(1.0-step(Proximity_Far_Distance,min(d1,d2))*(1.0-step(0.0001,Selection)));
+        Width = max(Gaze, Width);
+    }
+    //BLOCK_END Proximity_Visibility
+
+    //BLOCK_BEGIN Permutation_To_FloatBool 290
+
+    void Permutation_To_FloatBool_B290(
+        out float Enabled    )
+    {
+        Enabled = 1.0;
+    }
+    //BLOCK_END Permutation_To_FloatBool
+
+    //BLOCK_BEGIN Selection_Vertex 297
+
+    float2 ramp2(float2 start, float2 end, float2 x)
+    {
+       return clamp((x-start)/(end-start),float2(0.0,0.0),float2(1.0,1.0));
+    }
+    
+    float computeSelection(
+        float3 blobPosition,
+        float3 normal,
+        float3 tangent,
+        float3 bitangent,
+        float3 faceCenter,
+        float2 faceSize,
+        float selectionFuzz,
+        float farDistance,
+        float fadeLength
+    )
+    {
+        float3 delta = blobPosition - faceCenter;
+        float absD = abs(dot(delta,normal));
+        float fadeIn = 1.0-clamp((absD-farDistance)/fadeLength,0.0,1.0);
+        
+        float2 blobCenterXY = float2(dot(delta,tangent),dot(delta,bitangent));
+    
+        float2 innerFace = faceSize * (1.0-selectionFuzz) * 0.5;
+        float2 selectPulse = ramp2(-faceSize*0.5,-innerFace,blobCenterXY)-ramp2(innerFace,faceSize*0.5,blobCenterXY);
+    //return saturate(abs(blobCenterXY.y)/faceSize.y);
+        return selectPulse.x * selectPulse.y * fadeIn;
+    }
+    
+    void Selection_Vertex_B297(
+        float3 Blob_Position,
+        float3 Blob_Position_2,
+        float3 Face_Center,
+        float2 Face_Size,
+        float3 Normal,
+        float3 Tangent,
+        float3 Bitangent,
+        float Selection_Fuzz,
+        float Selected,
+        float Far_Distance,
+        float Fade_Length,
+        float3 Active_Face_Dir,
+        float Blob_Enable,
+        float Blob_Enable_2,
+        out float Show_Selection    )
+    {
+        float select1 = computeSelection(Blob_Position,Normal,Tangent,Bitangent,Face_Center,Face_Size,Selection_Fuzz,Far_Distance,Fade_Length)*Blob_Enable;
+        float select2 = computeSelection(Blob_Position_2,Normal,Tangent,Bitangent,Face_Center,Face_Size,Selection_Fuzz,Far_Distance,Fade_Length)*Blob_Enable_2;
+        Show_Selection = lerp(max(select1,select2),1.0,Selected);
+    }
+    //BLOCK_END Selection_Vertex
+
+    //BLOCK_BEGIN Object_To_World_Dir 248
+
+    void Object_To_World_Dir_B248(
+        float3 Dir_Object,
+        out float3 Binormal_World    )
+    {
+        Binormal_World = (mul((float3x3)UNITY_MATRIX_M, Dir_Object));
+        
+    }
+    //BLOCK_END Object_To_World_Dir
+
+    //BLOCK_BEGIN GeneralScale 314
+
+    void GeneralScale_B314(
+        out float MinGeneralScale    )
+    {
+        float scaleX = length((mul((float3x3)UNITY_MATRIX_M, float3(1,0,0))));
+        float scaleY = length((mul((float3x3)UNITY_MATRIX_M, float3(0,1,0))));
+        float scaleZ = length((mul((float3x3)UNITY_MATRIX_M, float3(0,0,1))));
+        MinGeneralScale = min(min(scaleX,scaleY),scaleZ);
+    }
+    //BLOCK_END GeneralScale
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        // Object_To_World_Pos (#293)
+        float3 Pos_World_Q293;
+        Pos_World_Q293=(mul(UNITY_MATRIX_M, float4(vertInput.vertex.xyz, 1)));
+        
+        // Object_To_World_Dir (#300)
+        float3 Nrm_World_Q300;
+        Nrm_World_Q300 = normalize((mul((float3x3)UNITY_MATRIX_M, vertInput.normal)));
+        
+        // Conditional (#261)
+        float3 Result_Q261;
+        Result_Q261 = _Use_Global_Left_Index_ ? Global_Left_Index_Tip_Position.xyz : _Blob_Position_;
+        
+        // Lerp (#271)
+        float Value_At_T_Q271=lerp(_Blob_Near_Size_,_Blob_Pulse_Max_Size_,_Blob_Pulse_);
+
+        // Anisotropy (#288)
+        float Anisotropy_Q288=vertInput.uv2.x/vertInput.uv2.y;
+
+        // Conditional (#262)
+        float3 Result_Q262;
+        Result_Q262 = _Use_Global_Right_Index_ ? Global_Right_Index_Tip_Position.xyz : _Blob_Position_2_;
+        
+        float Enabled_Q290;
+        #if defined(_BLOB_ENABLE_)
+          Permutation_To_FloatBool_B290(Enabled_Q290);
+        #else
+          Enabled_Q290 = 0;
+        #endif
+
+        float Enabled_Q291;
+        #if defined(_BLOB_ENABLE_2_)
+          Permutation_To_FloatBool_B290(Enabled_Q291);
+        #else
+          Enabled_Q291 = 0;
+        #endif
+
+        // Lerp (#272)
+        float Value_At_T_Q272=lerp(_Blob_Near_Size_2_,_Blob_Pulse_Max_Size_,_Blob_Pulse_2_);
+
+        // Object_To_World_Dir (#247)
+        float3 Tangent_World_Q247;
+        Tangent_World_Q247 = (mul((float3x3)UNITY_MATRIX_M, vertInput.tangent));
+        
+        float3 Binormal_World_Q248;
+        Object_To_World_Dir_B248((normalize(cross(vertInput.normal,vertInput.tangent))),Binormal_World_Q248);
+
+        float MinGeneralScale_Q314;
+        GeneralScale_B314(MinGeneralScale_Q314);
+
+        // Multiply (#263)
+        float Product_Q263 = _Gaze_Intensity_ * _Gaze_Focus_;
+
+        // Normalize3 (#249)
+        float3 Tangent_World_N_Q249 = normalize(Tangent_World_Q247);
+
+        // Normalize3 (#250)
+        float3 Binormal_World_N_Q250 = normalize(Binormal_World_Q248);
+
+        // Face_Size (#305)
+        float2 Face_Size_Q305;
+        float ScaleY_Q305;
+        Face_Size_Q305 = vertInput.uv2*MinGeneralScale_Q314;
+        ScaleY_Q305 = vertInput.uv2.y;
+        
+        // Step (#264)
+        float Step_Q264 = step(0.0001, Product_Q263);
+
+        float4 Extra_Q296;
+        float Distance_Fade1_Q296;
+        float Distance_Fade2_Q296;
+        Proximity_Vertex_B296(Result_Q261,Result_Q262,Pos_World_Q293,_Proximity_Far_Distance_,1.0,_Proximity_Anisotropy_,Nrm_World_Q300,Tangent_World_N_Q249,Binormal_World_N_Q250,Enabled_Q290,Enabled_Q291,Extra_Q296,Distance_Fade1_Q296,Distance_Fade2_Q296);
+
+        // Scale_Radius_And_Width (#289)
+        float Out_Radius_Q289;
+        float Out_Line_Width_Q289;
+        Out_Radius_Q289 = _Relative_To_Height_ ? _Radius_ : _Radius_ * _Fixed_Unit_Multiplier_ / ScaleY_Q305;
+        Out_Line_Width_Q289 = _Relative_To_Height_ ? _Line_Width_ : _Line_Width_ * _Fixed_Unit_Multiplier_ / ScaleY_Q305;
+
+        // FaceCenter (#299)
+        float3 Face_Center_Q299;
+        //Face_Center_Q299=(mul(UNITY_MATRIX_M, float4(Pos_Object, 1)));
+        Face_Center_Q299 = Pos_World_Q293 + (0.5-vertInput.uv0.x)*Face_Size_Q305.x*Tangent_World_N_Q249 - (0.5-vertInput.uv0.y)*Face_Size_Q305.y*Binormal_World_N_Q250;
+
+        float Show_Selection_Q297;
+        Selection_Vertex_B297(Result_Q261,Result_Q262,Face_Center_Q299,Face_Size_Q305,Nrm_World_Q300,Tangent_World_N_Q249,Binormal_World_N_Q250,_Selection_Fuzz_,_Selected_,_Selected_Distance_,_Selected_Fade_Length_,float3(0,0,-1),Enabled_Q290,Enabled_Q291,Show_Selection_Q297);
+
+        float2 Out_UV_Q280;
+        float3 Blob_Info_Q280;
+        #if defined(_BLOB_ENABLE_)
+          Blob_Vertex_B280(Pos_World_Q293,Nrm_World_Q300,Tangent_World_N_Q249,Binormal_World_N_Q250,Result_Q261,_Blob_Intensity_,Value_At_T_Q271,_Blob_Far_Size_,_Blob_Near_Distance_,_Blob_Far_Distance_,vertInput.uv0,Face_Center_Q299,Face_Size_Q305,_Blob_Fade_Length_,_Selection_Fade_,_Selection_Fade_Size_,_Blob_Inner_Fade_,_Blob_Pulse_,_Blob_Fade_,Out_UV_Q280,Blob_Info_Q280);
+        #else
+          Out_UV_Q280 = float2(0,0);
+          Blob_Info_Q280 = float3(0,0,0);
+        #endif
+
+        float4 Rect_Parms_Q278;
+        Round_Rect_Vertex_B278(vertInput.uv0,Out_Radius_Q289,Anisotropy_Q288,Rect_Parms_Q278);
+
+        float4 Blob_Info_Q286;
+        #if defined(_BLOB_ENABLE_2_)
+          Blob_Vertex_B286(Pos_World_Q293,Nrm_World_Q300,Tangent_World_N_Q249,Binormal_World_N_Q250,Result_Q262,_Blob_Intensity_,Value_At_T_Q272,_Blob_Far_Size_,_Blob_Near_Distance_,_Blob_Far_Distance_,vertInput.uv0,Face_Center_Q299,Face_Size_Q305,_Blob_Fade_Length_,_Selection_Fade_,_Selection_Fade_Size_,_Blob_Inner_Fade_2_,_Blob_Pulse_2_,_Blob_Fade_2_,Blob_Info_Q286);
+        #else
+          Blob_Info_Q286 = float4(0,0,0,0);
+        #endif
+
+        float Width_Q269;
+        Proximity_Visibility_B269(Show_Selection_Q297,Result_Q261,Result_Q262,_Proximity_Far_Distance_,_Proximity_Near_Radius_,Face_Center_Q299,Nrm_World_Q300,Face_Size_Q305,Step_Q264,Width_Q269);
+
+        // Multiply (#279)
+        float Product_Q279 = Out_Line_Width_Q289 * Width_Q269;
+
+        // Max (#260)
+        float MaxAB_Q260=max(Show_Selection_Q297,Product_Q263);
+
+        // Visibility (#287)
+        float3 Result_Q287 = (Width_Q269+Blob_Info_Q280.y+Blob_Info_Q286.y)>0.0 ? Pos_World_Q293 : float3(0.0,0.0,0.0);
+
+        // From_XYZ (#275)
+        float3 Vec3_Q275 = float3(Out_Radius_Q289,Product_Q279,Out_Line_Width_Q289);
+
+        // From_XYZ (#281)
+        float3 Vec3_Q281 = float3(MaxAB_Q260,Distance_Fade1_Q296,Distance_Fade2_Q296);
+
+        float3 Position = Result_Q287;
+        float3 Normal = Vec3_Q275;
+        float2 UV = Out_UV_Q280;
+        float3 Tangent = Blob_Info_Q280;
+        float3 Binormal = Vec3_Q281;
+        float4 Color = vertInput.color;
+        float4 Extra1 = Rect_Parms_Q278;
+        float4 Extra2 = Extra_Q296;
+        float4 Extra3 = Blob_Info_Q286;
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
+#ifdef UNITY_UI_CLIP_RECT
+        o.posLocal = vertInput.vertex.xyz;
+#endif
+        o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
+        o.uv = UV;
+        o.tangent.xyz = Tangent; o.tangent.w=1.0;
+        o.binormal.xyz = Binormal; o.binormal.w=1.0;
+        o.vertexColor = Color;
+        o.extra1=Extra1;
+        o.extra2=Extra2;
+        o.extra3=Extra3;
+
+        return o;
+    }
+
+    //BLOCK_BEGIN Blob_Fragment 284
+
+    void Blob_Fragment_B284(
+        float2 UV,
+        float3 Blob_Info,
+        sampler2D Blob_Texture,
+        out half4 Blob_Color    )
+    {
+        float k = dot(UV,UV);
+        Blob_Color = Blob_Info.y * tex2D(Blob_Texture,float2(float2(sqrt(k),Blob_Info.x).x,1.0-float2(sqrt(k),Blob_Info.x).y))*(1.0-saturate(k));
+    }
+    //BLOCK_END Blob_Fragment
+
+    //BLOCK_BEGIN Blob_Fragment 283
+
+    void Blob_Fragment_B283(
+        sampler2D Blob_Texture,
+        float4 Blob_Info,
+        out half4 Blob_Color    )
+    {
+        float k = dot(Blob_Info.zw,Blob_Info.zw);
+        Blob_Color = Blob_Info.y * tex2D(Blob_Texture,float2(float2(sqrt(k),Blob_Info.x).x,1.0-float2(sqrt(k),Blob_Info.x).y))*(1.0-saturate(k));
+    }
+    //BLOCK_END Blob_Fragment
+
+    //BLOCK_BEGIN Round_Rect_Fragment 277
+
+    void Round_Rect_Fragment_B277(
+        half Radius,
+        half Line_Width,
+        half Filter_Width,
+        half4 Rect_Parms,
+        out half Inside_Line,
+        out half Inside_Rect    )
+    {
+        half d = length(max(abs(Rect_Parms.zw)-Rect_Parms.xy,0.0));
+        half dx = max(fwidth(d)*Filter_Width,0.00001);
+        
+        Inside_Line = 1.0-saturate((Radius-d-Line_Width)/dx);
+        Inside_Rect = saturate((Radius-d)/dx);
+        
+    }
+    //BLOCK_END Round_Rect_Fragment
+
+    //BLOCK_BEGIN Proximity_Fragment 295
+
+    void Proximity_Fragment_B295(
+        half Proximity_Max_Intensity,
+        half Proximity_Near_Radius,
+        half4 Deltas,
+        half Show_Selection,
+        half Distance_Fade1,
+        half Distance_Fade2,
+        out half Proximity    )
+    {
+        float proximity1 = (1.0-saturate(length(Deltas.xy)/Proximity_Near_Radius))*Distance_Fade1;
+        float proximity2 = (1.0-saturate(length(Deltas.zw)/Proximity_Near_Radius))*Distance_Fade2;
+        Proximity = (Proximity_Max_Intensity * max(proximity1, proximity2) *(1.0-Show_Selection)+Show_Selection);
+        
+    }
+    //BLOCK_END Proximity_Fragment
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+    #ifdef UNITY_UI_CLIP_RECT
+        clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
+    #endif
+        half4 result;
+
+        half4 Blob_Color_Q284;
+        #if defined(_BLOB_ENABLE_)
+          Blob_Fragment_B284(fragInput.uv,fragInput.tangent.xyz,_Blob_Texture_,Blob_Color_Q284);
+        #else
+          Blob_Color_Q284 = half4(0,0,0,0);
+        #endif
+
+        half4 Blob_Color_Q283;
+        #if defined(_BLOB_ENABLE_2_)
+          Blob_Fragment_B283(_Blob_Texture_,fragInput.extra3,Blob_Color_Q283);
+        #else
+          Blob_Color_Q283 = half4(0,0,0,0);
+        #endif
+
+        // To_XYZ (#276)
+        half X_Q276;
+        half Y_Q276;
+        half Z_Q276;
+        X_Q276=fragInput.normalWorld.xyz.x;
+        Y_Q276=fragInput.normalWorld.xyz.y;
+        Z_Q276=fragInput.normalWorld.xyz.z;
+        
+        // To_XYZ (#282)
+        half X_Q282;
+        half Y_Q282;
+        half Z_Q282;
+        X_Q282=fragInput.binormal.xyz.x;
+        Y_Q282=fragInput.binormal.xyz.y;
+        Z_Q282=fragInput.binormal.xyz.z;
+        
+        half Inside_Line_Q277;
+        half Inside_Rect_Q277;
+        Round_Rect_Fragment_B277(X_Q276,Y_Q276,_Filter_Width_,fragInput.extra1,Inside_Line_Q277,Inside_Rect_Q277);
+
+        half Proximity_Q295;
+        Proximity_Fragment_B295(_Proximity_Max_Intensity_,_Proximity_Near_Radius_,fragInput.extra2,X_Q282,Y_Q282,Z_Q282,Proximity_Q295);
+
+        // Multiply (#273)
+        half Product_Q273 = Inside_Rect_Q277 * _Fade_Out_;
+
+        // Multiply (#274)
+        half Product_Q274 = Proximity_Q295 * Inside_Line_Q277;
+
+        half4 Result_Q267 = _Edge_Color_ * Product_Q274;
+
+        // Add_Colors (#285)
+        half4 Sum_Q285 = Blob_Color_Q284 + Blob_Color_Q283 + Result_Q267;
+
+        // Scale_Color (#265)
+        half4 Result_Q265 = Product_Q273 * Sum_Q285;
+
+        // Multiply_Colors (#308)
+        half4 Product_Q308 = fragInput.vertexColor * Result_Q265;
+
+        half4 Out_Color = Product_Q308;
+        half Clip_Threshold = 0.001;
+        bool To_sRGB = false;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasFrontplateNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasFrontplateNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: b56a326b001817143b56791bcb4477ce
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasGlowNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasGlowNonSrp.shader
@@ -1,0 +1,303 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Canvas/Non-SRP/GlowNonSrp" {
+
+Properties {
+
+    [Header(Sizes)]
+        [Toggle] _Relative_To_Height_("Relative To Height", Float) = 1
+        _Bevel_Radius_("Bevel Radius", Float) = .05
+        _Line_Width_("Line Width", Float) = 0.03
+        _Outer_Fuzz_Start_("Outer Fuzz Start", Float) = 0.002
+        _Outer_Fuzz_End_("Outer Fuzz End", Float) = 0.001
+        _Fixed_Unit_Multiplier_("Fixed Unit Multiplier", Float) = 1000
+     
+    [Header(Animation)]
+        _Motion_("Motion", Range(0,1)) = 1
+        _Max_Intensity_("Max Intensity", Range(0,1)) = 0.5
+        _Intensity_Fade_In_Exponent_("Intensity Fade In Exponent", Range(0,5)) = 2
+     
+    [Header(Color)]
+        _Color_("Color", Color) = (1,1,1,1)
+        _Inner_Color_("Inner Color", Color) = (1,1,1,1)
+        _Blend_Exponent_("Blend Exponent", Range(0,9)) = 1
+     
+    [Header(Inner Transition)]
+        _Falloff_("Falloff", Range(0,5)) = 1.0
+        _Bias_("Bias", Range(0,1)) = 0.5
+     
+
+    [Header(Blending)]
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 1  // "One"
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+
+    [Header(Depth)]
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 0 // "Off"
+
+    [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
+    [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.
+    [HideInInspector] _ClipRectRadii("Clip Rect Radii", Vector) = (10.0, 10.0, 10.0, 10.0) // Added to avoid SRP warnings.
+}
+
+SubShader {
+    Tags { "RenderType" = "Transparent" "Queue" = "Transparent" }
+    Blend One One
+    ZWrite[_ZWrite]
+    ZTest[_ZTest]
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+
+    Pass
+
+    {
+
+    CGPROGRAM
+
+    #pragma vertex vert
+    #pragma fragment frag
+
+    #pragma target 4.0
+    #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
+    #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+    //#pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    int _Relative_To_Height_;
+    float _Bevel_Radius_;
+    float _Line_Width_;
+    float _Outer_Fuzz_Start_;
+    float _Outer_Fuzz_End_;
+    float _Fixed_Unit_Multiplier_;
+    half _Motion_;
+    half _Max_Intensity_;
+    half _Intensity_Fade_In_Exponent_;
+    half4 _Color_;
+    half4 _Inner_Color_;
+    half _Blend_Exponent_;
+    half _Falloff_;
+    half _Bias_;
+    // #if defined(UNITY_UI_CLIP_RECT)
+    float4 _ClipRect;
+    // #if defined(_UI_CLIP_RECT_ROUNDED) || defined(_UI_CLIP_RECT_ROUNDED_INDEPENDENT)
+    float4 _ClipRectRadii;
+
+
+
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        float2 uv0 : TEXCOORD0;
+        float2 uv2 : TEXCOORD2;
+        float4 color : COLOR;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+        float3 posWorld : TEXCOORD7;
+#ifdef UNITY_UI_CLIP_RECT
+        float3 posLocal : TEXCOORD8;
+#endif
+        half4 normalWorld : TEXCOORD5;
+        float2 uv : TEXCOORD0;
+        float4 tangent : TANGENT;
+        float4 vertexColor : COLOR;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    //BLOCK_BEGIN Scale_Sizes 32
+
+    void Scale_Sizes_B32(
+        float2 ScaleXY,
+        bool Relative_To_Height,
+        float Radius,
+        float Line_Width,
+        float Max_Outer_Fuzz,
+        float Outer_Fuzz,
+        float Fixed_Unit,
+        out float3 RadiusLineAniso,
+        out float3 OuterFuzz    )
+    {
+        float fixedScale = Fixed_Unit / ScaleXY.y;
+        RadiusLineAniso.x = Relative_To_Height ? Radius : Radius * fixedScale;
+        RadiusLineAniso.y = Relative_To_Height ? Line_Width : Line_Width * fixedScale;
+        RadiusLineAniso.z = ScaleXY.x / ScaleXY.y;  // anisotropy
+        OuterFuzz.x = Relative_To_Height ? Outer_Fuzz : Outer_Fuzz * fixedScale;
+        OuterFuzz.y = Relative_To_Height ? Max_Outer_Fuzz : Max_Outer_Fuzz * fixedScale;
+        OuterFuzz.z = 0.0;
+    }
+    //BLOCK_END Scale_Sizes
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        // ScaleUVs (#37)
+        float2 XY_Q37 = (vertInput.uv0 - float2(0.5,0.5))*float2(vertInput.uv2.x/vertInput.uv2.y,1.0);
+
+        // Max (#19)
+        half MaxAB_Q19=max(0,_Motion_);
+
+        // Greater_Than (#39)
+        bool Greater_Than_Q39 = MaxAB_Q19 > 0;
+
+        // Sqrt (#24)
+        half Sqrt_F_Q24 = sqrt(MaxAB_Q19);
+
+        // Conditional_Vec3 (#36)
+        float3 Result_Q36 = Greater_Than_Q39 ? vertInput.vertex.xyz : float3(0,0,0);
+
+        // Lerp (#22)
+        float Value_At_T_Q22=lerp(_Outer_Fuzz_Start_,_Outer_Fuzz_End_,Sqrt_F_Q24);
+
+        // Object_To_World_Pos (#38)
+        float3 Pos_World_Q38=(mul(UNITY_MATRIX_M, float4(Result_Q36, 1)));
+
+        float3 RadiusLineAniso_Q32;
+        float3 OuterFuzz_Q32;
+        Scale_Sizes_B32(vertInput.uv2,_Relative_To_Height_,_Bevel_Radius_,_Line_Width_,_Outer_Fuzz_Start_,Value_At_T_Q22,_Fixed_Unit_Multiplier_,RadiusLineAniso_Q32,OuterFuzz_Q32);
+
+        float3 Position = Pos_World_Q38;
+        float3 Normal = RadiusLineAniso_Q32;
+        float2 UV = XY_Q37;
+        float3 Tangent = OuterFuzz_Q32;
+        float3 Binormal = float3(0,0,0);
+        float4 Color = vertInput.color;
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
+#ifdef UNITY_UI_CLIP_RECT
+        o.posLocal = vertInput.vertex.xyz;
+#endif
+        o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
+        o.uv = UV;
+        o.tangent.xyz = Tangent; o.tangent.w=1.0;
+        o.vertexColor = Color;
+
+        return o;
+    }
+
+    //BLOCK_BEGIN Ease_Transition 42
+
+    float Bias_Bid42(float b, float v) {
+      return pow(v,log(clamp(b,0.001,0.999))/log(0.5));
+    }
+    void Ease_Transition_B42(
+        half Falloff,
+        half Bias,
+        half F,
+        out half Result    )
+    {
+        Result = pow(Bias_Bid42(Bias,F),Falloff);
+    }
+    //BLOCK_END Ease_Transition
+
+    //BLOCK_BEGIN Round_Rect_Fragment 26
+
+    void Round_Rect_Fragment_B26(
+        half Radius,
+        half Line_Width,
+        half Anisotropy,
+        float2 UV,
+        half Outer_Fuzz,
+        half Max_Outer_Fuzz,
+        out half Rect_Distance,
+        out half Inner_Distance    )
+    {
+        half2 center = half2(Anisotropy*0.5-Radius,0.5-Radius);
+        half d = length(max(abs(UV)-center,0.0));
+        half radius = Radius - Max_Outer_Fuzz;
+        Inner_Distance = saturate(1.0-(radius-d)/Line_Width);
+        Rect_Distance = saturate(1.0-(d-radius)/Outer_Fuzz)*Inner_Distance;
+    }
+    //BLOCK_END Round_Rect_Fragment
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+    #ifdef UNITY_UI_CLIP_RECT
+        clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
+    #endif
+        half4 result;
+
+        // To_XYZ (#35)
+        half X_Q35;
+        half Y_Q35;
+        half Z_Q35;
+        X_Q35=fragInput.normalWorld.xyz.x;
+        Y_Q35=fragInput.normalWorld.xyz.y;
+        Z_Q35=fragInput.normalWorld.xyz.z;
+        
+        // To_XYZ (#34)
+        half X_Q34;
+        half Y_Q34;
+        half Z_Q34;
+        X_Q34=fragInput.tangent.xyz.x;
+        Y_Q34=fragInput.tangent.xyz.y;
+        Z_Q34=fragInput.tangent.xyz.z;
+        
+        // Max (#19)
+        half MaxAB_Q19=max(0,_Motion_);
+
+        half Rect_Distance_Q26;
+        half Inner_Distance_Q26;
+        Round_Rect_Fragment_B26(X_Q35,Y_Q35,Z_Q35,fragInput.uv,X_Q34,Y_Q34,Rect_Distance_Q26,Inner_Distance_Q26);
+
+        // Power (#40)
+        half Power_Q40 = pow(MaxAB_Q19, _Intensity_Fade_In_Exponent_);
+
+        // Power (#41)
+        half Power_Q41 = pow(Inner_Distance_Q26, _Blend_Exponent_);
+
+        half Result_Q42;
+        Ease_Transition_B42(_Falloff_,_Bias_,Rect_Distance_Q26,Result_Q42);
+
+        // Multiply (#18)
+        half Product_Q18 = _Max_Intensity_ * Power_Q40;
+
+        // Mix_Colors (#21)
+        half4 Color_At_T_Q21 = lerp(_Inner_Color_, _Color_,float4( Power_Q41, Power_Q41, Power_Q41, Power_Q41));
+
+        // Multiply (#17)
+        half Product_Q17 = Result_Q42 * Product_Q18;
+
+        // Scale_Color (#25)
+        half4 Result_Q25 = Product_Q17 * Color_At_T_Q21;
+
+        // Multiply_Colors (#45)
+        half4 Product_Q45 = fragInput.vertexColor * Result_Q25;
+
+        half4 Out_Color = Product_Q45;
+        half Clip_Threshold = 0;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasGlowNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasGlowNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 1479e8b59036c70468acd267e76eb0d6
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasProgressBarNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasProgressBarNonSrp.shader
@@ -1,0 +1,365 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Canvas/Non-SRP/Progress BarNonSrp" {
+
+Properties {
+
+    [Header(Bar)]
+        _Back_Color_("Back Color", Color) = (0.223529,0.223529,0.223529,1)
+        _Fill_1_("Fill 1", Color) = (0.364706,0.356863,0.831373,1)
+        _Fill_2_("Fill 2", Color) = (0.623529,0.635294,0.988235,1)
+        _Filled_Fraction_("Filled Fraction", Range(0,1)) = 0.2
+     
+    [Header(Animation)]
+        [Toggle(_CYCLE_)] _Cycle_("Cycle", Float) = 0
+        _Cycle_Rate_("Cycle Rate", Range(0,2)) = 0.7
+        _Rate_Vary_("Rate Vary", Range(0,1)) = 0.5
+        _Fill_Vary_("Fill Vary", Range(0,1)) = 0.7
+        _Period_("Period", Float) = 1.0
+        _Cycle_Offset_("Cycle Offset", Float) = -0.3
+     
+    [Header(Blurred Background)]
+        [Toggle(_BLUR_CIRCLE_)] _Blur_Circle_("Blur Circle", Float) = 0
+        [NoScaleOffset] _blurTexture("blurTexture", 2D) = "" {}
+        _BlurBackgroundRect("BlurBackgroundRect", Vector) = (0, 0, 1, 1)
+     
+
+    [Header(Blending)]
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 10  // "OneMinusSrcAlpha"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+
+    [Header(Depth)]
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
+
+    [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
+    [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.
+    [HideInInspector] _ClipRectRadii("Clip Rect Radii", Vector) = (10.0, 10.0, 10.0, 10.0) // Added to avoid SRP warnings.
+}
+
+SubShader {
+    Tags { "RenderType" = "Transparent" "Queue" = "Transparent" }
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+    ZWrite[_ZWrite]
+    ZTest[_ZTest]
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+
+    Pass
+
+    {
+
+    CGPROGRAM
+
+    #pragma vertex vert
+    #pragma fragment frag
+    #pragma target 4.0
+    #pragma shader_feature_local _ _BLUR_CIRCLE_
+    #pragma shader_feature_local _ _CYCLE_
+    #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
+    #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+    //#pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    half4 _Back_Color_;
+    half4 _Fill_1_;
+    half4 _Fill_2_;
+    float _Filled_Fraction_;
+    //bool _Cycle_;
+    float _Cycle_Rate_;
+    float _Rate_Vary_;
+    float _Fill_Vary_;
+    float _Period_;
+    float _Cycle_Offset_;
+    //bool _Blur_Circle_;
+    sampler2D _blurTexture;
+    float4 _BlurBackgroundRect;
+    // #if defined(UNITY_UI_CLIP_RECT)
+    float4 _ClipRect;
+    // #if defined(_UI_CLIP_RECT_ROUNDED) || defined(_UI_CLIP_RECT_ROUNDED_INDEPENDENT)
+    float4 _ClipRectRadii;
+
+
+
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        float2 uv0 : TEXCOORD0;
+        float2 uv2 : TEXCOORD2;
+        float2 uv3 : TEXCOORD3;
+        float4 color : COLOR;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+        float3 posWorld : TEXCOORD7;
+#ifdef UNITY_UI_CLIP_RECT
+        float3 posLocal : TEXCOORD8;
+#endif
+        half4 normalWorld : TEXCOORD5;
+        float2 uv : TEXCOORD0;
+        float4 vertexColor : COLOR;
+        float4 extra1 : TEXCOORD4;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    //BLOCK_BEGIN Timing 86
+
+    void Timing_B86(
+        float Time,
+        float Rate,
+        float Rate_Vary,
+        float Fill_Vary,
+        float Period,
+        float Fill_Fraction,
+        out float Result,
+        out float Fill_Offset    )
+    {
+        float tr = Time * Rate / Period;
+        float ft = frac(tr);
+        float tri = 2*abs(ft-0.5);
+        float wave = sin(tr*6.283);
+        float delta = (1-wave)*Rate_Vary/3.4;
+        Result = (lerp(ft,tri*tri*0.5*sign(ft-0.5)+0.5,Rate_Vary) + delta)*Period;
+        Fill_Offset = delta*Fill_Vary;
+    }
+    //BLOCK_END Timing
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        // Object_To_World_Pos (#62)
+        float3 Pos_World_Q62;
+        Pos_World_Q62=(mul(UNITY_MATRIX_M, float4(vertInput.vertex.xyz, 1)));
+        
+        // Scale_Sizes (#72)
+        float3 RadiusAniso_Q72;
+        RadiusAniso_Q72.x = 0.0;
+        RadiusAniso_Q72.y = vertInput.uv2.x / vertInput.uv2.y;  // anisotropy
+        RadiusAniso_Q72.z = vertInput.uv0.x;
+
+        // ScaleUVs (#60)
+        float2 XY_Q60 = (vertInput.uv0 - float2(0.5,0.5))*float2(vertInput.uv2.x/vertInput.uv2.y,1.0);
+
+        // ToCanvasSpace (#80)
+        float2 Result_Q80 = float2((vertInput.vertex.xyz.x-_BlurBackgroundRect.x)/(_BlurBackgroundRect.z-_BlurBackgroundRect.x), (vertInput.vertex.xyz.y-_BlurBackgroundRect.y)/(_BlurBackgroundRect.w-_BlurBackgroundRect.y));
+
+        float Result_Q86;
+        float Fill_Offset_Q86;
+        Timing_B86(_Time.y,_Cycle_Rate_,_Rate_Vary_,_Fill_Vary_,_Period_,_Filled_Fraction_,Result_Q86,Fill_Offset_Q86);
+
+        // To_XY (#78)
+        float X_Q78;
+        float Y_Q78;
+        X_Q78 = Result_Q80.x;
+        Y_Q78 = Result_Q80.y;
+
+        // Add (#71)
+        float Sum_Q71 = Result_Q86 + _Cycle_Offset_;
+
+        // Add (#83)
+        float Sum_Q83 = Fill_Offset_Q86 + _Filled_Fraction_;
+
+        // From_XYZW (#79)
+        float4 Vec4_Q79 = float4(X_Q78, Y_Q78, Sum_Q71, Sum_Q83);
+
+        float3 Position = Pos_World_Q62;
+        float3 Normal = RadiusAniso_Q72;
+        float2 UV = XY_Q60;
+        float3 Tangent = float3(0,0,0);
+        float3 Binormal = float3(0,0,0);
+        float4 Color = vertInput.color;
+        float4 Extra1 = Vec4_Q79;
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
+#ifdef UNITY_UI_CLIP_RECT
+        o.posLocal = vertInput.vertex.xyz;
+#endif
+        o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
+        o.uv = UV;
+        o.vertexColor = Color;
+        o.extra1=Extra1;
+
+        return o;
+    }
+
+    //BLOCK_BEGIN DeterminateBar 89
+
+    void DeterminateBar_B89(
+        float2 UV,
+        float Length,
+        half4 Line_Color,
+        half4 Left_Color,
+        half4 Right_Color,
+        float Filled_Fraction,
+        out half4 Result    )
+    {
+        float halfLength = Length * 0.5;
+        float x = UV.x - clamp(UV.x,-halfLength+0.5,halfLength-0.5);
+        float d = sqrt(x*x+UV.y*UV.y);
+        half inLine = saturate((0.5-d)/fwidth(d));
+        
+        float fillEnd = (Length-1)*Filled_Fraction+0.5-halfLength;
+        float fx = UV.x - clamp(UV.x,-halfLength+0.5,fillEnd);
+        float fd = sqrt(fx*fx+UV.y*UV.y);
+        half filled = saturate((0.5-fd)/fwidth(fd));
+        
+        half blend = saturate( (UV.x+halfLength)/(fillEnd+halfLength+0.5) );
+        half4 fillColor = lerp(Left_Color, Right_Color,float4( blend, blend, blend, blend));
+        
+        Result = filled * fillColor + (1-filled)*inLine*Line_Color;
+    }
+    //BLOCK_END DeterminateBar
+
+    //BLOCK_BEGIN IndeterminateBar 88
+
+    half Line(float startX, float endX, float2 uv)
+    {
+        float x = uv.x - clamp(uv.x, startX, endX);
+        half d = sqrt(x*x+uv.y*uv.y);
+        return saturate((0.5-d)/fwidth(d));    
+    }
+    
+    void IndeterminateBar_B88(
+        float2 UV,
+        float Length,
+        half4 Line_Color,
+        half4 Left_Color,
+        half4 Right_Color,
+        float Filled_Fraction,
+        float Cycle,
+        out half4 Result    )
+    {
+        float halfLength = Length * 0.5;
+        half inLine = Line(-halfLength+0.5,halfLength-0.5,UV);
+        
+        float fcycle = frac(Cycle);
+        float end = (fcycle)*(Length+1);
+        float start = end - Filled_Fraction * (Length-1);
+        float dir = end>Length*0.5 ? -1 : 1;
+        float start2 = start + dir * (Length+1);
+        float end2 = end + dir * (Length+1);
+        half filled = max( Line(start,end,UV), Line(start2,end2,UV)) * inLine;
+        
+        //find gradient
+        float inFirst = abs(UV.x-clamp(UV.x,start,end));
+        float inSecond = abs(UV.x-clamp(UV.x,start2,end2));
+        float2 segment = inFirst<inSecond ? float2(start,end) : float2(start2,end2);
+        
+        half blend = saturate( (UV.x-segment.x+0.5)/(segment.y-segment.x+1) );
+        half4 fillColor = lerp(Left_Color, Right_Color,float4( blend, blend, blend, blend));
+        
+        Result = inLine * Line_Color * (1-filled) + filled * fillColor;
+    }
+    //BLOCK_END IndeterminateBar
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+    #ifdef UNITY_UI_CLIP_RECT
+        clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
+    #endif
+        half4 result;
+
+        // To_RGBA (#92)
+        half R_Q92;
+        half G_Q92;
+        half B_Q92;
+        half A_Q92;
+        R_Q92=fragInput.vertexColor.r; G_Q92=fragInput.vertexColor.g; B_Q92=fragInput.vertexColor.b; A_Q92=fragInput.vertexColor.a;
+
+        // To_XYZ (#68)
+        float X_Q68;
+        float Y_Q68;
+        float Z_Q68;
+        X_Q68=fragInput.normalWorld.xyz.x;
+        Y_Q68=fragInput.normalWorld.xyz.y;
+        Z_Q68=fragInput.normalWorld.xyz.z;
+        
+        // To_XYZW (#76)
+        float X_Q76;
+        float Y_Q76;
+        float Z_Q76;
+        float W_Q76;
+        X_Q76=fragInput.extra1.x;
+        Y_Q76=fragInput.extra1.y;
+        Z_Q76=fragInput.extra1.z;
+        W_Q76=fragInput.extra1.w;
+
+        // Permutation_To_Bool (#74)
+        bool Use_Blur_Map_Q74;
+        #if defined(_BLUR_CIRCLE_)
+          Use_Blur_Map_Q74 = true;
+        #else
+          Use_Blur_Map_Q74 = false;
+        #endif
+
+        // From_XY (#75)
+        float2 Vec2_Q75 = float2(X_Q76,Y_Q76);
+
+        // Circle_Color (#81)
+        half4 Color_Q81;
+        if (Use_Blur_Map_Q74) {
+            Color_Q81 = tex2D(_blurTexture,Vec2_Q75);
+        } else {
+            Color_Q81 = _Back_Color_;
+        }
+
+        half4 Result_Q89;
+        #if defined(_CYCLE_)
+          Result_Q89 = half4(0,0,0,0);
+        #else
+          DeterminateBar_B89(fragInput.uv,Y_Q68,Color_Q81,_Fill_2_,_Fill_1_,_Filled_Fraction_,Result_Q89);
+        #endif
+
+        half4 Result_Q88;
+        #if defined(_CYCLE_)
+          IndeterminateBar_B88(fragInput.uv,Y_Q68,Color_Q81,_Fill_2_,_Fill_1_,W_Q76,Z_Q76,Result_Q88);
+        #else
+          Result_Q88 = half4(0,0,0,0);
+        #endif
+
+        // Add_Colors (#70)
+        half4 Sum_Q70 = Result_Q89 + Result_Q88;
+
+        // Scale_Color (#91)
+        half4 Result_Q91 = A_Q92 * Sum_Q70;
+
+        half4 Out_Color = Result_Q91;
+        half Clip_Threshold = 0;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasProgressBarNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasProgressBarNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 01da28269f452164789cafabd7f98a74
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasQuadGlowNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasQuadGlowNonSrp.shader
@@ -1,0 +1,233 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Canvas/Non-SRP/Quad GlowNonSrp" {
+
+Properties {
+
+    [Header(Color)]
+        _Color_("Color", Color) = (1,1,1,1)
+     
+    [Header(Shape)]
+        _Radius_("Radius", Float) = 0.5
+        [Toggle] _Fixed_Radius_("Fixed Radius", Float) = 0
+        _Fixed_Unit_Multiplier_("Fixed Unit Multiplier", Float) = 1000
+        _Filter_Width_("Filter Width", Range(0,4)) = 2
+     
+    [Header(Glow)]
+        _Glow_Fraction_("Glow Fraction", Range(0.01,0.99)) = 0.5
+        _Glow_Max_("Glow Max", Range(0,1)) = 0.5
+        _Glow_Falloff_("Glow Falloff", Range(0,5)) = 2
+     
+
+    [Header(Blending)]
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 10  // "OneMinusSrcAlpha"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+
+    [Header(Depth)]
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 0 // "Off"
+
+    [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
+    [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.
+    [HideInInspector] _ClipRectRadii("Clip Rect Radii", Vector) = (10.0, 10.0, 10.0, 10.0) // Added to avoid SRP warnings.
+}
+
+SubShader {
+    Tags{ "RenderType" = "AlphaTest" "Queue" = "AlphaTest"}
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+    ZWrite[_ZWrite]
+    ZTest[_ZTest]
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+
+    Pass
+
+    {
+
+    CGPROGRAM
+
+    #pragma vertex vert
+    #pragma fragment frag
+    #pragma target 4.0
+    #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
+    #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+    //#pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    half4 _Color_;
+    float _Radius_;
+    int _Fixed_Radius_;
+    float _Fixed_Unit_Multiplier_;
+    half _Filter_Width_;
+    half _Glow_Fraction_;
+    half _Glow_Max_;
+    half _Glow_Falloff_;
+    // #if defined(UNITY_UI_CLIP_RECT)
+    float4 _ClipRect;
+    // #if defined(_UI_CLIP_RECT_ROUNDED) || defined(_UI_CLIP_RECT_ROUNDED_INDEPENDENT)
+    float4 _ClipRectRadii;
+
+
+
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        float2 uv0 : TEXCOORD0;
+        float2 uv2 : TEXCOORD2;
+        float4 color : COLOR;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+        float3 posWorld : TEXCOORD7;
+#ifdef UNITY_UI_CLIP_RECT
+        float3 posLocal : TEXCOORD8;
+#endif
+        half4 normalWorld : TEXCOORD5;
+        float2 uv : TEXCOORD0;
+        float4 vertexColor : COLOR;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    //BLOCK_BEGIN Scale_Sizes 29
+
+    void Scale_Sizes_B29(
+        float2 ScaleXY,
+        float Radius,
+        bool Fixed,
+        float Fixed_Unit,
+        out float3 RadiusAniso    )
+    {
+        RadiusAniso.x = Fixed ? Radius * Fixed_Unit / ScaleXY.y : Radius;
+        RadiusAniso.y = ScaleXY.x / ScaleXY.y;  // anisotropy
+        RadiusAniso.z = 0.0;
+    }
+    //BLOCK_END Scale_Sizes
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        // Object_To_World_Pos (#27)
+        float3 Pos_World_Q27;
+        Pos_World_Q27=(mul(UNITY_MATRIX_M, float4(vertInput.vertex.xyz, 1)));
+        
+        float3 RadiusAniso_Q29;
+        Scale_Sizes_B29(vertInput.uv2,_Radius_,_Fixed_Radius_,_Fixed_Unit_Multiplier_,RadiusAniso_Q29);
+
+        // ScaleUVs (#24)
+        float2 XY_Q24 = (vertInput.uv0 - float2(0.5,0.5))*float2(vertInput.uv2.x/vertInput.uv2.y,1.0);
+
+        float3 Position = Pos_World_Q27;
+        float3 Normal = RadiusAniso_Q29;
+        float2 UV = XY_Q24;
+        float3 Tangent = float3(0,0,0);
+        float3 Binormal = float3(0,0,0);
+        float4 Color = vertInput.color;
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
+#ifdef UNITY_UI_CLIP_RECT
+        o.posLocal = vertInput.vertex.xyz;
+#endif
+        o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
+        o.uv = UV;
+        o.vertexColor = Color;
+
+        return o;
+    }
+
+    //BLOCK_BEGIN Round_Rect 30
+
+    half FilterStep_Bid30(half edge, half x, half filterWidth)
+    {
+       half dx = max(1.0E-5,fwidth(x)*filterWidth);
+       return max((x+dx*0.5 - max(edge,x-dx*0.5))/dx,0.0);
+    }
+    void Round_Rect_B30(
+        half Radius,
+        half Size_X,
+        half Size_Y,
+        half4 Rect_Color,
+        half Filter_Width,
+        half2 UV,
+        half Glow_Fraction,
+        half Glow_Max,
+        half Glow_Falloff,
+        out half4 Color    )
+    {
+        half2 halfSize = half2(Size_X,Size_Y)*0.5;
+        half2 r = max(min(half2(Radius,Radius),halfSize),half2(0.01,0.01));
+        
+        half2 v = abs(UV);
+        
+        half2 nearestp = min(v,halfSize-r);
+        half2 delta = (v-nearestp)/max(half2(0.01,0.01),r);
+        half Distance = length(delta);
+        
+        half insideRect = 1.0 - FilterStep_Bid30(1.0-Glow_Fraction,Distance,Filter_Width);
+        
+        half glow = saturate((1.0-Distance)/Glow_Fraction);
+        glow = pow(glow, Glow_Falloff);
+        Color = Rect_Color * max(insideRect, glow*Glow_Max);
+    }
+    //BLOCK_END Round_Rect
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+    #ifdef UNITY_UI_CLIP_RECT
+        clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
+    #endif
+        half4 result;
+
+        // To_XYZ (#20)
+        half X_Q20;
+        half Y_Q20;
+        half Z_Q20;
+        X_Q20=fragInput.normalWorld.xyz.x;
+        Y_Q20=fragInput.normalWorld.xyz.y;
+        Z_Q20=fragInput.normalWorld.xyz.z;
+        
+        half4 Color_Q30;
+        Round_Rect_B30(X_Q20,Y_Q20,1.0,_Color_,_Filter_Width_,fragInput.uv,_Glow_Fraction_,_Glow_Max_,_Glow_Falloff_,Color_Q30);
+
+        // Multiply_Colors (#31)
+        half4 Product_Q31 = Color_Q30 * fragInput.vertexColor;
+
+        half4 Out_Color = Product_Q31;
+        half Clip_Threshold = 0;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasQuadGlowNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasQuadGlowNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 9c714d70378414b44a26cee634e55823
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasRadialSpinnerNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasRadialSpinnerNonSrp.shader
@@ -1,0 +1,344 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Canvas/Non-SRP/Radial SpinnerNonSrp" {
+
+Properties {
+
+    [Header(Animation)]
+        [Toggle(_CYCLE_)] _Cycle_("Cycle", Float) = 0
+        _Cycle_Rate_("Cycle Rate", Range(0,1)) = .7
+        _Rate_Vary_("Rate Vary", Range(0,1)) = 0.6
+        _Fill_Vary_("Fill Vary", Range(0,1)) = 1
+        _Period_("Period", Float) = 1
+        _Cycle_Offset_("Cycle Offset", Range(0,10)) = 0
+     
+    [Header(Colors)]
+        _Circle_Color_("Circle Color", Color) = (0.239216,0.239216,0.239216,1)
+        _Fill_1_("Fill 1", Color) = (0.364706,0.356863,0.831373,1)
+        _Fill_2_("Fill 2", Color) = (0.623529,0.635294,0.988235,1)
+     
+    [Header(Circle)]
+        _Circle_Width_("Circle Width", Range(0,1)) = 0.3
+        _Filled_Fraction_("Filled Fraction", Range(0,1)) = 0.1
+     
+    [Header(Blurred Background)]
+        [Toggle(_BLUR_CIRCLE_)] _Blur_Circle_("Blur Circle", Float) = 0
+        [NoScaleOffset] _blurTexture("blurTexture", 2D) = "" {}
+        _BlurBackgroundRect("BlurBackgroundRect", Vector) = (0, 0, 1, 1)
+     
+
+    [Header(Blending)]
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 10  // "OneMinusSrcAlpha"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+
+    [Header(Depth)]
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
+
+    [HideInInspector] _MainTex("Texture", 2D) = "white" {} // Added to avoid UnityUI warnings.
+    [HideInInspector] _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0) // Added to avoid SRP warnings.
+    [HideInInspector] _ClipRectRadii("Clip Rect Radii", Vector) = (10.0, 10.0, 10.0, 10.0) // Added to avoid SRP warnings.
+}
+
+SubShader {
+    Tags { "RenderType" = "Transparent" "Queue" = "Transparent" }
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+    ZWrite[_ZWrite]
+    ZTest[_ZTest]
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+
+    Pass
+
+    {
+
+    CGPROGRAM
+
+    #pragma vertex vert
+    #pragma fragment frag
+    #pragma target 4.0
+    #pragma shader_feature_local _ _BLUR_CIRCLE_
+    #pragma shader_feature_local _ _CYCLE_
+    #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
+    #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+    //#pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    //bool _Cycle_;
+    float _Cycle_Rate_;
+    float _Rate_Vary_;
+    float _Fill_Vary_;
+    float _Period_;
+    float _Cycle_Offset_;
+    half4 _Circle_Color_;
+    half4 _Fill_1_;
+    half4 _Fill_2_;
+    float _Circle_Width_;
+    float _Filled_Fraction_;
+    //bool _Blur_Circle_;
+    sampler2D _blurTexture;
+    float4 _BlurBackgroundRect;
+    // #if defined(UNITY_UI_CLIP_RECT)
+    float4 _ClipRect;
+    // #if defined(_UI_CLIP_RECT_ROUNDED) || defined(_UI_CLIP_RECT_ROUNDED_INDEPENDENT)
+    float4 _ClipRectRadii;
+
+
+
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        float2 uv0 : TEXCOORD0;
+        float4 color : COLOR;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+        float3 posWorld : TEXCOORD7;
+#ifdef UNITY_UI_CLIP_RECT
+        float3 posLocal : TEXCOORD8;
+#endif
+        float2 uv : TEXCOORD0;
+        float4 vertexColor : COLOR;
+        float4 extra1 : TEXCOORD4;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    //BLOCK_BEGIN Object_To_World_Pos 102
+
+    void Object_To_World_Pos_B102(
+        float3 Pos_Object,
+        out float3 Pos_World    )
+    {
+        Pos_World=(mul(UNITY_MATRIX_M, float4(Pos_Object, 1)));
+        
+    }
+    //BLOCK_END Object_To_World_Pos
+
+    //BLOCK_BEGIN Timing 126
+
+    void Timing_B126(
+        float Time,
+        float Rate,
+        float Rate_Vary,
+        float Fill_Vary,
+        float Period,
+        out float Result,
+        out float Fill_Offset    )
+    {
+        float tr = Time * Rate / Period;
+        float ft = frac(tr);
+        float tri = 2*abs(ft-0.5);
+        float wave = sin(tr*6.283);
+        float delta = (1-wave)*Rate_Vary/3.4;
+        Result = (lerp(ft,tri*tri*0.5*sign(ft-0.5)+0.5,Rate_Vary) + delta)*Period;
+        Fill_Offset = delta*Fill_Vary;
+    }
+    //BLOCK_END Timing
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        float3 Pos_World_Q102;
+        Object_To_World_Pos_B102(vertInput.vertex.xyz,Pos_World_Q102);
+
+        // Subtract2 (#103)
+        float2 Difference2_Q103 = vertInput.uv0 - float2(0.5,0.5);
+
+        // ToCanvasSpace (#107)
+        float2 Result_Q107 = float2((vertInput.vertex.xyz.x-_BlurBackgroundRect.x)/(_BlurBackgroundRect.z-_BlurBackgroundRect.x), (vertInput.vertex.xyz.y-_BlurBackgroundRect.y)/(_BlurBackgroundRect.w-_BlurBackgroundRect.y));
+
+        float Result_Q126;
+        float Fill_Offset_Q126;
+        #if defined(_CYCLE_)
+          Timing_B126(_Time.y,_Cycle_Rate_,_Rate_Vary_,_Fill_Vary_,_Period_,Result_Q126,Fill_Offset_Q126);
+        #else
+          Result_Q126 = 0.0;
+          Fill_Offset_Q126 = 0.0;
+        #endif
+
+        // To_XY (#109)
+        float X_Q109;
+        float Y_Q109;
+        X_Q109 = Result_Q107.x;
+        Y_Q109 = Result_Q107.y;
+
+        // Add (#104)
+        float Sum_Q104 = Result_Q126 + _Cycle_Offset_;
+
+        // Add (#125)
+        float Sum_Q125 = Fill_Offset_Q126 + _Filled_Fraction_;
+
+        // From_XYZW (#108)
+        float4 Vec4_Q108 = float4(X_Q109, Y_Q109, Sum_Q104, Sum_Q125);
+
+        float3 Position = Pos_World_Q102;
+        float3 Normal = float3(0,0,0);
+        float2 UV = Difference2_Q103;
+        float3 Tangent = float3(0,0,0);
+        float3 Binormal = float3(0,0,0);
+        float4 Color = vertInput.color;
+        float4 Extra1 = Vec4_Q108;
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
+#ifdef UNITY_UI_CLIP_RECT
+        o.posLocal = vertInput.vertex.xyz;
+#endif
+        o.uv = UV;
+        o.vertexColor = Color;
+        o.extra1=Extra1;
+
+        return o;
+    }
+
+    //BLOCK_BEGIN Spinner 129
+
+    float2 rotate2d(float2 uv, float angle)
+    {
+        float cosa = cos(angle);
+        float sina = sin(angle);
+        return float2(cosa*uv.x-sina*uv.y, sina*uv.x+cosa*uv.y);
+    }
+    
+    float Circle(float2 center, float radius, float2 xy)
+    {
+        float d = distance(center,xy);
+        return saturate((radius-d)/fwidth(d));
+    }
+    
+    void Spinner_B129(
+        float Circle_Width,
+        half4 Circle_Color,
+        float2 UV,
+        half4 Start_Color,
+        half4 End_Color,
+        float Cycle,
+        float Segment_Width,
+        bool CycleOn,
+        out half4 Result    )
+    {
+        float cycleAngle = Cycle * 6.283;
+        float dir = CycleOn ? -1.0 : 1.0;
+        float2 xy = rotate2d(UV, cycleAngle + dir * Segment_Width*3.14159);
+        half angle = atan2(xy.x,xy.y)/3.14159;
+        
+        float r = (length(UV)*2.0);
+        float dr = fwidth(r);
+        float inCircle = saturate((1-r)/dr)-(1-saturate((r-(1-Circle_Width))/dr));
+        float inSegment = inCircle;
+        
+        half inArc = step(-Segment_Width,angle)-step(Segment_Width,angle);
+        inSegment *= inArc;
+        
+        float segmentAngle = Segment_Width*3.14159;
+        
+        float2 endpt = rotate2d(float2(0,0.5-Circle_Width*0.25), segmentAngle);
+        
+        float circle1 = Circle(endpt, Circle_Width*0.25, xy);
+        float circle2 = Circle(float2(-endpt.x,endpt.y), Circle_Width*0.25, xy);
+        
+        inSegment = max(max(circle1,circle2),inSegment);
+        
+        half endToEndWidth = (Segment_Width+Circle_Width/3.14159*0.5)*2;
+        half t = saturate(angle/endToEndWidth+0.5);
+        half4 segmentColor = lerp(Start_Color, End_Color,float4( t, t, t, t));
+        Result = Circle_Color * (inCircle * (1-inSegment)) + inSegment * segmentColor;
+    }
+    //BLOCK_END Spinner
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+    #ifdef UNITY_UI_CLIP_RECT
+        clip(GTUnityUIClipRect(fragInput.posLocal.xy, _ClipRect, _ClipRectRadii) - 0.5);
+    #endif
+        half4 result;
+
+        // To_RGBA (#131)
+        half R_Q131;
+        half G_Q131;
+        half B_Q131;
+        half A_Q131;
+        R_Q131=fragInput.vertexColor.r; G_Q131=fragInput.vertexColor.g; B_Q131=fragInput.vertexColor.b; A_Q131=fragInput.vertexColor.a;
+
+        // To_XYZW (#111)
+        float X_Q111;
+        float Y_Q111;
+        float Z_Q111;
+        float W_Q111;
+        X_Q111=fragInput.extra1.x;
+        Y_Q111=fragInput.extra1.y;
+        Z_Q111=fragInput.extra1.z;
+        W_Q111=fragInput.extra1.w;
+
+        // Permutation_To_Bool (#124)
+        bool Bool_Q124;
+        #if defined(_CYCLE_)
+          Bool_Q124 = true;
+        #else
+          Bool_Q124 = false;
+        #endif
+
+        // Permutation_To_Bool (#113)
+        bool Use_Blur_Map_Q113;
+        #if defined(_BLUR_CIRCLE_)
+          Use_Blur_Map_Q113 = true;
+        #else
+          Use_Blur_Map_Q113 = false;
+        #endif
+
+        // From_XY (#110)
+        float2 Vec2_Q110 = float2(X_Q111,Y_Q111);
+
+        // Circle_Color (#123)
+        half4 Color_Q123;
+        if (Use_Blur_Map_Q113) {
+            Color_Q123 = tex2D(_blurTexture,Vec2_Q110);
+        } else {
+            Color_Q123 = _Circle_Color_;
+        }
+
+        half4 Result_Q129;
+        Spinner_B129(_Circle_Width_,Color_Q123,fragInput.uv,_Fill_2_,_Fill_1_,Z_Q111,W_Q111,Bool_Q124,Result_Q129);
+
+        // Scale_Color (#132)
+        half4 Result_Q132 = A_Q131 * Result_Q129;
+
+        half4 Out_Color = Result_Q132;
+        half Clip_Threshold = 0;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasRadialSpinnerNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/CanvasRadialSpinnerNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 4b329dd2d860955438a41936aad917b6
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvasNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvasNonSrp.shader
@@ -1,0 +1,252 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/// <summary>
+/// Standard shader configured to work best with UnityUI (uGUI) CanvasRenderers.
+/// See "Graphics Tools/Standard" for improved Mesh Renderer support.
+/// </summary>
+Shader "Graphics Tools/Non-SRP/Standard CanvasNonSrp"
+{
+    Properties
+    {
+        // Main maps.
+        _Color("Color", Color) = (1.0, 1.0, 1.0, 1.0)
+        [PerRendererData] _MainTex("Albedo", 2D) = "white" {}
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.AlbedoAlphaMode)] _AlbedoAlphaMode("Albedo Alpha Mode", Float) = 0 // "Transparency"
+        [Toggle] _AlbedoAssignedAtRuntime("Albedo Assigned at Runtime", Float) = 0.0
+        _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
+        _Fade("Alpha Fade", Range(0.0, 1.0)) = 1.0
+        _Metallic("Metallic", Range(0.0, 1.0)) = 0.0
+        _Smoothness("Smoothness", Range(0.0, 1.0)) = 0.5
+        [Toggle(_CHANNEL_MAP)] _EnableChannelMap("Enable Channel Map", Float) = 0.0
+        [NoScaleOffset] _ChannelMap("Channel Map", 2D) = "white" {}
+        [Toggle(_NORMAL_MAP)] _EnableNormalMap("Enable Normal Map", Float) = 0.0
+        [NoScaleOffset] _NormalMap("Normal Map", 2D) = "bump" {}
+        _NormalMapScale("Scale", Float) = 1.0
+        [Toggle(_EMISSION)] _EnableEmission("Enable Emission", Float) = 0.0
+        [HDR]_EmissiveColor("Emissive Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _EmissiveMap("Emissive Map",2D) = "white" {}
+        [Toggle(_TRIPLANAR_MAPPING)] _EnableTriplanarMapping("Triplanar Mapping", Float) = 0.0
+        [Toggle(_LOCAL_SPACE_TRIPLANAR_MAPPING)] _EnableLocalSpaceTriplanarMapping("Local Space", Float) = 0.0
+        _TriplanarMappingBlendSharpness("Blend Sharpness", Range(1.0, 16.0)) = 4.0
+        [Toggle(_USE_SSAA)] _EnableSSAA("Super Sample Anti Aliasing", Float) = 0.0
+        _MipmapBias("Mipmap Bias", Range(-5.0, 0.0)) = -2.0
+
+        // Rendering options.
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.LightMode)] _DirectionalLight("Light Mode", Float) = 0.0 // "Unlit"
+        [Toggle(_NON_PHOTOREALISTIC)] _NPR("Non-Photorealistic Rendering", Float) = 0.0
+        [Toggle(_SPECULAR_HIGHLIGHTS)] _SpecularHighlights("Specular Highlights", Float) = 1.0
+        [Toggle(_SPHERICAL_HARMONICS)] _SphericalHarmonics("Spherical Harmonics", Float) = 0.0
+        [Toggle(_REFLECTIONS)] _Reflections("Reflections", Float) = 0.0
+        [Toggle(_RIM_LIGHT)] _RimLight("Rim Light", Float) = 0.0
+        _RimColor("Rim Color", Color) = (0.5, 0.5, 0.5, 1.0)
+        _RimPower("Rim Power", Range(0.0, 8.0)) = 0.25
+        [Toggle(_VERTEX_COLORS)] _VertexColors("Vertex Colors", Float) = 1.0
+        [Toggle(_VERTEX_EXTRUSION)] _VertexExtrusion("Vertex Extrusion", Float) = 0.0
+        _VertexExtrusionValue("Vertex Extrusion Value", Float) = 0.0
+        [Toggle(_VERTEX_EXTRUSION_SMOOTH_NORMALS)] _VertexExtrusionSmoothNormals("Vertex Extrusion Smooth Normals", Float) = 0.0
+        [Toggle(_VERTEX_EXTRUSION_CONSTANT_WIDTH)] _VertexExtrusionConstantWidth("Vertex Extrusion Constant Width", Float) = 0.0
+        _BlendedClippingWidth("Clipping Alpha Falloff", Range(0.0, 10.0)) = 0.0
+        [Toggle(_CLIPPING_BORDER)] _ClippingBorder("Clipping Border", Float) = 0.0
+        _ClippingBorderWidth("Clipping Border Width", Range(0.0, 1.0)) = 0.025
+        _ClippingBorderColor("Clipping Border Color", Color) = (1.0, 0.2, 0.0, 1.0)
+        [Toggle(_NEAR_PLANE_FADE)] _NearPlaneFade("Near Plane Fade", Float) = 0.0
+        [Toggle(_NEAR_LIGHT_FADE)] _NearLightFade("Near Light Fade", Float) = 0.0
+        _FadeBeginDistance("Fade Begin Distance", Range(0.0, 10.0)) = 0.85
+        _FadeCompleteDistance("Fade Complete Distance", Range(0.0, 10.0)) = 0.5
+        _FadeMinValue("Fade Min Value", Range(0.0, 1.0)) = 0.0
+
+        // Fluent options.
+        [Toggle(_HOVER_LIGHT)] _HoverLight("Hover Light", Float) = 0.0
+        [Toggle(_HOVER_COLOR_OVERRIDE)] _EnableHoverColorOverride("Hover Color Override", Float) = 0.0
+        _HoverColorOverride("Hover Color Override", Color) = (1.0, 1.0, 1.0, 1.0)
+        [Toggle(_PROXIMITY_LIGHT)] _ProximityLight("Proximity Light", Float) = 0.0
+        [Toggle(_PROXIMITY_LIGHT_COLOR_OVERRIDE)] _EnableProximityLightColorOverride("Proximity Light Color Override", Float) = 0.0
+        [HDR]_ProximityLightCenterColorOverride("Proximity Light Center Color Override", Color) = (1.0, 0.0, 0.0, 0.0)
+        [HDR]_ProximityLightMiddleColorOverride("Proximity Light Middle Color Override", Color) = (0.0, 1.0, 0.0, 0.5)
+        [HDR]_ProximityLightOuterColorOverride("Proximity Light Outer Color Override", Color) = (0.0, 0.0, 1.0, 1.0)
+        [Toggle(_PROXIMITY_LIGHT_SUBTRACTIVE)] _ProximityLightSubtractive("Proximity Light Subtractive", Float) = 0.0
+        [Toggle(_PROXIMITY_LIGHT_TWO_SIDED)] _ProximityLightTwoSided("Proximity Light Two Sided", Float) = 0.0
+        _FluentLightIntensity("Fluent Light Intensity", Range(0.0, 1.0)) = 1.0
+        [Toggle(_ROUND_CORNERS)] _RoundCorners("Round Corners", Float) = 0.0
+        _RoundCornerRadius("Round Corner Radius", Range(0.0, 0.5)) = 0.25
+        _RoundCornerMargin("Round Corner Margin", Range(0.0, 0.5)) = 0.01
+        [Toggle(_INDEPENDENT_CORNERS)] _IndependentCorners("Independent Corners", Float) = 0.0
+        _RoundCornersRadius("Round Corners Radius", Vector) = (0.5 ,0.5, 0.5, 0.5)
+        [Toggle(_ROUND_CORNERS_HIDE_INTERIOR)] _RoundCornersHideInterior("Hide Interior", Float) = 0.0
+        [Toggle(_BORDER_LIGHT)] _BorderLight("Border Light", Float) = 0.0
+        [Toggle(_BORDER_LIGHT_REPLACES_ALBEDO)] _BorderLightReplacesAlbedo("Border Light Replaces Albedo", Float) = 0.0
+        [Toggle(_BORDER_LIGHT_OPAQUE)] _BorderLightOpaque("Border Light Opaque", Float) = 0.0
+        _BorderWidth("Border Width", Range(0.0, 1.0)) = 0.1
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.BorderColorMode)] _BorderColorMode("Border Color Mode", Float) = 0 // "Brightness"
+        _BorderMinValue("Border Min Value", Range(0.0, 1.0)) = 0.1
+        _BorderColor("Border Color", Color) = (1.0, 1.0, 1.0, 0.0)
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.EdgeSmoothingMode)] _EdgeSmoothingMode("Edge Smoothing Mode", Float) = 0 // "Manual"
+        _EdgeSmoothingValue("Edge Smoothing Value", Float) = 0.002
+        _BorderLightOpaqueAlpha("Border Light Opaque Alpha", Range(0.0, 1.0)) = 1.0
+        [Toggle(_INNER_GLOW)] _InnerGlow("Inner Glow", Float) = 0.0
+        _InnerGlowColor("Inner Glow Color (RGB) and Intensity (A)", Color) = (1.0, 1.0, 1.0, 0.75)
+        _InnerGlowPower("Inner Glow Power", Range(2.0, 32.0)) = 4.0
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.GradientMode)] _GradientMode("Gradient Mode", Float) = 0 // "None"
+        [NoScaleOffset] _IridescentSpectrumMap("Iridescent Spectrum Map", 2D) = "white" {}
+        _IridescenceIntensity("Iridescence Intensity", Range(0.0, 1.0)) = 0.5
+        _IridescenceThreshold("Iridescence Threshold", Range(0.0, 1.0)) = 0.05
+        _IridescenceAngle("Iridescence Angle", Range(-0.78, 0.78)) = -0.78
+        _GradientAngle("Gradient Angle", Range(0, 360.0)) = 180
+        _GradientColor0("Gradient Color 0", Color) = (0.631373, 0.631373, 0.631373, 0.0)
+        _GradientColor1("Gradient Color 1", Color) = (1.0, 0.690196, 0.976471, 0.25)
+        _GradientColor2("Gradient Color 2", Color) = (0.0, 0.33, 0.88, 0.5)
+        _GradientColor3("Gradient Color 3", Color) = (0.0, 0.33, 0.88, 1.0)
+        _GradientColor4("Gradient Color 4", Color) = (1.0, 1.0, 1.0, 1.0)
+        _GradientAlpha("Gradient Alpha", Vector) = (1.0, 1.0, 1.0, 1.0)
+        _GradientAlphaTime("Gradient Alpha Time", Vector) = (0.0, 0.0, 0.0, 0.0)
+        [Toggle(_ENVIRONMENT_COLORING)] _EnvironmentColoring("Environment Coloring", Float) = 0.0
+        _EnvironmentColorThreshold("Environment Color Threshold", Range(0.0, 3.0)) = 1.5
+        _EnvironmentColorIntensity("Environment Color Intensity", Range(0.0, 1.0)) = 0.5
+        _EnvironmentColorX("Environment Color X (RGB)", Color) = (1.0, 0.0, 0.0, 1.0)
+        _EnvironmentColorY("Environment Color Y (RGB)", Color) = (0.0, 1.0, 0.0, 1.0)
+        _EnvironmentColorZ("Environment Color Z (RGB)", Color) = (0.0, 0.0, 1.0, 1.0)
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.BlurMode)] _BlurMode("Blur Mode", Float) = 0 // "None"
+        _BlurTextureIntensity("Blur Texture Intensity", Range(0.0, 1.0)) = 1.0
+        _BlurBorderIntensity("Blur Border Intensity", Range(0.0, 1.0)) = 0.0
+        _BlurBackgroundRect("Blur Background Rect", Vector) = (0.0, 0.0, 1.0, 1.0)
+
+        // Advanced options.
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.RenderingMode)] _Mode("Rendering Mode", Float) = 3          // "Transparent"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.RenderingMode)] _CustomMode("Mode", Float) = 2              // "Fade"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                                  // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 10                            // "OneMinusSrcAlpha"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1                       // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1                  // "One"
+        [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0                                  // "Add"
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4                                 // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 0              // "Off"
+        _ZOffsetFactor("Depth Offset Factor", Float) = 0                                                              // "Zero"
+        _ZOffsetUnits("Depth Offset Units", Float) = 0                                                                // "Zero"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.ColorWriteMask)] _ColorMask("Color Write Mask", Float) = 15 // "All"
+        [Enum(UnityEngine.Rendering.CullMode)] _CullMode("Cull Mode", Float) = 0                                      // "Off"
+        _RenderQueueOverride("Render Queue Override", Range(-1.0, 5000)) = -1
+        [Toggle(_USE_WORLD_SCALE)] _UseWorldScale("Absolute Size", Float) = 1.0
+        [Toggle(_STENCIL)] _EnableStencil("Enable Stencil Testing", Float) = 0.0
+        _Stencil("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComp("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOp("Stencil Operation", Int) = 0
+        _StencilWriteMask("Stencil Write Mask", Range(0, 255)) = 255
+        _StencilReadMask("Stencil Read Mask", Range(0, 255)) = 255
+        _ClipRect("Clip Rect", Vector) = (-32767.0, -32767.0, 32767.0, 32767.0)
+        _ClipRectRadii("Clip Rect Radii", Vector) = (10.0, 10.0, 10.0, 10.0)
+    }
+
+    /// <summary>
+    /// Sub Shader for the Universal Render Pipeline (URP).
+    /// </summary>
+    SubShader
+    {
+        PackageRequirements
+        {
+            "com.unity.render-pipelines.universal": "12.1.0"
+        }
+
+        Tags
+        {
+            "RenderPipeline" = "UniversalPipeline"
+            "Queue" = "Transparent"
+            "IgnoreProjector" = "True"
+            "RenderType" = "Fade"
+            "PreviewType" = "Plane"
+            "CanUseSpriteAtlas" = "True"
+        }
+
+        // Default pass (no meta pass needed for UI).
+        Pass
+        {
+            Name "Main"
+            Tags{ "LightMode" = "UniversalForward" }
+            LOD 100
+            Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+            BlendOp[_BlendOp]
+            ZTest[_ZTest]
+            ZWrite[_ZWrite]
+            Cull[_CullMode]
+            Offset[_ZOffsetFactor],[_ZOffsetUnits]
+            ColorMask[_ColorMask]
+
+            Stencil
+            {
+                Ref[_Stencil]
+                Comp[_StencilComp]
+                Pass[_StencilOp]
+                ReadMask[_StencilReadMask]
+                WriteMask[_StencilWriteMask]
+            }
+
+            HLSLPROGRAM
+
+            #define _URP
+            #define _CANVAS_RENDERED
+
+            #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
+            #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+            #pragma multi_compile_local _ UNITY_UI_ALPHACLIP
+
+            #define _NON_SRP
+            #include_with_pragmas "GraphicsToolsStandardProgram.hlsl"
+
+            ENDHLSL
+        }
+    }
+    
+    /// <summary>
+    /// Sub Shader for the Built-in Render Pipeline.
+    /// </summary>
+    SubShader
+    {
+        Tags
+        {
+            "Queue" = "Transparent"
+            "IgnoreProjector" = "True"
+            "RenderType" = "Fade"
+            "PreviewType" = "Plane"
+            "CanUseSpriteAtlas" = "True"
+        }
+
+        // Default pass (no meta pass needed for UI).
+        Pass
+        {
+            Name "Main"
+            Tags{ "LightMode" = "ForwardBase" }
+            LOD 100
+            Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+            BlendOp[_BlendOp]
+            ZTest[_ZTest]
+            ZWrite[_ZWrite]
+            Cull[_CullMode]
+            Offset[_ZOffsetFactor],[_ZOffsetUnits]
+            ColorMask[_ColorMask]
+
+            Stencil
+            {
+                Ref[_Stencil]
+                Comp[_StencilComp]
+                Pass[_StencilOp]
+                ReadMask[_StencilReadMask]
+                WriteMask[_StencilWriteMask]
+            }
+
+            HLSLPROGRAM
+
+            #define _CANVAS_RENDERED
+
+            #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
+            #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+            #pragma multi_compile_local _ UNITY_UI_ALPHACLIP
+            
+            #define _NON_SRP
+            #include_with_pragmas "GraphicsToolsStandardProgram.hlsl"
+
+            ENDHLSL
+        }
+    }
+    
+    CustomEditor "Microsoft.MixedReality.GraphicsTools.Editor.StandardShaderGUI"
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvasNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardCanvasNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: ff5e5f27db353174eb7d3800d7c86f52
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardInput.hlsl
@@ -173,9 +173,9 @@ float4 _ProximityLightData[PROXIMITY_LIGHT_COUNT * PROXIMITY_LIGHT_DATA_SIZE];
 /// <summary>
 /// Per material properties.
 /// </summary>
-
+#ifndef _NON_SRP
 CBUFFER_START(UnityPerMaterial)
-
+#endif
 #if defined(UNITY_INSTANCING_ENABLED)
     half4 _ColorUnused; // Color is defined in the PerMaterialInstanced constant buffer.
 #else
@@ -286,9 +286,9 @@ CBUFFER_START(UnityPerMaterial)
     half _BlurTextureIntensity;
     half _BlurBorderIntensity;
     float4 _BlurBackgroundRect;
-
+#ifndef _NON_SRP
 CBUFFER_END
-
+#endif
 #if defined(UNITY_INSTANCING_ENABLED)
 UNITY_INSTANCING_BUFFER_START(PerMaterialInstanced)
 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardNonSrp.shader
@@ -1,0 +1,421 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/// <summary>
+/// Standard shader configured to work best with Mesh Renderers.
+/// See "Graphics Tools/Standard Canvas" for UnityUI (uGUI) CanvasRenderers support.
+/// </summary>
+Shader "Graphics Tools/Non-SRP/StandardNonSrp"
+{
+    Properties
+    {
+        // Main maps.
+        _Color("Color", Color) = (1.0, 1.0, 1.0, 1.0)
+        _MainTex("Albedo", 2D) = "white" {}
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.AlbedoAlphaMode)] _AlbedoAlphaMode("Albedo Alpha Mode", Float) = 0 // "Transparency"
+        [Toggle] _AlbedoAssignedAtRuntime("Albedo Assigned at Runtime", Float) = 0.0
+        _Cutoff("Alpha Cutoff", Range(0.0, 1.0)) = 0.5
+        _Fade("Alpha Fade", Range(0.0, 1.0)) = 1.0
+        _Metallic("Metallic", Range(0.0, 1.0)) = 0.0
+        _Smoothness("Smoothness", Range(0.0, 1.0)) = 0.5
+        [Toggle(_CHANNEL_MAP)] _EnableChannelMap("Enable Channel Map", Float) = 0.0
+        [NoScaleOffset] _ChannelMap("Channel Map", 2D) = "white" {}
+        [Toggle(_NORMAL_MAP)] _EnableNormalMap("Enable Normal Map", Float) = 0.0
+        [NoScaleOffset] _NormalMap("Normal Map", 2D) = "bump" {}
+        _NormalMapScale("Scale", Float) = 1.0
+        [Toggle(_EMISSION)] _EnableEmission("Enable Emission", Float) = 0.0
+        [HDR]_EmissiveColor("Emissive Color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _EmissiveMap("Emissive Map",2D) = "white" {}
+        [Toggle(_TRIPLANAR_MAPPING)] _EnableTriplanarMapping("Triplanar Mapping", Float) = 0.0
+        [Toggle(_LOCAL_SPACE_TRIPLANAR_MAPPING)] _EnableLocalSpaceTriplanarMapping("Local Space", Float) = 0.0
+        _TriplanarMappingBlendSharpness("Blend Sharpness", Range(1.0, 16.0)) = 4.0
+        [Toggle(_USE_SSAA)] _EnableSSAA("Super Sample Anti Aliasing", Float) = 0.0
+        _MipmapBias("Mipmap Bias", Range(-5.0, 0.0)) = -2.0
+
+        // Rendering options.
+        [Toggle(_DIRECTIONAL_LIGHT)] _DirectionalLight("Light Mode", Float) = 1.0 // "LitDirectional"
+        [Toggle(_SPECULAR_HIGHLIGHTS)] _SpecularHighlights("Specular Highlights", Float) = 1.0
+        [Toggle(_SPHERICAL_HARMONICS)] _SphericalHarmonics("Spherical Harmonics", Float) = 0.0
+        [Toggle(_NON_PHOTOREALISTIC)] _NPR("Non-Photorealistic Rendering", Float) = 0.0
+        [Toggle(_REFLECTIONS)] _Reflections("Reflections", Float) = 0.0
+        [Toggle(_RIM_LIGHT)] _RimLight("Rim Light", Float) = 0.0
+        _RimColor("Rim Color", Color) = (0.5, 0.5, 0.5, 1.0)
+        _RimPower("Rim Power", Range(0.0, 8.0)) = 0.25
+        [Toggle(_VERTEX_COLORS)] _VertexColors("Vertex Colors", Float) = 0.0
+        [Toggle(_VERTEX_EXTRUSION)] _VertexExtrusion("Vertex Extrusion", Float) = 0.0
+        _VertexExtrusionValue("Vertex Extrusion Value", Float) = 0.0
+        [Toggle(_VERTEX_EXTRUSION_SMOOTH_NORMALS)] _VertexExtrusionSmoothNormals("Vertex Extrusion Smooth Normals", Float) = 0.0
+        [Toggle(_VERTEX_EXTRUSION_CONSTANT_WIDTH)] _VertexExtrusionConstantWidth("Vertex Extrusion Constant Width", Float) = 0.0
+        _BlendedClippingWidth("Clipping Alpha Falloff", Range(0.0, 10.0)) = 0.0
+        [Toggle(_CLIPPING_BORDER)] _ClippingBorder("Clipping Border", Float) = 0.0
+        _ClippingBorderWidth("Clipping Border Width", Range(0.0, 1.0)) = 0.025
+        _ClippingBorderColor("Clipping Border Color", Color) = (1.0, 0.2, 0.0, 1.0)
+        [Toggle(_NEAR_PLANE_FADE)] _NearPlaneFade("Near Plane Fade", Float) = 0.0
+        [Toggle(_NEAR_LIGHT_FADE)] _NearLightFade("Near Light Fade", Float) = 0.0
+        _FadeBeginDistance("Fade Begin Distance", Range(0.0, 10.0)) = 0.85
+        _FadeCompleteDistance("Fade Complete Distance", Range(0.0, 10.0)) = 0.5
+        _FadeMinValue("Fade Min Value", Range(0.0, 1.0)) = 0.0
+
+        // Fluent options.
+        [Toggle(_HOVER_LIGHT)] _HoverLight("Hover Light", Float) = 0.0
+        [Toggle(_HOVER_COLOR_OVERRIDE)] _EnableHoverColorOverride("Hover Color Override", Float) = 0.0
+        _HoverColorOverride("Hover Color Override", Color) = (1.0, 1.0, 1.0, 1.0)
+        [Toggle(_PROXIMITY_LIGHT)] _ProximityLight("Proximity Light", Float) = 0.0
+        [Toggle(_PROXIMITY_LIGHT_COLOR_OVERRIDE)] _EnableProximityLightColorOverride("Proximity Light Color Override", Float) = 0.0
+        [HDR]_ProximityLightCenterColorOverride("Proximity Light Center Color Override", Color) = (1.0, 0.0, 0.0, 0.0)
+        [HDR]_ProximityLightMiddleColorOverride("Proximity Light Middle Color Override", Color) = (0.0, 1.0, 0.0, 0.5)
+        [HDR]_ProximityLightOuterColorOverride("Proximity Light Outer Color Override", Color) = (0.0, 0.0, 1.0, 1.0)
+        [Toggle(_PROXIMITY_LIGHT_SUBTRACTIVE)] _ProximityLightSubtractive("Proximity Light Subtractive", Float) = 0.0
+        [Toggle(_PROXIMITY_LIGHT_TWO_SIDED)] _ProximityLightTwoSided("Proximity Light Two Sided", Float) = 0.0
+        _FluentLightIntensity("Fluent Light Intensity", Range(0.0, 1.0)) = 1.0
+        [Toggle(_ROUND_CORNERS)] _RoundCorners("Round Corners", Float) = 0.0
+        _RoundCornerRadius("Round Corner Radius", Range(0.0, 0.5)) = 0.25
+        _RoundCornerMargin("Round Corner Margin", Range(0.0, 0.5)) = 0.01
+        [Toggle(_INDEPENDENT_CORNERS)] _IndependentCorners("Independent Corners", Float) = 0.0
+        _RoundCornersRadius("Round Corners Radius", Vector) = (0.5 ,0.5, 0.5, 0.5)
+        [Toggle(_ROUND_CORNERS_HIDE_INTERIOR)] _RoundCornersHideInterior("Hide Interior", Float) = 0.0
+        [Toggle(_BORDER_LIGHT)] _BorderLight("Border Light", Float) = 0.0
+        [Toggle(_BORDER_LIGHT_REPLACES_ALBEDO)] _BorderLightReplacesAlbedo("Border Light Replaces Albedo", Float) = 0.0
+        [Toggle(_BORDER_LIGHT_OPAQUE)] _BorderLightOpaque("Border Light Opaque", Float) = 0.0
+        _BorderWidth("Border Width", Range(0.0, 1.0)) = 0.1
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.BorderColorMode)] _BorderColorMode("Border Color Mode", Float) = 0 // "Brightness"
+        _BorderMinValue("Border Min Value", Range(0.0, 1.0)) = 0.1
+        _BorderColor("Border Color", Color) = (1.0, 1.0, 1.0, 0.0)
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.EdgeSmoothingMode)] _EdgeSmoothingMode("Edge Smoothing Mode", Float) = 0 // "Manual"
+        _EdgeSmoothingValue("Edge Smoothing Value", Float) = 0.002
+        _BorderLightOpaqueAlpha("Border Light Opaque Alpha", Range(0.0, 1.0)) = 1.0
+        [Toggle(_INNER_GLOW)] _InnerGlow("Inner Glow", Float) = 0.0
+        _InnerGlowColor("Inner Glow Color (RGB) and Intensity (A)", Color) = (1.0, 1.0, 1.0, 0.75)
+        _InnerGlowPower("Inner Glow Power", Range(2.0, 32.0)) = 4.0
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.GradientMode)] _GradientMode("Gradient Mode", Float) = 0 // "None"
+        [NoScaleOffset] _IridescentSpectrumMap("Iridescent Spectrum Map", 2D) = "white" {}
+        _IridescenceIntensity("Iridescence Intensity", Range(0.0, 1.0)) = 0.5
+        _IridescenceThreshold("Iridescence Threshold", Range(0.0, 1.0)) = 0.05
+        _IridescenceAngle("Iridescence Angle", Range(-0.78, 0.78)) = -0.78
+        _GradientAngle("Gradient Angle", Range(0, 360.0)) = 180
+        _GradientColor0("Gradient Color 0", Color) = (0.631373, 0.631373, 0.631373, 0.0)
+        _GradientColor1("Gradient Color 1", Color) = (1.0, 0.690196, 0.976471, 0.25)
+        _GradientColor2("Gradient Color 2", Color) = (0.0, 0.33, 0.88, 0.5)
+        _GradientColor3("Gradient Color 3", Color) = (0.0, 0.33, 0.88, 1.0)
+        _GradientColor4("Gradient Color 4", Color) = (1.0, 1.0, 1.0, 1.0)
+        _GradientAlpha("Gradient Alpha", Vector) = (1.0, 1.0, 1.0, 1.0)
+        _GradientAlphaTime("Gradient Alpha Time", Vector) = (0.0, 0.0, 0.0, 0.0)
+        [Toggle(_ENVIRONMENT_COLORING)] _EnvironmentColoring("Environment Coloring", Float) = 0.0
+        _EnvironmentColorThreshold("Environment Color Threshold", Range(0.0, 3.0)) = 1.5
+        _EnvironmentColorIntensity("Environment Color Intensity", Range(0.0, 1.0)) = 0.5
+        _EnvironmentColorX("Environment Color X (RGB)", Color) = (1.0, 0.0, 0.0, 1.0)
+        _EnvironmentColorY("Environment Color Y (RGB)", Color) = (0.0, 1.0, 0.0, 1.0)
+        _EnvironmentColorZ("Environment Color Z (RGB)", Color) = (0.0, 0.0, 1.0, 1.0)
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.BlurMode)] _BlurMode("Blur Mode", Float) = 0 // "None"
+        _BlurTextureIntensity("Blur Texture Intensity", Range(0.0, 1.0)) = 1.0
+        _BlurBorderIntensity("Blur Border Intensity", Range(0.0, 1.0)) = 0.0
+        _BlurBackgroundRect("Blur Background Rect", Vector) = (0.0, 0.0, 1.0, 1.0)
+
+        // Advanced options.
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.RenderingMode)] _Mode("Rendering Mode", Float) = 0               // "Opaque"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.RenderingMode)] _CustomMode("Mode", Float) = 0                   // "Opaque"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                                       // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0                                  // "Zero"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1                            // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1                       // "One"
+        [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0                                       // "Add"
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4                                      // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1                   // "On"
+        _ZOffsetFactor("Depth Offset Factor", Float) = 0                                                                   // "Zero"
+        _ZOffsetUnits("Depth Offset Units", Float) = 0                                                                     // "Zero"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.ColorWriteMask)] _ColorWriteMask("Color Write Mask", Float) = 15 // "All"
+        [Enum(UnityEngine.Rendering.CullMode)] _CullMode("Cull Mode", Float) = 2                                           // "Back"
+        _RenderQueueOverride("Render Queue Override", Range(-1.0, 5000)) = -1
+        [Toggle(_USE_WORLD_SCALE)] _UseWorldScale("Absolute Size", Float) = 1.0
+        [Toggle(_STENCIL)] _EnableStencil("Enable Stencil Testing", Float) = 0.0
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+        _StencilWriteMask("Stencil Write Mask", Range(0, 255)) = 255
+        _StencilReadMask("Stencil Read Mask", Range(0, 255)) = 255
+    }
+
+    /// <summary>
+    /// Sub Shader for the Universal Render Pipeline (URP).
+    /// </summary>
+    SubShader
+    {
+        PackageRequirements
+        {
+            "com.unity.render-pipelines.universal": "12.1.0"
+        }
+
+        Tags
+        { 
+            "RenderPipeline" = "UniversalPipeline"
+            "RenderType" = "Opaque"
+            "DisableBatching" = "False"
+        }
+
+        // Default pass (only pass outside of the editor).
+        Pass
+        {
+            Name "Main"
+            Tags{ "LightMode" = "UniversalForward" }
+            LOD 100
+            Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+            BlendOp[_BlendOp]
+            ZTest[_ZTest]
+            ZWrite[_ZWrite]
+            Cull[_CullMode]
+            Offset[_ZOffsetFactor],[_ZOffsetUnits]
+            ColorMask[_ColorWriteMask]
+
+            Stencil
+            {
+                Ref[_StencilReference]
+                Comp[_StencilComparison]
+                Pass[_StencilOperation]
+                ReadMask[_StencilReadMask]
+                WriteMask[_StencilWriteMask]
+            }
+
+            HLSLPROGRAM
+
+            #define _URP
+
+            #pragma multi_compile_instancing
+            #pragma multi_compile _ LIGHTMAP_ON
+            #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+            #pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+
+            #pragma shader_feature_local_fragment _CLIPPING_BORDER
+
+            #define _NON_SRP
+            #include_with_pragmas "GraphicsToolsStandardProgram.hlsl"
+
+            ENDHLSL
+        }
+
+        // Shadow casting pass.
+        Pass
+        {
+            Name "ShadowCaster"
+            Tags{"LightMode" = "ShadowCaster"}
+
+            ZWrite On
+            ZTest LEqual
+            ColorMask 0
+            Cull[_CullMode]
+
+            HLSLPROGRAM
+        
+            #define _URP
+            #define _SHADOW_PASS
+
+            #pragma multi_compile_instancing
+        
+            #pragma shader_feature_local_fragment _CLIPPING_BORDER
+
+            #define _NON_SRP
+            #include_with_pragmas "GraphicsToolsStandardProgram.hlsl"
+
+            ENDHLSL
+        }
+
+        // Extracts information for lightmapping, GI (emission, albedo, ...)
+        // This pass it not used during regular rendering.
+        Pass
+        {
+            Name "Meta"
+            Tags { "LightMode" = "Meta" }
+
+            HLSLPROGRAM
+
+            #define _URP
+
+            #include_with_pragmas "GraphicsToolsStandardMetaProgram.hlsl"
+            
+            ENDHLSL
+        }
+        
+        // Depth pass.
+        // From Packages/com.unity.render-pipelines.universal/Shader/Lit.hlsl
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            ZWrite On
+            ColorMask R
+            Cull[_Cull]
+
+            HLSLPROGRAM
+#if UNITY_VERSION >= 202230
+            #pragma exclude_renderers gles gles3 glcore
+            #pragma target 4.5
+#else
+            #pragma target 2.0
+#endif
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex DepthOnlyVertex
+            #pragma fragment DepthOnlyFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+
+#if UNITY_VERSION >= 202200
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+#endif
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+#if UNITY_VERSION >= 202230
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+#else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+#endif
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/DepthOnlyPass.hlsl"
+            ENDHLSL
+        }
+        
+        // This pass is used when drawing to a _CameraNormalsTexture texture.
+        // From Packages/com.unity.render-pipelines.universal/Shader/Lit.hlsl
+        Pass
+        {
+            Name "DepthNormals"
+            Tags
+            {
+                "LightMode" = "DepthNormals"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            ZWrite On
+            Cull[_Cull]
+
+            HLSLPROGRAM
+#if UNITY_VERSION >= 202230
+            #pragma target 2.0
+#else
+            #pragma exclude_renderers gles gles3 glcore
+            #pragma target 4.5
+#endif
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex DepthNormalsVertex
+            #pragma fragment DepthNormalsFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _NORMALMAP
+            #pragma shader_feature_local _PARALLAXMAP
+            #pragma shader_feature_local _ _DETAIL_MULX2 _DETAIL_SCALED
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _SMOOTHNESS_TEXTURE_ALBEDO_CHANNEL_A
+
+#if UNITY_VERSION >= 202200
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+#endif
+#if UNITY_VERSION >= 202230
+            // -------------------------------------
+            // Universal Pipeline keywords
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+#endif
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+#if UNITY_VERSION >= 202230
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+#else
+            #pragma multi_compile _ DOTS_INSTANCING_ON
+#endif
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/LitDepthNormalsPass.hlsl"
+            ENDHLSL
+        }
+    }
+    
+    /// <summary>
+    /// Sub Shader for the Built-in Render Pipeline.
+    /// </summary>
+    SubShader
+    {
+        Tags
+        { 
+            "RenderType" = "Opaque"
+            "DisableBatching" = "False"
+        }
+
+        // Default pass (only pass outside of the editor).
+        Pass
+        {
+            Name "Main"
+            Tags{ "LightMode" = "ForwardBase" }
+            LOD 100
+            Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+            BlendOp[_BlendOp]
+            ZTest[_ZTest]
+            ZWrite[_ZWrite]
+            Cull[_CullMode]
+            Offset[_ZOffsetFactor],[_ZOffsetUnits]
+            ColorMask[_ColorWriteMask]
+
+            Stencil
+            {
+                Ref[_StencilReference]
+                Comp[_StencilComparison]
+                Pass[_StencilOperation]
+                ReadMask[_StencilReadMask]
+                WriteMask[_StencilWriteMask]
+            }
+
+            HLSLPROGRAM
+
+            #pragma multi_compile_instancing
+            #pragma multi_compile _ LIGHTMAP_ON
+            #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+            #pragma shader_feature_local_fragment _CLIPPING_BORDER
+
+            #define _NON_SRP
+            #include_with_pragmas "GraphicsToolsStandardProgram.hlsl"
+
+            ENDHLSL
+        }
+
+        // Extracts information for lightmapping, GI (emission, albedo, ...)
+        // This pass it not used during regular rendering.
+        Pass
+        {
+            Name "Meta"
+            Tags { "LightMode" = "Meta" }
+
+            HLSLPROGRAM
+
+            #include_with_pragmas "GraphicsToolsStandardMetaProgram.hlsl"
+
+            ENDHLSL
+        }
+    }
+    
+    CustomEditor "Microsoft.MixedReality.GraphicsTools.Editor.StandardShaderGUI"
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsStandardNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 820ab96634c188e48b297ea1b2d7b3de
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsTextMeshProNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsTextMeshProNonSrp.shader
@@ -1,0 +1,442 @@
+// TextMesh Pro copyright © 2021 Unity Technologies ApS
+// Licensed under the Unity Companion License for Unity-dependent projects--see http://www.unity3d.com/legal/licenses/Unity_Companion_License.
+// Unless expressly provided otherwise, the Software under this license is made available strictly on an “AS IS” BASIS WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. Please review the license for details on these and other terms and conditions.
+
+// Simplified SDF shader:
+// - No Shading Option (bevel / bump / env map)
+// - No Glow Option
+// - Softness is applied on both side of the outline
+
+// Graphics Tools Additions
+// - Single Pass Instanced Stereo Rendering Support
+// - Support for Clipping Primitives (Plane, Sphere, Box)
+// - _SrcBlend and _DstBlend Properties
+// - ZWrite and ZTest Properties
+// - SRP Batcher Support
+// - Text Color Inversion Support for Accessibility
+
+Shader "Graphics Tools/Non-SRP/Text Mesh ProNonSrp" {
+
+Properties {
+    _FaceColor      ("Face Color", Color) = (1,1,1,1)
+    _FaceDilate           ("Face Dilate", Range(-1,1)) = 0
+
+    _OutlineColor   ("Outline Color", Color) = (0,0,0,1)
+    _OutlineWidth         ("Outline Thickness", Range(0,1)) = 0
+    _OutlineSoftness      ("Outline Softness", Range(0,1)) = 0
+
+    _UnderlayColor  ("Border Color", Color) = (0,0,0,.5)
+    _UnderlayOffsetX      ("Border OffsetX", Range(-1,1)) = 0
+    _UnderlayOffsetY      ("Border OffsetY", Range(-1,1)) = 0
+    _UnderlayDilate       ("Border Dilate", Range(-1,1)) = 0
+    _UnderlaySoftness     ("Border Softness", Range(0,1)) = 0
+
+    _WeightNormal         ("Weight Normal", float) = 0
+    _WeightBold           ("Weight Bold", float) = .5
+
+    _ShaderFlags          ("Flags", float) = 0
+    _ScaleRatioA          ("Scale RatioA", float) = 1
+    _ScaleRatioB          ("Scale RatioB", float) = 1
+    _ScaleRatioC          ("Scale RatioC", float) = 1
+
+    _MainTex              ("Font Atlas", 2D) = "white" {}
+    _TextureWidth         ("Texture Width", float) = 512
+    _TextureHeight        ("Texture Height", float) = 512
+    _GradientScale        ("Gradient Scale", float) = 5
+    _ScaleX               ("Scale X", float) = 1
+    _ScaleY               ("Scale Y", float) = 1
+    _PerspectiveFilter    ("Perspective Correction", Range(0, 1)) = 0.875
+    _Sharpness            ("Sharpness", Range(-1,1)) = 0
+
+    _VertexOffsetX        ("Vertex OffsetX", float) = 0
+    _VertexOffsetY        ("Vertex OffsetY", float) = 0
+
+    _ClipRect             ("Clip Rect", vector) = (-32767, -32767, 32767, 32767)
+    _ClipRectRadii        ("Clip Rect Radii", vector) = (10, 10, 10, 10)
+    _MaskSoftnessX        ("Mask SoftnessX", float) = 0
+    _MaskSoftnessY        ("Mask SoftnessY", float) = 0
+    
+    _StencilComp          ("Stencil Comparison", Float) = 8
+    _Stencil              ("Stencil ID", Float) = 0
+    _StencilOp            ("Stencil Operation", Float) = 0
+    _StencilWriteMask     ("Stencil Write Mask", Float) = 255
+    _StencilReadMask      ("Stencil Read Mask", Float) = 255
+    
+    _CullMode             ("Cull Mode", Float) = 0
+    _ColorMask            ("Color Mask", Float) = 15
+
+    [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite                          ("Depth Write", Float) = 0     // Off
+    [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4      // "LessEqual"
+
+    [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                 // "One"
+    [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 10           // "OneMinusSrcAlpha"
+    [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+    [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
+}
+
+SubShader {
+    Tags 
+    {
+        "Queue"="Transparent"
+        "IgnoreProjector"="True"
+        "RenderType"="Transparent"
+    }
+
+
+    Stencil
+    {
+        Ref [_Stencil]
+        Comp [_StencilComp]
+        Pass [_StencilOp] 
+        ReadMask [_StencilReadMask]
+        WriteMask [_StencilWriteMask]
+    }
+
+    Cull [_CullMode]
+    ZWrite[_ZWrite]
+    Lighting Off
+    Fog { Mode Off }
+    ZTest [_ZTest]
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+    ColorMask [_ColorMask]
+
+    Pass {
+        CGPROGRAM
+        #pragma vertex VertShader
+        #pragma fragment PixShader
+        #pragma shader_feature_local __ OUTLINE_ON
+        #pragma shader_feature_local __ UNDERLAY_ON UNDERLAY_INNER
+        #pragma shader_feature_local __ MULTISAMPLE_ON
+
+        #pragma multi_compile_local _ UNITY_UI_CLIP_RECT
+        #pragma multi_compile_local _ _UI_CLIP_RECT_ROUNDED _UI_CLIP_RECT_ROUNDED_INDEPENDENT
+        #pragma multi_compile_local __ UNITY_UI_ALPHACLIP
+
+        #pragma multi_compile_local __ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+        #pragma multi_compile_local __ _INVERT_TEXT_COLOR
+
+        #include "UnityCG.cginc"
+        #include "UnityUI.cginc"
+        #include "GraphicsToolsCommon.hlsl"
+
+#if defined(_CLIPPING_PLANE) || defined(_CLIPPING_SPHERE) || defined(_CLIPPING_BOX)
+        #define _CLIPPING_PRIMITIVE
+#else
+        #undef _CLIPPING_PRIMITIVE
+#endif
+
+        // Direct include from TMPro_Properties.cginc for SRP support and portability.
+
+
+        // UI Editable properties
+        uniform sampler2D    _FaceTex;                    // Alpha : Signed Distance
+        uniform float        _FaceUVSpeedX;
+        uniform float        _FaceUVSpeedY;
+        uniform fixed4        _FaceColor;                    // RGBA : Color + Opacity
+        uniform float        _FaceDilate;                // v[ 0, 1]
+        uniform float        _OutlineSoftness;            // v[ 0, 1]
+        
+        uniform sampler2D    _OutlineTex;                // RGBA : Color + Opacity
+        uniform float        _OutlineUVSpeedX;
+        uniform float        _OutlineUVSpeedY;
+        uniform fixed4        _OutlineColor;                // RGBA : Color + Opacity
+        uniform float        _OutlineWidth;                // v[ 0, 1]
+        
+        uniform float        _Bevel;                        // v[ 0, 1]
+        uniform float        _BevelOffset;                // v[-1, 1]
+        uniform float        _BevelWidth;                // v[-1, 1]
+        uniform float        _BevelClamp;                // v[ 0, 1]
+        uniform float        _BevelRoundness;            // v[ 0, 1]
+        
+        uniform sampler2D    _BumpMap;                    // Normal map
+        uniform float        _BumpOutline;                // v[ 0, 1]
+        uniform float        _BumpFace;                    // v[ 0, 1]
+        
+        uniform samplerCUBE    _Cube;                        // Cube / sphere map
+        uniform fixed4         _ReflectFaceColor;            // RGB intensity
+        uniform fixed4        _ReflectOutlineColor;
+        uniform float3      _EnvMatrixRotation;
+        uniform float4x4    _EnvMatrix;
+        
+        uniform fixed4        _SpecularColor;                // RGB intensity
+        uniform float        _LightAngle;                // v[ 0,Tau]
+        uniform float        _SpecularPower;                // v[ 0, 1]
+        uniform float        _Reflectivity;                // v[ 5, 15]
+        uniform float        _Diffuse;                    // v[ 0, 1]
+        uniform float        _Ambient;                    // v[ 0, 1]
+        
+        uniform fixed4        _UnderlayColor;                // RGBA : Color + Opacity
+        uniform float        _UnderlayOffsetX;            // v[-1, 1]
+        uniform float        _UnderlayOffsetY;            // v[-1, 1]
+        uniform float        _UnderlayDilate;            // v[-1, 1]
+        uniform float        _UnderlaySoftness;            // v[ 0, 1]
+        
+        uniform fixed4         _GlowColor;                    // RGBA : Color + Intensity
+        uniform float         _GlowOffset;                // v[-1, 1]
+        uniform float         _GlowOuter;                    // v[ 0, 1]
+        uniform float         _GlowInner;                    // v[ 0, 1]
+        uniform float         _GlowPower;                    // v[ 1, 1/(1+4*4)]
+        
+        // API Editable properties
+        uniform float         _ShaderFlags;
+        uniform float        _WeightNormal;
+        uniform float        _WeightBold;
+        
+        uniform float        _ScaleRatioA;
+        uniform float        _ScaleRatioB;
+        uniform float        _ScaleRatioC;
+        
+        uniform float        _VertexOffsetX;
+        uniform float        _VertexOffsetY;
+        
+        uniform float        _MaskID;
+        uniform sampler2D    _MaskTex;
+        uniform float4        _MaskCoord;
+
+        // #if defined(UNITY_UI_CLIP_RECT)
+        uniform float4        _ClipRect;    // bottom left(x,y) : top right(z,w)
+        // #if defined(_UI_CLIP_RECT_ROUNDED) || defined(_UI_CLIP_RECT_ROUNDED_INDEPENDENT)
+        float4                _ClipRectRadii;
+        
+        uniform float        _MaskSoftnessX;
+        uniform float        _MaskSoftnessY;
+        
+        // Font Atlas properties
+        uniform sampler2D    _MainTex;
+        uniform float        _TextureWidth;
+        uniform float        _TextureHeight;
+        uniform float         _GradientScale;
+        uniform float        _ScaleX;
+        uniform float        _ScaleY;
+        uniform float        _PerspectiveFilter;
+        uniform float        _Sharpness;
+
+
+        struct vertex_t {
+            UNITY_VERTEX_INPUT_INSTANCE_ID
+            float4    vertex            : POSITION;
+            float3    normal            : NORMAL;
+            fixed4    color            : COLOR;
+#if UNITY_VERSION >= 202300 // Unity 6 (2023)+
+            float4	texcoord0		: TEXCOORD0;
+#else
+            float2    texcoord0        : TEXCOORD0;
+#endif
+            float2    texcoord1        : TEXCOORD1;
+        };
+
+        struct pixel_t {
+            UNITY_VERTEX_INPUT_INSTANCE_ID
+            UNITY_VERTEX_OUTPUT_STEREO
+            float4    vertex            : SV_POSITION;
+            fixed4    faceColor        : COLOR;
+            fixed4    outlineColor    : COLOR1;
+            float4    texcoord0        : TEXCOORD0;            // Texture UV, Mask UV
+            half4    param            : TEXCOORD1;            // Scale(x), BiasIn(y), BiasOut(z), Bias(w)
+            half4    mask            : TEXCOORD2;            // Position in clip space(xy), Softness(zw)
+            #if (UNDERLAY_ON | UNDERLAY_INNER)
+            float4    texcoord1        : TEXCOORD3;            // Texture UV, alpha, reserved
+            half2    underlayParam    : TEXCOORD4;            // Scale(x), Bias(y)
+            #endif
+#if defined(_CLIPPING_PRIMITIVE)
+            float3 worldPosition    : TEXCOORD5;
+#endif
+        };
+
+#if UNITY_VERSION >= 202300 // Unity 6 (2023)+
+		float _UIMaskSoftnessX;
+        float _UIMaskSoftnessY;
+        int _UIVertexColorAlwaysGammaSpace;
+#endif
+
+        pixel_t VertShader(vertex_t input)
+        {
+            pixel_t output;
+
+            UNITY_INITIALIZE_OUTPUT(pixel_t, output);
+            UNITY_SETUP_INSTANCE_ID(input);
+            UNITY_TRANSFER_INSTANCE_ID(input, output);
+            UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+            
+#if UNITY_VERSION >= 202300 // Unity 6 (2023)+
+            float bold = step(input.texcoord0.w, 0);
+#else
+            float bold = step(input.texcoord1.y, 0);
+#endif
+
+            float4 vert = input.vertex;
+            vert.x += _VertexOffsetX;
+            vert.y += _VertexOffsetY;
+            float4 vPosition = UnityObjectToClipPos(vert);
+
+            float2 pixelSize = vPosition.w;
+            pixelSize /= float2(_ScaleX, _ScaleY) * abs(mul((float2x2)UNITY_MATRIX_P, _ScreenParams.xy));
+            
+            float scale = rsqrt(dot(pixelSize, pixelSize));
+#if UNITY_VERSION >= 202300 // Unity 6 (2023)+
+            scale *= abs(input.texcoord0.w) * _GradientScale * (_Sharpness + 1);
+#else
+            scale *= abs(input.texcoord1.y) * _GradientScale * (_Sharpness + 1);
+#endif
+            if(UNITY_MATRIX_P[3][3] == 0) scale = lerp(abs(scale) * (1 - _PerspectiveFilter), scale, abs(dot(UnityObjectToWorldNormal(input.normal.xyz), normalize(WorldSpaceViewDir(vert)))));
+
+            float weight = lerp(_WeightNormal, _WeightBold, bold) / 4.0;
+            weight = (weight + _FaceDilate) * _ScaleRatioA * 0.5;
+
+            float layerScale = scale;
+
+            scale /= 1 + (_OutlineSoftness * _ScaleRatioA * scale);
+            float bias = (0.5 - weight) * scale - 0.5;
+            float outline = _OutlineWidth * _ScaleRatioA * 0.5 * scale;
+
+#if UNITY_VERSION >= 202300 // Unity 6 (2023)+
+            if (_UIVertexColorAlwaysGammaSpace && !IsGammaSpace())
+            {
+                input.color.rgb = UIGammaToLinear(input.color.rgb);
+            }
+#endif
+            float opacity = input.color.a;
+            #if (UNDERLAY_ON | UNDERLAY_INNER)
+            opacity = 1.0;
+            #endif
+
+            fixed4 faceColor = fixed4(input.color.rgb, opacity) * _FaceColor;
+            #if (_INVERT_TEXT_COLOR)
+            // Force the face color to white so that `Blend OneMinusDstColor OneMinusSrcColor` performs a true inverted blend.
+            faceColor.rgb = fixed3(1, 1, 1);
+            #endif
+            faceColor.rgb *= faceColor.a;
+
+            fixed4 outlineColor = _OutlineColor;
+            //#if (_INVERT_TEXT_COLOR)
+            // TBD, need to design how the outline color should be altered. 
+            //outlineColor.rgb = fixed3(1, 1, 1) - outlineColor.rgb;
+            //#endif
+            outlineColor.a *= opacity;
+            outlineColor.rgb *= outlineColor.a;
+            outlineColor = lerp(faceColor, outlineColor, sqrt(min(1.0, (outline * 2))));
+
+            #if (UNDERLAY_ON | UNDERLAY_INNER)
+            layerScale /= 1 + ((_UnderlaySoftness * _ScaleRatioC) * layerScale);
+            float layerBias = (.5 - weight) * layerScale - .5 - ((_UnderlayDilate * _ScaleRatioC) * .5 * layerScale);
+
+            float x = -(_UnderlayOffsetX * _ScaleRatioC) * _GradientScale / _TextureWidth;
+            float y = -(_UnderlayOffsetY * _ScaleRatioC) * _GradientScale / _TextureHeight;
+            float2 layerOffset = float2(x, y);
+            #endif
+
+            // Generate UV for the Masking Texture
+            float4 clampedRect = clamp(_ClipRect, -2e10, 2e10);
+            float2 maskUV = (vert.xy - clampedRect.xy) / (clampedRect.zw - clampedRect.xy);
+
+            // Populate structure for pixel shader
+            output.vertex = vPosition;
+            output.faceColor = faceColor;
+            output.outlineColor = outlineColor;
+            output.texcoord0 = float4(input.texcoord0.x, input.texcoord0.y, maskUV.x, maskUV.y);
+            output.param = half4(scale, bias - outline, bias + outline, bias);
+            output.mask = vert;
+// #if UNITY_VERSION >= 202300 // Unity 6 (2023)+
+//             const half2 maskSoftness = half2(max(_UIMaskSoftnessX, _MaskSoftnessX), max(_UIMaskSoftnessY, _MaskSoftnessY));
+//             output.mask = half4(vert.xy * 2 - clampedRect.xy - clampedRect.zw, 0.25 / (0.25 * maskSoftness + pixelSize.xy));
+// #else
+//             output.mask = half4(vert.xy * 2 - clampedRect.xy - clampedRect.zw, 0.25 / (0.25 * half2(_MaskSoftnessX, _MaskSoftnessY) + pixelSize.xy));
+// #endif
+            #if (UNDERLAY_ON || UNDERLAY_INNER)
+            output.texcoord1 = float4(input.texcoord0 + layerOffset, input.color.a, 0);
+            output.underlayParam = half2(layerScale, layerBias);
+            #endif
+#if defined(_CLIPPING_PRIMITIVE)
+            output.worldPosition = mul(UNITY_MATRIX_M, vert).xyz;
+#endif
+
+            return output;
+        }
+
+        float4 Tex2DMultisample(sampler2D tex, float2 uv)
+        {
+            float2 dx = ddx(uv) * 0.25;
+            float2 dy = ddy(uv) * 0.25;
+
+            float4 sample0 = tex2D(tex, uv + dx + dy);
+            float4 sample1 = tex2D(tex, uv + dx - dy);
+            float4 sample2 = tex2D(tex, uv - dx + dy);
+            float4 sample3 = tex2D(tex, uv - dx - dy);
+        
+            return (sample0 + sample1 + sample2 + sample3) * 0.25;
+        }
+
+        // PIXEL SHADER
+        fixed4 PixShader(pixel_t input) : SV_Target
+        {
+            UNITY_SETUP_INSTANCE_ID(input);
+            
+            #if MULTISAMPLE_ON
+            half d = Tex2DMultisample(_MainTex, input.texcoord0.xy).a * input.param.x;
+            #else
+            half d = tex2D(_MainTex, input.texcoord0.xy).a * input.param.x;
+            #endif
+
+            half4 c = input.faceColor * saturate(d - input.param.w);
+
+            #ifdef OUTLINE_ON
+            c = lerp(input.outlineColor, input.faceColor, saturate(d - input.param.z));
+            c *= saturate(d - input.param.y);
+            #endif
+
+            #if (UNDERLAY_ON | UNDERLAY_INNER)
+            float4 underlayColor = float4(_UnderlayColor.rgb * _UnderlayColor.a, _UnderlayColor.a);
+            //#if (_INVERT_TEXT_COLOR)
+            // TBD, need to design how the underlay color should be altered. 
+            //underlayColor.rgb = float3(1, 1, 1) - underlayColor.rgb;
+            //#endif
+            #endif
+
+            #if UNDERLAY_ON
+            d = tex2D(_MainTex, input.texcoord1.xy).a * input.underlayParam.x;
+            c += underlayColor * saturate(d - input.underlayParam.y) * (1 - c.a);
+            #endif
+
+            #if UNDERLAY_INNER
+            half sd = saturate(d - input.param.z);
+            d = tex2D(_MainTex, input.texcoord1.xy).a * input.underlayParam.x;
+            c += underlayColor * (1 - saturate(d - input.underlayParam.y)) * sd * (1 - c.a);
+            #endif
+
+            #if defined(UNITY_UI_CLIP_RECT)
+            //half2 m = saturate((_ClipRect.zw - _ClipRect.xy - abs(input.mask.xy)) * input.mask.zw);
+            //c *= m.x * m.y;
+            c *= GTUnityUIClipRect(input.mask.xy, _ClipRect, _ClipRectRadii);
+            #endif
+
+            #if (UNDERLAY_ON | UNDERLAY_INNER)
+            c *= input.texcoord1.z;
+            #endif
+
+            // Primitive clipping.
+#if defined(_CLIPPING_PRIMITIVE)
+            float primitiveDistance = 1.0;
+#if defined(_CLIPPING_PLANE)
+            primitiveDistance = min(primitiveDistance, GTPointVsPlane(input.worldPosition, _ClipPlane) * _ClipPlaneSide);
+#endif
+#if defined(_CLIPPING_SPHERE)
+            primitiveDistance = min(primitiveDistance, GTPointVsSphere(input.worldPosition, _ClipSphereInverseTransform) * _ClipSphereSide);
+#endif
+#if defined(_CLIPPING_BOX)
+            primitiveDistance = min(primitiveDistance, GTPointVsBox(input.worldPosition, _ClipBoxInverseTransform) * _ClipBoxSide);
+#endif
+            c *= step(0.0, primitiveDistance);
+#endif
+
+            #if UNITY_UI_ALPHACLIP
+            clip(c.a - 0.001);
+            #endif
+
+            return c;
+        }
+        ENDCG
+    }
+}
+
+CustomEditor "Microsoft.MixedReality.GraphicsTools.Editor.TextMeshProShaderGUI"
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsTextMeshProNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsTextMeshProNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 538bd9d5f27d149488af9815d7929b71
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsWireframeNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsWireframeNonSrp.shader
@@ -1,0 +1,167 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/// <summary>
+/// Displays a mesh's triagles based on the approach described in Shader-Based Wireframe Drawing (2008)
+/// http://orbit.dtu.dk/en/publications/id(13e2122d-bec7-48de-beca-03ce6ea1c3f1).html
+/// </summary>
+Shader "Graphics Tools/Non-SRP/WireframeNonSrp"
+{
+    Properties
+    {
+        // Rendering options.
+        _BaseColor("Base color", Color) = (0.0, 0.0, 0.0, 1.0)
+        _WireColor("Wire color", Color) = (1.0, 1.0, 1.0, 1.0)
+        _WireThickness("Wire thickness", Range(0, 800)) = 100
+
+        // Advanced options.
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.RenderingMode)] _Mode("Rendering Mode", Float) = 0 // "Opaque"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.RenderingMode)] _CustomMode("Mode", Float) = 0     // "Opaque"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1                         // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0                    // "Zero"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1              // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1         // "One"
+        [Enum(UnityEngine.Rendering.BlendOp)] _BlendOp("Blend Operation", Float) = 0                         // "Add"
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4                        // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1     // "On"
+        _ZOffsetFactor("Depth Offset Factor", Float) = 0                                                     // "Zero"
+        _ZOffsetUnits("Depth Offset Units", Float) = 0                                                       // "Zero"
+        [Enum(UnityEngine.Rendering.ColorWriteMask)] _ColorWriteMask("Color Write Mask", Float) = 15         // "All"
+        [Enum(UnityEngine.Rendering.CullMode)] _CullMode("Cull Mode", Float) = 2                             // "Back"
+        _RenderQueueOverride("Render Queue Override", Range(-1.0, 5000)) = -1
+    }
+    SubShader
+    {
+        Tags { "RenderType" = "Opaque" }
+
+        Pass
+        {
+            Name "Main"
+            Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+            BlendOp[_BlendOp]
+            ZTest[_ZTest]
+            ZWrite[_ZWrite]
+            Cull[_CullMode]
+            Offset[_ZOffsetFactor],[_ZOffsetUnits]
+            ColorMask[_ColorWriteMask]
+
+            HLSLPROGRAM
+
+            #pragma vertex vert
+            #pragma geometry geom
+            #pragma fragment frag
+
+            #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+            #if defined(_CLIPPING_PLANE) || defined(_CLIPPING_SPHERE) || defined(_CLIPPING_BOX)
+                #define _CLIPPING_PRIMITIVE
+            #else
+                #undef _CLIPPING_PRIMITIVE
+            #endif
+
+            #include "UnityCG.cginc"
+            #include "GraphicsToolsCommon.hlsl"
+
+
+            float4 _BaseColor;
+            float4 _WireColor;
+            float _WireThickness;
+
+
+            struct v2g
+            {
+                float4 viewPos : SV_POSITION;
+#if defined(_CLIPPING_PRIMITIVE)
+                float3 worldPos : TEXCOORD0;
+#endif
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            v2g vert(appdata_base v)
+            {
+                UNITY_SETUP_INSTANCE_ID(v);
+                v2g o;
+                o.viewPos = UnityObjectToClipPos(v.vertex);
+#if defined(_CLIPPING_PRIMITIVE)
+                o.worldPos = mul(UNITY_MATRIX_M, v.vertex).xyz;
+#endif
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                return o;
+            }
+
+            // inverseW is to counteract the effect of perspective-correct interpolation so that the lines
+            // look the same thickness regardless of their depth in the scene.
+            struct g2f
+            {
+                float4 viewPos : SV_POSITION;
+                float inverseW : TEXCOORD0;
+                float3 dist : TEXCOORD1;
+#if defined(_CLIPPING_PRIMITIVE)
+                float3 worldPos : TEXCOORD2;
+#endif
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            [maxvertexcount(3)]
+            void geom(triangle v2g i[3], inout TriangleStream<g2f> triStream)
+            {
+                // Calculate the vectors that define the triangle from the input points.
+                float2 point0 = i[0].viewPos.xy / i[0].viewPos.w;
+                float2 point1 = i[1].viewPos.xy / i[1].viewPos.w;
+                float2 point2 = i[2].viewPos.xy / i[2].viewPos.w;
+
+                // Calculate the area of the triangle.
+                float2 vector0 = point2 - point1;
+                float2 vector1 = point2 - point0;
+                float2 vector2 = point1 - point0;
+                float area = abs(vector1.x * vector2.y - vector1.y * vector2.x);
+
+                float3 distScale[3];
+                distScale[0] = float3(area / length(vector0), 0, 0);
+                distScale[1] = float3(0, area / length(vector1), 0);
+                distScale[2] = float3(0, 0, area / length(vector2));
+
+                float wireScale = 800 - _WireThickness;
+
+                // Output each original vertex with its distance to the opposing line defined
+                // by the other two vertices.
+                g2f o;
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+                [unroll]
+                for (uint idx = 0; idx < 3; ++idx)
+                {
+                   o.viewPos = i[idx].viewPos;
+                   o.inverseW = 1.0 / o.viewPos.w;
+                   o.dist = distScale[idx] * o.viewPos.w * wireScale;
+#if defined(_CLIPPING_PRIMITIVE)
+                   o.worldPos = i[idx].worldPos;
+#endif
+                   UNITY_TRANSFER_VERTEX_OUTPUT_STEREO(i[idx], o);
+                   triStream.Append(o);
+                }
+            }
+
+            float4 frag(g2f i) : COLOR
+            {
+#if defined(_CLIPPING_PRIMITIVE)
+                ClipAgainstPrimitive(i.worldPos);
+#endif
+
+                // Calculate  minimum distance to one of the triangle lines, making sure to correct
+                // for perspective-correct interpolation.
+                float dist = min(i.dist[0], min(i.dist[1], i.dist[2])) * i.inverseW;
+
+                // Make the intensity of the line very bright along the triangle edges but fall-off very
+                // quickly.
+                float I = exp2(-2 * dist * dist);
+
+                return I * _WireColor + (1 - I) * _BaseColor;
+            }
+
+            ENDHLSL
+        }
+    }
+
+    CustomEditor "Microsoft.MixedReality.GraphicsTools.Editor.WireframeShaderGUI"
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsWireframeNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/GraphicsToolsWireframeNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d5782a985c4b23a42b1d3fdd9de9b783
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplateNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplateNonSrp.shader
@@ -1,0 +1,686 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Non-Canvas/Non-SRP/BackplateNonSrp" {
+
+Properties {
+
+    [Header(Round Rect)]
+        _Radius_("Radius", Range(0,0.5)) = 0.012
+        [Toggle(_LINE_ENABLE_)] _Line_Enable_("Line Enable", Float) = 1
+        _Line_Width_("Line Width", Range(0,1)) = 0.001
+        [Toggle] _Absolute_Sizes_("Absolute Sizes", Float) = 1
+        _Filter_Width_("Filter Width", Range(0,4)) = 1
+        _Base_Color_("Base Color", Color) = (0,0,0,1)
+        _Line_Color_("Line Color", Color) = (0.2,0.262745,0.4,1)
+     
+    [Header(Radii Multipliers)]
+        _Radius_Top_Left_("Radius Top Left", Range(0,1)) = 1
+        _Radius_Top_Right_("Radius Top Right", Range(0,1)) = 1.0
+        _Radius_Bottom_Left_("Radius Bottom Left", Range(0,1)) = 1.0
+        _Radius_Bottom_Right_("Radius Bottom Right", Range(0,1)) = 1.0
+     
+    [Header(Line Highlight)]
+        _Rate_("Rate", Range(0,1)) = 0
+        _Highlight_Color_("Highlight Color", Color) = (0.98,0.98,0.98,1)
+        _Highlight_Width_("Highlight Width", Range(0,2)) = 0
+        _Highlight_Transform_("Highlight Transform", Vector) = (1, 1, 0, 0)
+        _Highlight_("Highlight", Range(0,1)) = 1
+     
+    [Header(Iridescence)]
+        [Toggle(_IRIDESCENCE_ENABLE_)] _Iridescence_Enable_("Iridescence Enable", Float) = 1
+        _Iridescence_Intensity_("Iridescence Intensity", Range(0,1)) = 0.45
+        _Iridescence_Edge_Intensity_("Iridescence Edge Intensity", Range(0,1)) = 1
+        _Iridescence_Tint_("Iridescence Tint", Color) = (1,1,1,1)
+        [NoScaleOffset] _Iridescent_Map_("Iridescent Map", 2D) = "" {}
+        _Angle_("Angle", Range(-90,90)) = -45
+        [Toggle] _Reflected_("Reflected", Float) = 1
+        _Frequency_("Frequency", Range(0,10)) = 1
+        _Vertical_Offset_("Vertical Offset", Range(0,2)) = 0
+     
+    [Header(Gradient)]
+        [Toggle(_GRADIENT_ENABLE_)] _Gradient_Enable_("Gradient Enable", Float) = 1
+        _Gradient_Color_("Gradient Color", Color) = (0.74902,0.74902,0.74902,1)
+        _Top_Left_("Top Left", Color) = (0.00784314,0.294118,0.580392,1)
+        _Top_Right_("Top Right", Color) = (0.305882,0,1,1)
+        _Bottom_Left_("Bottom Left", Color) = (0.133333,0.258824,0.992157,1)
+        _Bottom_Right_("Bottom Right", Color) = (0.176471,0.176471,0.619608,1)
+        [Toggle(_EDGE_ONLY_)] _Edge_Only_("Edge Only", Float) = 0
+        _Edge_Width_("Edge Width", Range(0,1)) = 0.5
+        _Edge_Power_("Edge Power", Range(0,10)) = 1
+        _Line_Gradient_Blend_("Line Gradient Blend", Range(0,1)) = 0.5
+     
+    [Header(Fade)]
+        _Fade_Out_("Fade Out", Range(0,1)) = 1
+     
+    [Header(Antialiasing)]
+        [Toggle(_SMOOTH_EDGES_)] _Smooth_Edges_("Smooth Edges", Float) = 0
+     
+    [Header(Blending)]
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0  // "Zero"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+
+    [Header(Depth)]
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
+}
+
+SubShader {
+    Tags{ "RenderType" = "Opaque" }
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+    ZWrite[_ZWrite]
+    ZTest[_ZTest]
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+
+    Pass
+
+    {
+
+    CGPROGRAM
+
+    #pragma vertex vert
+    #pragma fragment frag
+
+    #pragma multi_compile_instancing
+
+    #pragma target 4.0
+
+    #pragma shader_feature_local _ _SMOOTH_EDGES_
+    #pragma shader_feature_local _ _IRIDESCENCE_ENABLE_
+    #pragma shader_feature_local _ _LINE_ENABLE_
+    #pragma shader_feature_local _ _GRADIENT_ENABLE_
+    #pragma shader_feature_local _ _EDGE_ONLY_
+
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    float _Radius_;
+    //bool _Line_Enable_;
+    float _Line_Width_;
+    int _Absolute_Sizes_;
+    float _Filter_Width_;
+    float4 _Base_Color_;
+    float4 _Line_Color_;
+    float _Radius_Top_Left_;
+    float _Radius_Top_Right_;
+    float _Radius_Bottom_Left_;
+    float _Radius_Bottom_Right_;
+    float _Rate_;
+    half4 _Highlight_Color_;
+    half _Highlight_Width_;
+    float4 _Highlight_Transform_;
+    half _Highlight_;
+    //bool _Iridescence_Enable_;
+    float _Iridescence_Intensity_;
+    float _Iridescence_Edge_Intensity_;
+    half4 _Iridescence_Tint_;
+    sampler2D _Iridescent_Map_;
+    float _Angle_;
+    int _Reflected_;
+    float _Frequency_;
+    float _Vertical_Offset_;
+    //bool _Gradient_Enable_;
+    half4 _Gradient_Color_;
+    half4 _Top_Left_;
+    half4 _Top_Right_;
+    half4 _Bottom_Left_;
+    half4 _Bottom_Right_;
+    //bool _Edge_Only_;
+    half _Edge_Width_;
+    half _Edge_Power_;
+    half _Line_Gradient_Blend_;
+    half _Fade_Out_;
+    //bool _Smooth_Edges_;
+
+
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        half3 normal : NORMAL;
+        float4 tangent : TANGENT;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+        half4 normalWorld : TEXCOORD5;
+        float2 uv : TEXCOORD0;
+        float3 posWorld : TEXCOORD7;
+        float4 tangent : TANGENT;
+        float4 binormal : TEXCOORD6;
+        float4 extra1 : TEXCOORD4;
+        float4 extra2 : TEXCOORD3;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    //BLOCK_BEGIN Object_To_World_Pos 1123
+
+    void Object_To_World_Pos_B1123(
+        float3 Pos_Object,
+        out float3 Pos_World    )
+    {
+        Pos_World=(mul(UNITY_MATRIX_M, float4(Pos_Object, 1)));
+        
+    }
+    //BLOCK_END Object_To_World_Pos
+
+    //BLOCK_BEGIN Round_Rect_Vertex 1165
+
+    void Round_Rect_Vertex_B1165(
+        float2 UV,
+        float Radius,
+        float Margin,
+        float Anisotropy,
+        float Gradient1,
+        float Gradient2,
+        float3 Normal,
+        float4 Color_Scale_Translate,
+        out float2 Rect_UV,
+        out float4 Rect_Parms,
+        out float2 Scale_XY,
+        out float2 Line_UV,
+        out float2 Color_UV_Info    )
+    {
+        Scale_XY = float2(Anisotropy,1.0);
+        Line_UV = (UV - float2(0.5,0.5));
+        Rect_UV = Line_UV * Scale_XY;
+        Rect_Parms.xy = Scale_XY*0.5-float2(Radius,Radius)-float2(Margin,Margin);
+        Rect_Parms.z = Gradient1; //Radius - Line_Width;
+        Rect_Parms.w = Gradient2;
+        Color_UV_Info = (Line_UV + float2(0.5,0.5)) * Color_Scale_Translate.xy + Color_Scale_Translate.zw;
+    }
+    //BLOCK_END Round_Rect_Vertex
+
+    //BLOCK_BEGIN Line_Vertex 1166
+
+    void Line_Vertex_B1166(
+        float2 Scale_XY,
+        float2 UV,
+        float Time,
+        float Rate,
+        float4 Highlight_Transform,
+        out float3 Line_Vertex    )
+    {
+        float angle2 = (Rate*Time) * 2.0 * 3.1416;
+        float sinAngle2 = sin(angle2);
+        float cosAngle2 = cos(angle2);
+        float2 xformUV = UV * Highlight_Transform.xy + Highlight_Transform.zw;
+        Line_Vertex.x = 0.0;
+        Line_Vertex.y = cosAngle2*xformUV.x-sinAngle2*xformUV.y;
+        Line_Vertex.z = 0.0; //sinAngle2*xformUV.x+cosAngle2*xformUV.y;
+    }
+    //BLOCK_END Line_Vertex
+
+    //BLOCK_BEGIN PickDir 1168
+
+    void PickDir_B1168(
+        float Degrees,
+        float3 DirX,
+        float3 DirY,
+        out float3 Dir    )
+    {
+        float a = Degrees*3.14159/180.0;
+        Dir = cos(a)*DirX+sin(a)*DirY;
+    }
+    //BLOCK_END PickDir
+
+    //BLOCK_BEGIN Move_Verts 1167
+
+    void Move_Verts_B1167(
+        float Anisotropy,
+        float3 P,
+        float Radius,
+        out float3 New_P,
+        out float2 New_UV,
+        out float Radial_Gradient,
+        out float3 Radial_Dir    )
+    {
+        float2 UV = P.xy * 2 + 0.5;
+        float2 center = saturate(UV);
+        float2 delta = UV - center;        
+        float2 r2 = 2.0 * float2(Radius / Anisotropy, Radius);        
+        New_UV = center + r2 * (UV - 2 * center + 0.5);
+        New_P = float3(New_UV - 0.5, P.z);      
+        Radial_Gradient = 1.0 - length(delta) * 2.0;
+        Radial_Dir = float3(delta * r2, 0.0);
+    }
+    //BLOCK_END Move_Verts
+
+    //BLOCK_BEGIN Pick_Radius 1138
+
+    void Pick_Radius_B1138(
+        float Radius,
+        float Radius_Top_Left,
+        float Radius_Top_Right,
+        float Radius_Bottom_Left,
+        float Radius_Bottom_Right,
+        float3 Position,
+        out float Result    )
+    {
+        bool whichY = Position.y>0;
+        Result = Position.x<0 ? (whichY ? Radius_Top_Left : Radius_Bottom_Left) : (whichY ? Radius_Top_Right : Radius_Bottom_Right);
+        Result *= Radius;
+    }
+    //BLOCK_END Pick_Radius
+
+    //BLOCK_BEGIN Edge_AA_Vertex 1164
+
+    void Edge_AA_Vertex_B1164(
+        float3 Position_World,
+        float3 Position_Object,
+        float3 Normal_Object,
+        float3 Eye,
+        float Radial_Gradient,
+        float3 Radial_Dir,
+        float3 Tangent,
+        out float Gradient1,
+        out float Gradient2    )
+    {
+        float3 I = (Eye-Position_World);
+        float3 T = UnityObjectToWorldNormal(Tangent);
+        float g = (dot(T,I)<0.0) ? 0.0 : 1.0;
+        if (Normal_Object.z==0) { // edge
+            Gradient1 = Position_Object.z>0.0 ? g : 1.0;
+            Gradient2 = Position_Object.z>0.0 ? 1.0 : g;
+        } else {
+            Gradient1 = g + (1.0-g)*(Radial_Gradient);
+            Gradient2 = 1.0;
+        }
+    }
+    //BLOCK_END Edge_AA_Vertex
+
+    //BLOCK_BEGIN Object_To_World_Dir 1135
+
+    void Object_To_World_Dir_B1135(
+        float3 Dir_Object,
+        out float3 Binormal_World,
+        out float3 Binormal_World_N,
+        out float Binormal_Length    )
+    {
+        Binormal_World = (mul((float3x3)UNITY_MATRIX_M, Dir_Object));
+        Binormal_Length = length(Binormal_World);
+        Binormal_World_N = Binormal_World / Binormal_Length;
+    }
+    //BLOCK_END Object_To_World_Dir
+
+    //BLOCK_BEGIN RelativeOrAbsoluteDetail 1163
+
+    void RelativeOrAbsoluteDetail_B1163(
+        float Nominal_Radius,
+        float Nominal_LineWidth,
+        bool Absolute_Measurements,
+        float Height,
+        out float Radius,
+        out float Line_Width    )
+    {
+        float scale = Absolute_Measurements ? 1.0/Height : 1.0;
+        Radius = Nominal_Radius * scale;
+        Line_Width = Nominal_LineWidth * scale;
+    }
+    //BLOCK_END RelativeOrAbsoluteDetail
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        // Object_To_World_Dir (#1133)
+        float3 Nrm_World_Q1133;
+        Nrm_World_Q1133 = normalize((mul((float3x3)UNITY_MATRIX_M, vertInput.normal)));
+        
+        // Object_To_World_Dir (#1134)
+        float3 Tangent_World_Q1134;
+        float3 Tangent_World_N_Q1134;
+        float Tangent_Length_Q1134;
+        Tangent_World_Q1134 = (mul((float3x3)UNITY_MATRIX_M, float3(1,0,0)));
+        Tangent_Length_Q1134 = length(Tangent_World_Q1134);
+        Tangent_World_N_Q1134 = Tangent_World_Q1134 / Tangent_Length_Q1134;
+
+        float3 Binormal_World_Q1135;
+        float3 Binormal_World_N_Q1135;
+        float Binormal_Length_Q1135;
+        Object_To_World_Dir_B1135(float3(0,1,0),Binormal_World_Q1135,Binormal_World_N_Q1135,Binormal_Length_Q1135);
+
+        float Radius_Q1163;
+        float Line_Width_Q1163;
+        RelativeOrAbsoluteDetail_B1163(_Radius_,_Line_Width_,_Absolute_Sizes_,Binormal_Length_Q1135,Radius_Q1163,Line_Width_Q1163);
+
+        float3 Dir_Q1168;
+        #if defined(_IRIDESCENCE_ENABLE_)
+          PickDir_B1168(_Angle_,Tangent_World_N_Q1134,Binormal_World_N_Q1135,Dir_Q1168);
+        #else
+          Dir_Q1168 = float3(0,0,0);
+        #endif
+
+        float Result_Q1138;
+        Pick_Radius_B1138(Radius_Q1163,_Radius_Top_Left_,_Radius_Top_Right_,_Radius_Bottom_Left_,_Radius_Bottom_Right_,vertInput.vertex.xyz,Result_Q1138);
+
+        // Divide (#1136)
+        float Anisotropy_Q1136 = Tangent_Length_Q1134 / Binormal_Length_Q1135;
+
+        // From_RGBA (#1139)
+        float4 Out_Color_Q1139 = float4(Result_Q1138, Line_Width_Q1163, 0, 1);
+
+        float3 New_P_Q1167;
+        float2 New_UV_Q1167;
+        float Radial_Gradient_Q1167;
+        float3 Radial_Dir_Q1167;
+        Move_Verts_B1167(Anisotropy_Q1136,vertInput.vertex.xyz,Result_Q1138,New_P_Q1167,New_UV_Q1167,Radial_Gradient_Q1167,Radial_Dir_Q1167);
+
+        float3 Pos_World_Q1123;
+        Object_To_World_Pos_B1123(New_P_Q1167,Pos_World_Q1123);
+
+        float Gradient1_Q1164;
+        float Gradient2_Q1164;
+        #if defined(_SMOOTH_EDGES_)
+          Edge_AA_Vertex_B1164(Pos_World_Q1123,vertInput.vertex.xyz,vertInput.normal,_WorldSpaceCameraPos,Radial_Gradient_Q1167,Radial_Dir_Q1167,vertInput.tangent,Gradient1_Q1164,Gradient2_Q1164);
+        #else
+          Gradient1_Q1164 = 1;
+          Gradient2_Q1164 = 1;
+        #endif
+
+        float2 Rect_UV_Q1165;
+        float4 Rect_Parms_Q1165;
+        float2 Scale_XY_Q1165;
+        float2 Line_UV_Q1165;
+        float2 Color_UV_Info_Q1165;
+        Round_Rect_Vertex_B1165(New_UV_Q1167,Result_Q1138,0,Anisotropy_Q1136,Gradient1_Q1164,Gradient2_Q1164,vertInput.normal,float4(1,1,0,0),Rect_UV_Q1165,Rect_Parms_Q1165,Scale_XY_Q1165,Line_UV_Q1165,Color_UV_Info_Q1165);
+
+        float3 Line_Vertex_Q1166;
+        #if defined(_LINE_ENABLE_)
+          Line_Vertex_B1166(Scale_XY_Q1165,Line_UV_Q1165,_Time.y,_Rate_,_Highlight_Transform_,Line_Vertex_Q1166);
+        #else
+          Line_Vertex_Q1166 = float3(0,0,0);
+        #endif
+
+        // To_XY (#1155)
+        float X_Q1155;
+        float Y_Q1155;
+        X_Q1155 = Color_UV_Info_Q1165.x;
+        Y_Q1155 = Color_UV_Info_Q1165.y;
+
+        // From_XYZW (#1154)
+        float4 Vec4_Q1154 = float4(X_Q1155, Y_Q1155, Result_Q1138, Line_Width_Q1163);
+
+        float3 Position = Pos_World_Q1123;
+        float3 Normal = Nrm_World_Q1133;
+        float2 UV = Rect_UV_Q1165;
+        float3 Tangent = Line_Vertex_Q1166;
+        float3 Binormal = Dir_Q1168;
+        float4 Color = Out_Color_Q1139;
+        float4 Extra1 = Rect_Parms_Q1165;
+        float4 Extra2 = Vec4_Q1154;
+        float4 Extra3 = float4(0,0,0,0);
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
+        o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
+        o.uv = UV;
+        o.tangent.xyz = Tangent; o.tangent.w=1.0;
+        o.binormal.xyz = Binormal; o.binormal.w=1.0;
+        o.extra1=Extra1;
+        o.extra2=Extra2;
+
+        return o;
+    }
+
+    //BLOCK_BEGIN Round_Rect_Fragment 1160
+
+    void Round_Rect_Fragment_B1160(
+        half Radius,
+        half Line_Width,
+        half Filter_Width,
+        float2 UV,
+        half4 Rect_Parms,
+        out half InLine    )
+    {
+        float d = length(max(abs(UV)-Rect_Parms.xy,0.0));
+        float dx = max(fwidth(d)*Filter_Width,0.00001);
+        InLine = saturate((d+dx*0.5-max(Radius-Line_Width,d-dx*0.5))/dx);
+    }
+    //BLOCK_END Round_Rect_Fragment
+
+    //BLOCK_BEGIN Smooth_Edges 1162
+
+    void Smooth_Edges_B1162(
+        half Filter_Width,
+        half4 Rect_Parms,
+        out half Inside_Rect    )
+    {
+        float g = min(Rect_Parms.z,Rect_Parms.w);
+        float dgrad = max(fwidth(g)*Filter_Width,0.00001);
+        Inside_Rect = saturate(g/dgrad);
+    }
+    //BLOCK_END Smooth_Edges
+
+    //BLOCK_BEGIN Iridescence 1143
+
+    void Iridescence_B1143(
+        half3 Position,
+        half3 Normal,
+        half2 UV,
+        half3 Axis,
+        half3 Eye,
+        half4 Tint,
+        sampler2D Texture,
+        bool Reflected,
+        half Frequency,
+        half Vertical_Offset,
+        out half4 Color    )
+    {
+        
+        half3 i = normalize(Position-Eye);
+        half3 r = reflect(i,Normal);
+        half idota = dot(i,Axis);
+        half idotr = dot(i,r);
+        
+        half x = Reflected ? idotr : idota;
+        
+        half2 xy;
+        xy.x = frac((x*Frequency+1.0)*0.5 + UV.y*Vertical_Offset);
+        xy.y = 0.5;
+        
+        Color = tex2D(Texture,xy);
+        Color.rgb*=Tint.rgb;
+    }
+    //BLOCK_END Iridescence
+
+    //BLOCK_BEGIN Scale_RGB 1146
+
+    void Scale_RGB_B1146(
+        half4 Color,
+        half Scalar,
+        out half4 Result    )
+    {
+        Result = float4(Scalar,Scalar,Scalar,1) * Color;
+    }
+    //BLOCK_END Scale_RGB
+
+    //BLOCK_BEGIN Scale_RGB 1144
+
+    void Scale_RGB_B1144(
+        half Scalar,
+        half4 Color,
+        out half4 Result    )
+    {
+        Result = float4(Scalar,Scalar,Scalar,1) * Color;
+    }
+    //BLOCK_END Scale_RGB
+
+    //BLOCK_BEGIN Line_Fragment 1157
+
+    void Line_Fragment_B1157(
+        half4 Base_Color,
+        half4 Highlight_Color,
+        half Highlight_Width,
+        half3 Line_Vertex,
+        half Highlight,
+        out half4 Line_Color    )
+    {
+        half k2 = 1.0-saturate(abs(Line_Vertex.y/Highlight_Width));
+        Line_Color = lerp(Base_Color,Highlight_Color,float4(Highlight*k2,Highlight*k2,Highlight*k2,Highlight*k2));
+    }
+    //BLOCK_END Line_Fragment
+
+    //BLOCK_BEGIN Gradient 1158
+
+    void Gradient_B1158(
+        half4 Gradient_Color,
+        half4 Top_Left,
+        half4 Top_Right,
+        half4 Bottom_Left,
+        half4 Bottom_Right,
+        half2 UV,
+        out half4 Result    )
+    {
+        half3 top = Top_Left.rgb + (Top_Right.rgb - Top_Left.rgb)*UV.x;
+        half3 bottom = Bottom_Left.rgb + (Bottom_Right.rgb - Bottom_Left.rgb)*UV.x;
+        Result.rgb = Gradient_Color.rgb * (bottom + (top - bottom)*UV.y);
+        Result.a = 1.0;
+    }
+    //BLOCK_END Gradient
+
+    //BLOCK_BEGIN Edge 1153
+
+    void Edge_B1153(
+        float4 RectParms,
+        half Radius,
+        half Line_Width,
+        float2 UV,
+        half Edge_Width,
+        half Edge_Power,
+        out half Result    )
+    {
+        half d = length(max(abs(UV)-RectParms.xy,0.0));
+        half edge = 1.0-saturate((1.0-d/(Radius-Line_Width))/Edge_Width);
+        Result = pow(edge, Edge_Power);
+        
+    }
+    //BLOCK_END Edge
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+        half4 result;
+
+        half Inside_Rect_Q1162;
+        #if defined(_SMOOTH_EDGES_)
+          Smooth_Edges_B1162(1,fragInput.extra1,Inside_Rect_Q1162);
+        #else
+          Inside_Rect_Q1162 = 1.0;
+        #endif
+
+        // To_XYZW (#1140)
+        float X_Q1140;
+        float Y_Q1140;
+        float Z_Q1140;
+        float W_Q1140;
+        X_Q1140=fragInput.extra2.x;
+        Y_Q1140=fragInput.extra2.y;
+        Z_Q1140=fragInput.extra2.z;
+        W_Q1140=fragInput.extra2.w;
+
+        half4 Color_Q1143;
+        #if defined(_IRIDESCENCE_ENABLE_)
+          Iridescence_B1143(fragInput.posWorld,fragInput.normalWorld.xyz,fragInput.uv,fragInput.binormal.xyz,_WorldSpaceCameraPos,_Iridescence_Tint_,_Iridescent_Map_,_Reflected_,_Frequency_,_Vertical_Offset_,Color_Q1143);
+        #else
+          Color_Q1143 = half4(0,0,0,0);
+        #endif
+
+        half4 Result_Q1144;
+        Scale_RGB_B1144(_Iridescence_Intensity_,Color_Q1143,Result_Q1144);
+
+        half4 Line_Color_Q1157;
+        #if defined(_LINE_ENABLE_)
+          Line_Fragment_B1157(_Line_Color_,_Highlight_Color_,_Highlight_Width_,fragInput.tangent.xyz,_Highlight_,Line_Color_Q1157);
+        #else
+          Line_Color_Q1157 = half4(0,0,0,1);
+        #endif
+
+        half Result_Q1153;
+        #if defined(_EDGE_ONLY_)
+          Edge_B1153(fragInput.extra1,Z_Q1140,W_Q1140,fragInput.uv,_Edge_Width_,_Edge_Power_,Result_Q1153);
+        #else
+          Result_Q1153 = 1;
+        #endif
+
+        // From_XY (#1141)
+        float2 Vec2_Q1141 = float2(X_Q1140,Y_Q1140);
+
+        // Multiply (#1161)
+        half Product_Q1161 = Inside_Rect_Q1162 * _Fade_Out_;
+
+        half InLine_Q1160;
+        #if defined(_LINE_ENABLE_)
+          Round_Rect_Fragment_B1160(Z_Q1140,W_Q1140,_Filter_Width_,fragInput.uv,fragInput.extra1,InLine_Q1160);
+        #else
+          InLine_Q1160 = 0.0;
+        #endif
+
+        half4 Result_Q1158;
+        #if defined(_GRADIENT_ENABLE_)
+          Gradient_B1158(_Gradient_Color_,_Top_Left_,_Top_Right_,_Bottom_Left_,_Bottom_Right_,Vec2_Q1141,Result_Q1158);
+        #else
+          Result_Q1158 = half4(0,0,0,0);
+        #endif
+
+        half4 Result_Q1146;
+        Scale_RGB_B1146(Result_Q1158,Result_Q1153,Result_Q1146);
+
+        // Add_Colors (#1145)
+        half4 Sum_Q1145 = Result_Q1146 + Result_Q1144;
+
+        // Mix_Colors (#1147)
+        half4 Color_At_T_Q1147 = lerp(Line_Color_Q1157, Result_Q1146,float4( _Line_Gradient_Blend_, _Line_Gradient_Blend_, _Line_Gradient_Blend_, _Line_Gradient_Blend_));
+
+        // Add_Colors (#1149)
+        half4 Base_And_Iridescent_Q1149;
+        Base_And_Iridescent_Q1149 = _Base_Color_ + float4(Sum_Q1145.rgb,0.0);
+        
+        // Add_Scaled_Color (#1148)
+        half4 Sum_Q1148 = Color_At_T_Q1147 + _Iridescence_Edge_Intensity_ * Color_Q1143;
+
+        // Set_Alpha (#1150)
+        half4 Result_Q1150 = Sum_Q1148; Result_Q1150.a = 1;
+
+        // Mix_Colors (#1159)
+        half4 Color_At_T_Q1159 = lerp(Base_And_Iridescent_Q1149, Result_Q1150,float4( InLine_Q1160, InLine_Q1160, InLine_Q1160, InLine_Q1160));
+
+        // Scale_Color (#1152)
+        half4 Result_Q1152 = Product_Q1161 * Color_At_T_Q1159;
+
+        float4 Out_Color = Result_Q1152;
+        float Clip_Threshold = 0.001;
+        bool To_sRGB = false;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplateNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplateNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d7ec11829f83e514fa6803a7f877c966
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplateTexNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplateTexNonSrp.shader
@@ -1,0 +1,727 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Non-Canvas/Non-SRP/BackplateTexNonSrp" {
+
+Properties {
+    [Header(Round Rect)]
+        [MainColor] _Base_Color_("Base Color", Color) = (0,0,0,1)
+        _MainTex("Texture", 2D) = "black" {}
+        _Brightness("Texture brightness", Range(0.0, 2.0)) = 1.0
+        [Toggle(_TEXTUREBACKSIDE_ENABLE_)] _TextureBackSide_Enable_("Texture both sides", Float) = 1
+        [Toggle(_TEXTUREGAMMATOLINEAR_ENABLE_)] _TEXTUREGAMMATOLINEAR_ENABLE_("Force texture gamma to linear", Float) = 0
+        _Radius_("Radius", Range(0,0.5)) = 0.012
+        [Toggle(_LINE_ENABLE_)] _Line_Enable_("Line Enable", Float) = 1
+        _Line_Width_("Line Width", Range(0,1)) = 0.001
+        [Toggle] _Absolute_Sizes_("Absolute Sizes", Float) = 1
+        _Filter_Width_("Filter Width", Range(0,4)) = 1
+        _Line_Color_("Line Color", Color) = (0.2,0.262745,0.4,1)
+     
+    [Header(Radii Multipliers)]
+        _Radius_Top_Left_("Radius Top Left", Range(0,1)) = 1
+        _Radius_Top_Right_("Radius Top Right", Range(0,1)) = 1.0
+        _Radius_Bottom_Left_("Radius Bottom Left", Range(0,1)) = 1.0
+        _Radius_Bottom_Right_("Radius Bottom Right", Range(0,1)) = 1.0
+     
+    [Header(Line Highlight)]
+        _Rate_("Rate", Range(0,1)) = 0
+        _Highlight_Color_("Highlight Color", Color) = (0.98,0.98,0.98,1)
+        _Highlight_Width_("Highlight Width", Range(0,2)) = 0
+        _Highlight_Transform_("Highlight Transform", Vector) = (1, 1, 0, 0)
+        _Highlight_("Highlight", Range(0,1)) = 1
+     
+    [Header(Iridescence)]
+        [Toggle(_IRIDESCENCE_ENABLE_)] _Iridescence_Enable_("Iridescence Enable", Float) = 1
+        _Iridescence_Intensity_("Iridescence Intensity", Range(0,1)) = 0.45
+        _Iridescence_Edge_Intensity_("Iridescence Edge Intensity", Range(0,1)) = 1
+        _Iridescence_Tint_("Iridescence Tint", Color) = (1,1,1,1)
+        [NoScaleOffset] _Iridescent_Map_("Iridescent Map", 2D) = "" {}
+        _Angle_("Angle", Range(-90,90)) = -45
+        [Toggle] _Reflected_("Reflected", Float) = 1
+        _Frequency_("Frequency", Range(0,10)) = 1
+        _Vertical_Offset_("Vertical Offset", Range(0,2)) = 0
+     
+    [Header(Gradient)]
+        [Toggle(_GRADIENT_ENABLE_)] _Gradient_Enable_("Gradient Enable", Float) = 1
+        _Gradient_Color_("Gradient Color", Color) = (0.74902,0.74902,0.74902,1)
+        _Top_Left_("Top Left", Color) = (0.00784314,0.294118,0.580392,1)
+        _Top_Right_("Top Right", Color) = (0.305882,0,1,1)
+        _Bottom_Left_("Bottom Left", Color) = (0.133333,0.258824,0.992157,1)
+        _Bottom_Right_("Bottom Right", Color) = (0.176471,0.176471,0.619608,1)
+        [Toggle(_EDGE_ONLY_)] _Edge_Only_("Edge Only", Float) = 0
+        _Edge_Width_("Edge Width", Range(0,1)) = 0.5
+        _Edge_Power_("Edge Power", Range(0,10)) = 1
+        _Line_Gradient_Blend_("Line Gradient Blend", Range(0,1)) = 0.5
+     
+    [Header(Fade)]
+        _Fade_Out_("Fade Out", Range(0,1)) = 1
+     
+    [Header(Antialiasing)]
+        [Toggle(_SMOOTH_EDGES_)] _Smooth_Edges_("Smooth Edges", Float) = 0
+     
+    [Header(Blending)]
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlend("Source Blend", Float) = 1       // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlend("Destination Blend", Float) = 0  // "Zero"
+        [Enum(UnityEngine.Rendering.BlendMode)] _SrcBlendAlpha("Source Blend Alpha", Float) = 1      // "One"
+        [Enum(UnityEngine.Rendering.BlendMode)] _DstBlendAlpha("Destination Blend Alpha", Float) = 1 // "One"
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+
+    [Header(Depth)]
+        [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4 // "LessEqual"
+        [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 1 // "On"
+}
+
+SubShader {
+    Tags{ "RenderType" = "Opaque" }
+    Blend[_SrcBlend][_DstBlend],[_SrcBlendAlpha][_DstBlendAlpha]
+    ZWrite[_ZWrite]
+    ZTest[_ZTest]
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+
+    Pass
+
+    {
+
+    CGPROGRAM
+
+    #pragma vertex vert
+    #pragma fragment frag
+
+    #pragma multi_compile_instancing
+
+    #pragma shader_feature_local _ _WEBSLATE_OVERLAY_ON
+    
+    #pragma target 4.0
+
+    #pragma shader_feature_local _ _SMOOTH_EDGES_
+    #pragma shader_feature_local _ _IRIDESCENCE_ENABLE_
+    #pragma shader_feature_local _ _LINE_ENABLE_
+    #pragma shader_feature_local _ _TEXTUREBACKSIDE_ENABLE_
+    #pragma shader_feature_local _ _TEXTUREGAMMATOLINEAR_ENABLE_
+    #pragma shader_feature_local _ _GRADIENT_ENABLE_
+    #pragma shader_feature_local _ _EDGE_ONLY_
+
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    half4 _Base_Color_;
+    sampler2D _MainTex;
+    float4 _MainTex_ST;
+    float _Brightness;
+    float _Radius_;
+    float _Line_Width_;
+    int _Absolute_Sizes_;
+    float _Filter_Width_;
+    float4 _Line_Color_;
+    float _Radius_Top_Left_;
+    float _Radius_Top_Right_;
+    float _Radius_Bottom_Left_;
+    float _Radius_Bottom_Right_;
+    float _Rate_;
+    half4 _Highlight_Color_;
+    half _Highlight_Width_;
+    float4 _Highlight_Transform_;
+    half _Highlight_;
+    float _Iridescence_Intensity_;
+    float _Iridescence_Edge_Intensity_;
+    half4 _Iridescence_Tint_;
+    sampler2D _Iridescent_Map_;
+    float _Angle_;
+    int _Reflected_;
+    float _Frequency_;
+    float _Vertical_Offset_;
+    half4 _Gradient_Color_;
+    half4 _Top_Left_;
+    half4 _Top_Right_;
+    half4 _Bottom_Left_;
+    half4 _Bottom_Right_;
+    half _Edge_Width_;
+    half _Edge_Power_;
+    half _Line_Gradient_Blend_;
+    half _Fade_Out_;
+
+
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        half3 normal : NORMAL;
+        float4 tangent : TANGENT;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+        half4 normalWorld : TEXCOORD5;
+        float2 uv : TEXCOORD0;
+        float3 st : TEXCOORD1;
+        float3 posWorld : TEXCOORD7;
+        float4 tangent : TANGENT;
+        float4 binormal : TEXCOORD6;
+        float4 extra1 : TEXCOORD4;
+        float4 extra2 : TEXCOORD3;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    //BLOCK_BEGIN Object_To_World_Pos 1123
+
+    void Object_To_World_Pos_B1123(
+        float3 Pos_Object,
+        out float3 Pos_World    )
+    {
+        Pos_World=(mul(UNITY_MATRIX_M, float4(Pos_Object, 1)));
+        
+    }
+    //BLOCK_END Object_To_World_Pos
+
+    //BLOCK_BEGIN Round_Rect_Vertex 1165
+
+    void Round_Rect_Vertex_B1165(
+        float2 UV,
+        float Radius,
+        float Margin,
+        float Anisotropy,
+        float Gradient1,
+        float Gradient2,
+        float3 Normal,
+        float4 Color_Scale_Translate,
+        out float2 Rect_UV,
+        out float4 Rect_Parms,
+        out float2 Scale_XY,
+        out float2 Line_UV,
+        out float2 Color_UV_Info    )
+    {
+        Scale_XY = float2(Anisotropy,1.0);
+        Line_UV = (UV - float2(0.5,0.5));
+        Rect_UV = Line_UV * Scale_XY;
+        Rect_Parms.xy = Scale_XY*0.5-float2(Radius,Radius)-float2(Margin,Margin);
+        Rect_Parms.z = Gradient1; //Radius - Line_Width;
+        Rect_Parms.w = Gradient2;
+        Color_UV_Info = (Line_UV + float2(0.5,0.5)) * Color_Scale_Translate.xy + Color_Scale_Translate.zw;
+    }
+    //BLOCK_END Round_Rect_Vertex
+
+    //BLOCK_BEGIN Line_Vertex 1166
+
+    void Line_Vertex_B1166(
+        float2 Scale_XY,
+        float2 UV,
+        float Time,
+        float Rate,
+        float4 Highlight_Transform,
+        out float3 Line_Vertex    )
+    {
+        float angle2 = (Rate*Time) * 2.0 * 3.1416;
+        float sinAngle2 = sin(angle2);
+        float cosAngle2 = cos(angle2);
+        float2 xformUV = UV * Highlight_Transform.xy + Highlight_Transform.zw;
+        Line_Vertex.x = 0.0;
+        Line_Vertex.y = cosAngle2*xformUV.x-sinAngle2*xformUV.y;
+        Line_Vertex.z = 0.0; //sinAngle2*xformUV.x+cosAngle2*xformUV.y;
+    }
+    //BLOCK_END Line_Vertex
+
+    //BLOCK_BEGIN PickDir 1168
+
+    void PickDir_B1168(
+        float Degrees,
+        float3 DirX,
+        float3 DirY,
+        out float3 Dir    )
+    {
+        float a = Degrees*3.14159/180.0;
+        Dir = cos(a)*DirX+sin(a)*DirY;
+    }
+    //BLOCK_END PickDir
+
+    //BLOCK_BEGIN Move_Verts 1167
+
+    void Move_Verts_B1167(
+        float Anisotropy,
+        float3 P,
+        float Radius,
+        out float3 New_P,
+        out float2 New_UV,
+        out float Radial_Gradient,
+        out float3 Radial_Dir    )
+    {
+        float2 UV = P.xy * 2 + 0.5;
+        float2 center = saturate(UV);
+        float2 delta = UV - center;        
+        float2 r2 = 2.0 * float2(Radius / Anisotropy, Radius);        
+        New_UV = center + r2 * (UV - 2 * center + 0.5);
+        New_P = float3(New_UV - 0.5, P.z);      
+        Radial_Gradient = 1.0 - length(delta) * 2.0;
+        Radial_Dir = float3(delta * r2, 0.0);
+    }
+    //BLOCK_END Move_Verts
+
+    //BLOCK_BEGIN Pick_Radius 1138
+
+    void Pick_Radius_B1138(
+        float Radius,
+        float Radius_Top_Left,
+        float Radius_Top_Right,
+        float Radius_Bottom_Left,
+        float Radius_Bottom_Right,
+        float3 Position,
+        out float Result    )
+    {
+        bool whichY = Position.y>0;
+        Result = Position.x<0 ? (whichY ? Radius_Top_Left : Radius_Bottom_Left) : (whichY ? Radius_Top_Right : Radius_Bottom_Right);
+        Result *= Radius;
+    }
+    //BLOCK_END Pick_Radius
+
+    //BLOCK_BEGIN Edge_AA_Vertex 1164
+
+    void Edge_AA_Vertex_B1164(
+        float3 Position_World,
+        float3 Position_Object,
+        float3 Normal_Object,
+        float3 Eye,
+        float Radial_Gradient,
+        float3 Radial_Dir,
+        float3 Tangent,
+        out float Gradient1,
+        out float Gradient2    )
+    {
+        float3 I = (Eye-Position_World);
+        float3 T = UnityObjectToWorldNormal(Tangent);
+        float g = (dot(T,I)<0.0) ? 0.0 : 1.0;
+        if (Normal_Object.z==0) { // edge
+            Gradient1 = Position_Object.z>0.0 ? g : 1.0;
+            Gradient2 = Position_Object.z>0.0 ? 1.0 : g;
+        } else {
+            Gradient1 = g + (1.0-g)*(Radial_Gradient);
+            Gradient2 = 1.0;
+        }
+    }
+    //BLOCK_END Edge_AA_Vertex
+
+    //BLOCK_BEGIN Object_To_World_Dir 1135
+
+    void Object_To_World_Dir_B1135(
+        float3 Dir_Object,
+        out float3 Binormal_World,
+        out float3 Binormal_World_N,
+        out float Binormal_Length    )
+    {
+        Binormal_World = (mul((float3x3)UNITY_MATRIX_M, Dir_Object));
+        Binormal_Length = length(Binormal_World);
+        Binormal_World_N = Binormal_World / Binormal_Length;
+    }
+    //BLOCK_END Object_To_World_Dir
+
+    //BLOCK_BEGIN RelativeOrAbsoluteDetail 1163
+    
+    void RelativeOrAbsoluteDetail_B1163(
+        float Nominal_Radius,
+        float Nominal_LineWidth,
+        bool Absolute_Measurements,
+        float Height,
+        out float Radius,
+        out float Line_Width    )
+    {
+        float scale = Absolute_Measurements ? 1.0/Height : 1.0;
+        Radius = Nominal_Radius * scale;
+        Line_Width = Nominal_LineWidth * scale;
+    }
+    //BLOCK_END RelativeOrAbsoluteDetail
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        // Object_To_World_Dir (#1133)
+        float3 Nrm_World_Q1133;
+        Nrm_World_Q1133 = normalize((mul((float3x3)UNITY_MATRIX_M, vertInput.normal)));
+        
+        // Object_To_World_Dir (#1134)
+        float3 Tangent_World_Q1134;
+        float3 Tangent_World_N_Q1134;
+        float Tangent_Length_Q1134;
+        Tangent_World_Q1134 = (mul((float3x3)UNITY_MATRIX_M, float3(1,0,0)));
+        Tangent_Length_Q1134 = length(Tangent_World_Q1134);
+        Tangent_World_N_Q1134 = Tangent_World_Q1134 / Tangent_Length_Q1134;
+
+        float3 Binormal_World_Q1135;
+        float3 Binormal_World_N_Q1135;
+        float Binormal_Length_Q1135;
+        Object_To_World_Dir_B1135(float3(0,1,0),Binormal_World_Q1135,Binormal_World_N_Q1135,Binormal_Length_Q1135);
+
+        float Radius_Q1163;
+        float Line_Width_Q1163;
+        RelativeOrAbsoluteDetail_B1163(_Radius_,_Line_Width_,_Absolute_Sizes_,Binormal_Length_Q1135,Radius_Q1163,Line_Width_Q1163);
+
+        float3 Dir_Q1168;
+        #if defined(_IRIDESCENCE_ENABLE_)
+          PickDir_B1168(_Angle_,Tangent_World_N_Q1134,Binormal_World_N_Q1135,Dir_Q1168);
+        #else
+          Dir_Q1168 = float3(0,0,0);
+        #endif
+
+        float Result_Q1138;
+        Pick_Radius_B1138(Radius_Q1163,_Radius_Top_Left_,_Radius_Top_Right_,_Radius_Bottom_Left_,_Radius_Bottom_Right_,vertInput.vertex.xyz,Result_Q1138);
+
+        // Divide (#1136)
+        float Anisotropy_Q1136 = Tangent_Length_Q1134 / Binormal_Length_Q1135;
+
+        // From_RGBA (#1139)
+        float4 Out_Color_Q1139 = float4(Result_Q1138, Line_Width_Q1163, 0, 1);
+
+        float3 New_P_Q1167;
+        float2 New_UV_Q1167;
+        float Radial_Gradient_Q1167;
+        float3 Radial_Dir_Q1167;
+        Move_Verts_B1167(Anisotropy_Q1136,vertInput.vertex.xyz,Result_Q1138,New_P_Q1167,New_UV_Q1167,Radial_Gradient_Q1167,Radial_Dir_Q1167);
+
+        float3 Pos_World_Q1123;
+        Object_To_World_Pos_B1123(New_P_Q1167,Pos_World_Q1123);
+
+        float Gradient1_Q1164;
+        float Gradient2_Q1164;
+        #if defined(_SMOOTH_EDGES_)
+          Edge_AA_Vertex_B1164(Pos_World_Q1123,vertInput.vertex.xyz,vertInput.normal,_WorldSpaceCameraPos,Radial_Gradient_Q1167,Radial_Dir_Q1167,vertInput.tangent,Gradient1_Q1164,Gradient2_Q1164);
+        #else
+          Gradient1_Q1164 = 1;
+          Gradient2_Q1164 = 1;
+        #endif
+
+        float2 Rect_UV_Q1165;
+        float4 Rect_Parms_Q1165;
+        float2 Scale_XY_Q1165;
+        float2 Line_UV_Q1165;
+        float2 Color_UV_Info_Q1165;
+        Round_Rect_Vertex_B1165(New_UV_Q1167,Result_Q1138,0,Anisotropy_Q1136,Gradient1_Q1164,Gradient2_Q1164,vertInput.normal,float4(1,1,0,0),Rect_UV_Q1165,Rect_Parms_Q1165,Scale_XY_Q1165,Line_UV_Q1165,Color_UV_Info_Q1165);
+
+        float3 Line_Vertex_Q1166;
+        #if defined(_LINE_ENABLE_)
+          Line_Vertex_B1166(Scale_XY_Q1165,Line_UV_Q1165,_Time.y,_Rate_,_Highlight_Transform_,Line_Vertex_Q1166);
+        #else
+          Line_Vertex_Q1166 = float3(0,0,0);
+        #endif
+
+        // To_XY (#1155)
+        float X_Q1155;
+        float Y_Q1155;
+        X_Q1155 = Color_UV_Info_Q1165.x;
+        Y_Q1155 = Color_UV_Info_Q1165.y;
+
+        // From_XYZW (#1154)
+        float4 Vec4_Q1154 = float4(X_Q1155, Y_Q1155, Result_Q1138, Line_Width_Q1163);
+
+        float3 Position = Pos_World_Q1123;
+        float3 Normal = Nrm_World_Q1133;
+        float2 UV = Rect_UV_Q1165;
+        float3 Tangent = Line_Vertex_Q1166;
+        float3 Binormal = Dir_Q1168;
+        float4 Color = Out_Color_Q1139;
+        float4 Extra1 = Rect_Parms_Q1165;
+        float4 Extra2 = Vec4_Q1154;
+        float4 Extra3 = float4(0,0,0,0);
+
+        float3 tmp = Position;
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
+        o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
+        o.uv = UV;
+
+        // put back mix into z coord
+        float backside = vertInput.vertex.z > 0.0f ? 1.0f : 0.0f;
+        float2 bottomleft = float2(New_P_Q1167.x + .5f, New_P_Q1167.y + .5f);
+        #if defined(_TEXTUREBACKSIDE_ENABLE_)
+            float2 flippeduv = float2(1.0 - bottomleft.x, bottomleft.y);
+            float2 nuv = lerp(bottomleft, flippeduv, backside);
+            o.st = float3(nuv.x, nuv.y, backside);
+        #else
+            o.st = float3(bottomleft.x, bottomleft.y, backside);
+        #endif
+
+        o.tangent.xyz = Tangent; o.tangent.w=1.0;
+        o.binormal.xyz = Binormal; o.binormal.w=1.0;
+        o.extra1=Extra1;
+        o.extra2=Extra2;
+
+        return o;
+    }
+
+    //BLOCK_BEGIN Round_Rect_Fragment 1160
+
+    void Round_Rect_Fragment_B1160(
+        half Radius,
+        half Line_Width,
+        half Filter_Width,
+        float2 UV,
+        half4 Rect_Parms,
+        out half InLine    )
+    {
+        float d = length(max(abs(UV)-Rect_Parms.xy,0.0));
+        float dx = max(fwidth(d)*Filter_Width,0.00001);
+        InLine = saturate((d+dx*0.5-max(Radius-Line_Width,d-dx*0.5))/dx);
+    }
+    //BLOCK_END Round_Rect_Fragment
+
+    //BLOCK_BEGIN Smooth_Edges 1162
+
+    void Smooth_Edges_B1162(
+        half Filter_Width,
+        half4 Rect_Parms,
+        out half Inside_Rect    )
+    {
+        float g = min(Rect_Parms.z,Rect_Parms.w);
+        float dgrad = max(fwidth(g)*Filter_Width,0.00001);
+        Inside_Rect = saturate(g/dgrad);
+    }
+    //BLOCK_END Smooth_Edges
+
+    //BLOCK_BEGIN Iridescence 1143
+
+    void Iridescence_B1143(
+        half3 Position,
+        half3 Normal,
+        half2 UV,
+        half3 Axis,
+        half3 Eye,
+        half4 Tint,
+        sampler2D Texture,
+        bool Reflected,
+        half Frequency,
+        half Vertical_Offset,
+        out half4 Color    )
+    {
+        
+        half3 i = normalize(Position-Eye);
+        half3 r = reflect(i,Normal);
+        half idota = dot(i,Axis);
+        half idotr = dot(i,r);
+        
+        half x = Reflected ? idotr : idota;
+        
+        half2 xy;
+        xy.x = frac((x*Frequency+1.0)*0.5 + UV.y*Vertical_Offset);
+        xy.y = 0.5;
+        
+        Color = tex2D(Texture,xy);
+        Color.rgb*=Tint.rgb;
+    }
+    //BLOCK_END Iridescence
+
+    //BLOCK_BEGIN Scale_RGB 1146
+
+    void Scale_RGB_B1146(
+        half4 Color,
+        half Scalar,
+        out half4 Result    )
+    {
+        Result = float4(Scalar,Scalar,Scalar,1) * Color;
+    }
+    //BLOCK_END Scale_RGB
+
+    //BLOCK_BEGIN Scale_RGB 1144
+
+    void Scale_RGB_B1144(
+        half Scalar,
+        half4 Color,
+        out half4 Result    )
+    {
+        Result = float4(Scalar,Scalar,Scalar,1) * Color;
+    }
+    //BLOCK_END Scale_RGB
+
+    //BLOCK_BEGIN Line_Fragment 1157
+
+    void Line_Fragment_B1157(
+        half4 Base_Color,
+        half4 Highlight_Color,
+        half Highlight_Width,
+        half3 Line_Vertex,
+        half Highlight,
+        out half4 Line_Color    )
+    {
+        half k2 = 1.0-saturate(abs(Line_Vertex.y/Highlight_Width));
+        Line_Color = lerp(Base_Color,Highlight_Color,float4(Highlight*k2,Highlight*k2,Highlight*k2,Highlight*k2));
+    }
+    //BLOCK_END Line_Fragment
+
+    //BLOCK_BEGIN Gradient 1158
+
+    void Gradient_B1158(
+        half4 Gradient_Color,
+        half4 Top_Left,
+        half4 Top_Right,
+        half4 Bottom_Left,
+        half4 Bottom_Right,
+        half2 UV,
+        out half4 Result    )
+    {
+        half3 top = Top_Left.rgb + (Top_Right.rgb - Top_Left.rgb)*UV.x;
+        half3 bottom = Bottom_Left.rgb + (Bottom_Right.rgb - Bottom_Left.rgb)*UV.x;
+        Result.rgb = Gradient_Color.rgb * (bottom + (top - bottom)*UV.y);
+        Result.a = 1.0;
+    }
+    //BLOCK_END Gradient
+
+    //BLOCK_BEGIN Edge 1153
+
+    void Edge_B1153(
+        float4 RectParms,
+        half Radius,
+        half Line_Width,
+        float2 UV,
+        half Edge_Width,
+        half Edge_Power,
+        out half Result    )
+    {
+        half d = length(max(abs(UV)-RectParms.xy,0.0));
+        half edge = 1.0-saturate((1.0-d/(Radius-Line_Width))/Edge_Width);
+        Result = pow(edge, Edge_Power);
+        
+    }
+    //BLOCK_END Edge
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+        half4 result;
+
+        half Inside_Rect_Q1162;
+        #if defined(_SMOOTH_EDGES_)
+          Smooth_Edges_B1162(1,fragInput.extra1,Inside_Rect_Q1162);
+        #else
+          Inside_Rect_Q1162 = 1.0;
+        #endif
+
+        // To_XYZW (#1140)
+        float X_Q1140;
+        float Y_Q1140;
+        float Z_Q1140;
+        float W_Q1140;
+        X_Q1140=fragInput.extra2.x;
+        Y_Q1140=fragInput.extra2.y;
+        Z_Q1140=fragInput.extra2.z;
+        W_Q1140=fragInput.extra2.w;
+
+        half4 Color_Q1143;
+        #if defined(_IRIDESCENCE_ENABLE_)
+          Iridescence_B1143(fragInput.posWorld,fragInput.normalWorld.xyz,fragInput.uv,fragInput.binormal.xyz,_WorldSpaceCameraPos,_Iridescence_Tint_,_Iridescent_Map_,_Reflected_,_Frequency_,_Vertical_Offset_,Color_Q1143);
+        #else
+          Color_Q1143 = half4(0,0,0,0);
+        #endif
+
+        half4 Result_Q1144;
+        Scale_RGB_B1144(_Iridescence_Intensity_,Color_Q1143,Result_Q1144);
+
+        half4 Line_Color_Q1157;
+        #if defined(_LINE_ENABLE_)
+          Line_Fragment_B1157(_Line_Color_,_Highlight_Color_,_Highlight_Width_,fragInput.tangent.xyz,_Highlight_,Line_Color_Q1157);
+        #else
+          Line_Color_Q1157 = half4(0,0,0,1);
+        #endif
+
+        half Result_Q1153;
+        #if defined(_EDGE_ONLY_)
+          Edge_B1153(fragInput.extra1,Z_Q1140,W_Q1140,fragInput.uv,_Edge_Width_,_Edge_Power_,Result_Q1153);
+        #else
+          Result_Q1153 = 1;
+        #endif
+
+        // From_XY (#1141)
+        float2 Vec2_Q1141 = float2(X_Q1140,Y_Q1140);
+
+        // Multiply (#1161)
+        half Product_Q1161 = Inside_Rect_Q1162 * _Fade_Out_;
+
+        half InLine_Q1160;
+        #if defined(_LINE_ENABLE_)
+          Round_Rect_Fragment_B1160(Z_Q1140,W_Q1140,_Filter_Width_,fragInput.uv,fragInput.extra1,InLine_Q1160);
+        #else
+          InLine_Q1160 = 0.0;
+        #endif
+
+        half4 Result_Q1158;
+        #if defined(_GRADIENT_ENABLE_)
+          Gradient_B1158(_Gradient_Color_,_Top_Left_,_Top_Right_,_Bottom_Left_,_Bottom_Right_,Vec2_Q1141,Result_Q1158);
+        #else
+          Result_Q1158 = half4(0,0,0,0);
+        #endif
+
+        half4 Result_Q1146;
+        Scale_RGB_B1146(Result_Q1158,Result_Q1153,Result_Q1146);
+
+        // Add_Colors (#1145)
+        half4 Sum_Q1145 = Result_Q1146 + Result_Q1144;
+
+        // Mix_Colors (#1147)
+        half4 Color_At_T_Q1147 = lerp(Line_Color_Q1157, Result_Q1146,float4( _Line_Gradient_Blend_, _Line_Gradient_Blend_, _Line_Gradient_Blend_, _Line_Gradient_Blend_));
+
+        // Sample texture
+        half2 st = TRANSFORM_TEX(fragInput.st.xy, _MainTex);
+        half4 tex = tex2D(_MainTex, st);
+
+        #if defined(_TEXTUREGAMMATOLINEAR_ENABLE_)
+            tex.rgb = GammaToLinearSpace(tex.rgb) * _Brightness;
+        #else
+            tex.rgb = tex.rgb * _Brightness;
+        #endif
+
+        #if defined(_TEXTUREBACKSIDE_ENABLE_)
+            tex.a = tex.a;
+        #else
+            tex.a = lerp(tex.a, 0, fragInput.st.z);
+        #endif
+
+        // Add_Colors (#1149)
+        half4 Base_And_Iridescent_Q1149 = lerp(_Base_Color_ + Sum_Q1145, tex, tex.a);
+
+        // Add_Scaled_Color (#1148)
+        half4 Sum_Q1148 = Color_At_T_Q1147 + _Iridescence_Edge_Intensity_ * Color_Q1143;
+
+        // Set_Alpha (#1150)
+        half4 Result_Q1150 = Sum_Q1148; Result_Q1150.a = 1;
+
+        // Mix_Colors (#1159)
+        half4 Color_At_T_Q1159 = lerp(Base_And_Iridescent_Q1149, Result_Q1150,float4( InLine_Q1160, InLine_Q1160, InLine_Q1160, InLine_Q1160));
+
+        // Scale_Color (#1152)
+        half4 Result_Q1152 = Product_Q1161 * Color_At_T_Q1159;
+
+        float4 Out_Color = Result_Q1152;
+        float Clip_Threshold = 0.001;
+        bool To_sRGB = false;
+
+        result = Out_Color;
+
+        // Fix me: migrate this ifdef to a shader feature toggle
+        // we shouldn't have to get this far only to return a transparent pixel
+        #if _WEBSLATE_OVERLAY_ON
+            return half4(0, 0, 0, 0); // filled in by Oculus Compositor Overlay
+        #else
+            return result;
+        #endif
+    }
+
+    ENDCG
+  }
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplateTexNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBackplateTexNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 38d46d3452cb60c4dabd55c6f658def6
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBeveledNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBeveledNonSrp.shader
@@ -1,0 +1,531 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Non-Canvas/Non-SRP/BeveledNonSrp" {
+
+Properties {
+
+    [Header(Round Rect)]
+        _Radius_("Radius", Range(0,0.5)) = 0.15
+        _Bevel_Front_("Bevel Front", Range(0,1)) = 0.035
+        _Bevel_Front_Stretch_("Bevel Front Stretch", Range(0,1)) = 0
+        _Bevel_Back_("Bevel Back", Range(0,1)) = 0.03
+        _Bevel_Back_Stretch_("Bevel Back Stretch", Range(0,1)) = 0
+     
+    [Header(Radii Multipliers)]
+        _Radius_Top_Left_("Radius Top Left", Range(0,1)) = 1
+        _Radius_Top_Right_("Radius Top Right", Range(0,1)) = 1.0
+        _Radius_Bottom_Left_("Radius Bottom Left", Range(0,1)) = 1.0
+        _Radius_Bottom_Right_("Radius Bottom Right", Range(0,1)) = 1.0
+     
+    [Header(Sun)]
+        _Sun_Intensity_("Sun Intensity", Range(0,2)) = 1
+        _Sun_Theta_("Sun Theta", Range(0,1)) = 0.9
+        _Sun_Phi_("Sun Phi", Range(0,1)) = 0.4
+        _Indirect_Diffuse_("Indirect Diffuse", Range(0,1)) = 1
+     
+    [Header(Diffuse And Specular)]
+        _Albedo_("Albedo", Color) = (0.0117647,0.505882,0.996078,1)
+        _Specular_("Specular", Range(0,5)) = 0
+        _Shininess_("Shininess", Range(0,10)) = 10
+        _Sharpness_("Sharpness", Range(0,1)) = 0
+        _Subsurface_("Subsurface", Range(0,1)) = 0
+     
+    [Header(Reflection)]
+        _Reflection_("Reflection", Range(0,2)) = 0.75
+        [Toggle(_FRESNEL_ENABLED_)] _Fresnel_Enabled_("Fresnel Enabled", Float) = 1
+        _Front_Reflect_("Front Reflect", Range(0,1)) = 0
+        _Edge_Reflect_("Edge Reflect", Range(0,1)) = 1
+        _Power_("Power", Range(0,10)) = 1
+     
+    [Header(Sky Environment)]
+        [Toggle(_SKY_ENABLED_)] _Sky_Enabled_("Sky Enabled", Float) = 1
+        _Sky_Color_("Sky Color", Color) = (0.0117647,0.960784,0.996078,1)
+        _Horizon_Color_("Horizon Color", Color) = (0.0117647,0.333333,0.996078,1)
+        _Ground_Color_("Ground Color", Color) = (0,0.254902,0.980392,1)
+        _Horizon_Power_("Horizon Power", Range(0,10)) = 1
+     
+    [Header(Mapped Environment)]
+        [Toggle(_ENV_ENABLE_)] _Env_Enable_("Env Enable", Float) = 0
+        [NoScaleOffset] _Reflection_Map_("Reflection Map", Cube) = "" {}
+        [NoScaleOffset] _Indirect_Environment_("Indirect Environment", Cube) = "" {}
+     
+    [Header(Decal Texture)]
+        [Toggle(_DECAL_ENABLE_)] _Decal_Enable_("Decal Enable", Float) = 0
+        [NoScaleOffset] _Decal_("Decal", 2D) = "" {}
+        _Decal_Scale_XY_("Decal Scale XY", Vector) = (1.5,1.5,0,0)
+        [Toggle] _Decal_Front_Only_("Decal Front Only", Float) = 1
+     
+    [Header(Iridescence)]
+        [Toggle(_IRIDESCENCE_ENABLED_)] _Iridescence_Enabled_("Iridescence Enabled", Float) = 0
+        _Iridescence_Intensity_("Iridescence Intensity", Range(0,1)) = 0
+        [NoScaleOffset] _Iridescence_Texture_("Iridescence Texture", 2D) = "" {}
+     
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+}
+
+SubShader {
+    Tags{ "RenderType" = "Opaque" }
+    Blend Off
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+
+    Pass
+
+    {
+
+    CGPROGRAM
+
+    #pragma vertex vert
+    #pragma fragment frag
+    #pragma multi_compile_instancing
+    #pragma target 4.0
+    #pragma shader_feature_local _ _ENV_ENABLE_
+    #pragma shader_feature_local _ _DECAL_ENABLE_
+    #pragma shader_feature_local _ _IRIDESCENCE_ENABLED_
+    #pragma shader_feature_local _ _FRESNEL_ENABLED_
+    #pragma shader_feature_local _ _SKY_ENABLED_
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #if defined(_CLIPPING_PLANE) || defined(_CLIPPING_SPHERE) || defined(_CLIPPING_BOX)
+        #define _CLIPPING_PRIMITIVE
+    #else
+        #undef _CLIPPING_PRIMITIVE
+    #endif
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    float _Radius_;
+    float _Bevel_Front_;
+    float _Bevel_Front_Stretch_;
+    float _Bevel_Back_;
+    float _Bevel_Back_Stretch_;
+    float _Radius_Top_Left_;
+    float _Radius_Top_Right_;
+    float _Radius_Bottom_Left_;
+    float _Radius_Bottom_Right_;
+    float _Sun_Intensity_;
+    float _Sun_Theta_;
+    float _Sun_Phi_;
+    float _Indirect_Diffuse_;
+    half4 _Albedo_;
+    half _Specular_;
+    half _Shininess_;
+    half _Sharpness_;
+    half _Subsurface_;
+    half _Reflection_;
+    //bool _Fresnel_Enabled_;
+    half _Front_Reflect_;
+    half _Edge_Reflect_;
+    half _Power_;
+    //bool _Sky_Enabled_;
+    half4 _Sky_Color_;
+    half4 _Horizon_Color_;
+    half4 _Ground_Color_;
+    half _Horizon_Power_;
+    //bool _Env_Enable_;
+    samplerCUBE _Reflection_Map_;
+    samplerCUBE _Indirect_Environment_;
+    //bool _Decal_Enable_;
+    sampler2D _Decal_;
+    float2 _Decal_Scale_XY_;
+    int _Decal_Front_Only_;
+    //bool _Iridescence_Enabled_;
+    half _Iridescence_Intensity_;
+    sampler2D _Iridescence_Texture_;
+
+
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        half3 normal : NORMAL;
+        float2 uv0 : TEXCOORD0;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+        half4 normalWorld : TEXCOORD5;
+        float2 uv : TEXCOORD0;
+        float3 posWorld : TEXCOORD7;
+        float4 tangent : TANGENT;
+        float4 binormal : TEXCOORD6;
+        float4 extra1 : TEXCOORD4;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    //BLOCK_BEGIN Move_Verts 1422
+
+    void Move_Verts_B1422(
+        float Anisotropy,
+        float3 P,
+        float Radius,
+        float Bevel,
+        float3 Normal_Object,
+        float ScaleZ,
+        float Stretch,
+        out float3 New_P,
+        out float2 New_UV,
+        out float Radial_Gradient,
+        out float3 Radial_Dir,
+        out float3 New_Normal    )
+    {
+        float2 UV = P.xy * 2 + 0.5;
+        float2 center = saturate(UV);
+        float2 delta = UV - center;
+        float deltad = (length(delta)*2);
+        float f = (Bevel+(Radius-Bevel)*Stretch)/Radius;
+        float innerd = saturate(deltad*2);
+        float outerd = saturate(deltad*2-1);
+        float bevelAngle = outerd*3.14159*0.5;
+        float sinb = sin(bevelAngle);
+        float cosb = cos(bevelAngle);
+        float beveld = (1-f)*innerd + f * sinb;
+        float br = outerd;
+        float2 r2 = 2.0 * float2(Radius / Anisotropy, Radius);
+        
+        float dir = P.z<0.0001 ? 1.0 : -1.0;
+        
+        New_UV = center + r2 * ((0.5-center)+normalize(delta+float2(0.0,0.000001))*beveld*0.5);
+        New_P = float3(New_UV - 0.5, P.z+dir*(1-cosb)*Bevel*ScaleZ);
+                
+        Radial_Gradient = saturate((deltad-0.5)*2);
+        Radial_Dir = float3(delta * r2, 0.0);
+        
+        float3 beveledNormal = cosb*Normal_Object + sinb*float3(delta.x,delta.y,0.0);
+        New_Normal = Normal_Object.z==0 ? Normal_Object : beveledNormal;
+    }
+    //BLOCK_END Move_Verts
+
+    //BLOCK_BEGIN SunDir 1410
+
+    void SunDir_B1410(
+        half Sun_Theta,
+        half Sun_Phi,
+        out half LightDirX,
+        out half LightDirY,
+        out half LightDirZ    )
+    {
+        half theta = Sun_Theta * 2.0 * 3.14159;
+        half phi = Sun_Phi * 3.14159;
+        LightDirX = cos(phi)*cos(theta);
+        LightDirY = sin(phi);
+        LightDirZ = cos(phi)*sin(theta);
+    }
+    //BLOCK_END SunDir
+
+    //BLOCK_BEGIN Pick_Radius 1398
+
+    void Pick_Radius_B1398(
+        float Radius,
+        float Radius_Top_Left,
+        float Radius_Top_Right,
+        float Radius_Bottom_Left,
+        float Radius_Bottom_Right,
+        float3 Position,
+        out float Result    )
+    {
+        bool whichY = Position.y>0;
+        Result = Position.x<0 ? (whichY ? Radius_Top_Left : Radius_Bottom_Left) : (whichY ? Radius_Top_Right : Radius_Bottom_Right);
+        Result *= Radius;
+    }
+    //BLOCK_END Pick_Radius
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        // Tex_Coords (#1400)
+        float2 XY_Q1400;
+        XY_Q1400 = (vertInput.uv0-float2(0.5,0.5))*_Decal_Scale_XY_ + float2(0.5,0.5);
+        
+        // Object_To_World_Dir (#1389)
+        float3 Tangent_World_Q1389;
+        float3 Tangent_World_N_Q1389;
+        float Tangent_Length_Q1389;
+        Tangent_World_Q1389 = (mul((float3x3)UNITY_MATRIX_M, float3(1,0,0)));
+        Tangent_Length_Q1389 = length(Tangent_World_Q1389);
+        Tangent_World_N_Q1389 = Tangent_World_Q1389 / Tangent_Length_Q1389;
+
+        // Object_To_World_Dir (#1419)
+        float3 Normal_World_Q1419;
+        float3 Normal_World_N_Q1419;
+        float Normal_Length_Q1419;
+        Normal_World_Q1419 = (mul((float3x3)UNITY_MATRIX_M, float3(0,0,1)));
+        Normal_Length_Q1419 = length(Normal_World_Q1419);
+        Normal_World_N_Q1419 = Normal_World_Q1419 / Normal_Length_Q1419;
+
+        // To_XYZ (#1420)
+        float X_Q1420;
+        float Y_Q1420;
+        float Z_Q1420;
+        X_Q1420=vertInput.vertex.xyz.x;
+        Y_Q1420=vertInput.vertex.xyz.y;
+        Z_Q1420=vertInput.vertex.xyz.z;
+
+        half LightDirX_Q1410;
+        half LightDirY_Q1410;
+        half LightDirZ_Q1410;
+        SunDir_B1410(_Sun_Theta_,_Sun_Phi_,LightDirX_Q1410,LightDirY_Q1410,LightDirZ_Q1410);
+
+        float Result_Q1398;
+        Pick_Radius_B1398(_Radius_,_Radius_Top_Left_,_Radius_Top_Right_,_Radius_Bottom_Left_,_Radius_Bottom_Right_,vertInput.vertex.xyz,Result_Q1398);
+
+        // Object_To_World_Dir (#1418)
+        float3 Binormal_World_Q1418;
+        float3 Binormal_World_N_Q1418;
+        float Binormal_Length_Q1418;
+        Binormal_World_Q1418 = (mul((float3x3)UNITY_MATRIX_M, float3(0,1,0)));
+        Binormal_Length_Q1418 = length(Binormal_World_Q1418);
+        Binormal_World_N_Q1418 = Binormal_World_Q1418 / Binormal_Length_Q1418;
+
+        // Greater_Than (#1415)
+        bool Greater_Than_Q1415 = Z_Q1420 > 0;
+
+        // Subtract3 (#1397)
+        float3 Difference_Q1397 = float3(0,0,0) - Normal_World_N_Q1419;
+
+        // From_RGBA (#1392)
+        float4 Out_Color_Q1392 = float4(X_Q1420, Y_Q1420, Z_Q1420, 1);
+
+        // Divide (#1390)
+        float Anisotropy_Q1390 = Tangent_Length_Q1389 / Binormal_Length_Q1418;
+
+        // Choose_Bevel (#1411)
+        float Result_Q1411 = Greater_Than_Q1415 ? _Bevel_Back_ : _Bevel_Front_;
+
+        // Divide (#1396)
+        float Anisotropy_Q1396 = Binormal_Length_Q1418 / Normal_Length_Q1419;
+
+        // Choose_Stretch (#1412)
+        float Result_Q1412 = Greater_Than_Q1415 ? _Bevel_Back_Stretch_ : _Bevel_Front_Stretch_;
+
+        float3 New_P_Q1422;
+        float2 New_UV_Q1422;
+        float Radial_Gradient_Q1422;
+        float3 Radial_Dir_Q1422;
+        float3 New_Normal_Q1422;
+        Move_Verts_B1422(Anisotropy_Q1390,vertInput.vertex.xyz,Result_Q1398,Result_Q1411,vertInput.normal,Anisotropy_Q1396,Result_Q1412,New_P_Q1422,New_UV_Q1422,Radial_Gradient_Q1422,Radial_Dir_Q1422,New_Normal_Q1422);
+
+        // Facing (#1421)
+        float Facing_Q1421 = _Decal_Front_Only_ ? (New_Normal_Q1422.z<0.0 ? 1.0 : 0.0) : 1.0;
+
+        // Object_To_World_Pos (#1416)
+        float3 Pos_World_Q1416=(mul(UNITY_MATRIX_M, float4(New_P_Q1422, 1)));
+
+        // Object_To_World_Normal (#1417)
+        float3 Nrm_World_Q1417=UnityObjectToWorldNormal(New_Normal_Q1422);
+
+        // From_XYZW (#1401)
+        float4 Vec4_Q1401 = float4(LightDirX_Q1410, LightDirY_Q1410, LightDirZ_Q1410, Facing_Q1421);
+
+        float3 Position = Pos_World_Q1416;
+        float3 Normal = Nrm_World_Q1417;
+        float2 UV = XY_Q1400;
+        float3 Tangent = Tangent_World_N_Q1389;
+        float3 Binormal = Difference_Q1397;
+        float4 Color = Out_Color_Q1392;
+        float4 Extra1 = Vec4_Q1401;
+        float4 Extra2 = float4(0,0,0,0);
+        float4 Extra3 = float4(0,0,0,0);
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
+        o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
+        o.uv = UV;
+        o.tangent.xyz = Tangent; o.tangent.w=1.0;
+        o.binormal.xyz = Binormal; o.binormal.w=1.0;
+        o.extra1=Extra1;
+
+        return o;
+    }
+
+    //BLOCK_BEGIN Fragment_Main 1425
+
+    void Fragment_Main_B1425(
+        half Sun_Intensity,
+        half Indirect_Diffuse,
+        half3 Normal,
+        half4 Albedo,
+        half Fresnel_Reflect,
+        half Specular,
+        half Shininess,
+        half Sharpness,
+        half Subsurface,
+        half3 Incident,
+        half Reflection,
+        half SSS,
+        half3 Reflected,
+        half4 Light_Dir,
+        half4 Reflection_Sample,
+        half4 Indirect_Sample,
+        half4 Iridescence,
+        out half4 Result    )
+    {
+        half3 lightDir = Light_Dir.xyz;
+        half NdotL = max(dot(lightDir,Normal),0.0);
+        half RdotL = max(0.0,dot(Reflected, lightDir));
+        half specular = pow(RdotL,Shininess);
+        specular = lerp(specular,smoothstep(0.495*Sharpness,1.0-0.495*Sharpness,specular),Sharpness);
+        Result.rgb = ((Sun_Intensity*NdotL + Indirect_Sample.rgb * Indirect_Diffuse)*(1.0 + SSS * Subsurface)) * (1.0-Fresnel_Reflect) * Albedo.rgb + (Sun_Intensity*specular + Fresnel_Reflect * Reflection*Reflection_Sample.rgb) + Iridescence.rgb;
+        Result.a = 1.0;
+    }
+    //BLOCK_END Fragment_Main
+
+    //BLOCK_BEGIN Fast_Fresnel 1409
+
+    void Fast_Fresnel_B1409(
+        half Front_Reflect,
+        half Edge_Reflect,
+        half Power,
+        half3 Normal,
+        half3 Incident,
+        out half Transmit,
+        out half Reflect    )
+    {
+        half d = max(-dot(Incident,Normal),0);
+        Reflect = Front_Reflect+(Edge_Reflect-Front_Reflect)*pow(1-d,Power);
+        Transmit = 1.0 - Reflect;
+    }
+    //BLOCK_END Fast_Fresnel
+
+    //BLOCK_BEGIN Iridescence 1428
+
+    void Iridescence_B1428(
+        half Intensity,
+        sampler2D Texture,
+        half3 Incident,
+        half3 Tangent,
+        out half4 Iridescence    )
+    {
+        half IdotT = dot(Incident, Tangent);
+        float angle = (acos(IdotT)/3.14159-1.0);
+        Iridescence = tex2D(Texture,half2(angle, 0.5))*Intensity;
+    }
+    //BLOCK_END Iridescence
+
+    //BLOCK_BEGIN Sky_Environment 1426
+
+    half4 SampleSky(half3 D, half4 S, half4 H, half4 G, half exponent)
+    {
+        half k = pow(abs(D.y),exponent);
+        half4 C;
+        if (D.y>0.0) {
+            C=lerp(H,S,float4(k,k,k,k));
+        } else {
+            C=lerp(H,G,float4(k,k,k,k));    
+        }
+        return C;
+    }
+    
+    //BLOCK_END Sky_Environment
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+        half4 result;
+
+        // Normalize3 (#1414)
+        half3 NormalN_Q1414 = normalize(fragInput.normalWorld.xyz);
+
+        // Incident3 (#1406)
+        half3 Incident_Q1406 = normalize(fragInput.posWorld - _WorldSpaceCameraPos);
+
+        // SSS (#1407)
+        half Result_Q1407 = abs(abs(dot(NormalN_Q1414,Incident_Q1406)) - abs(dot(fragInput.binormal.xyz,Incident_Q1406)));
+
+        // Reflect (#1408)
+        half3 Reflected_Q1408 = reflect(Incident_Q1406, NormalN_Q1414);
+
+        // Color_Texture (#1429)
+        half4 Decal_Q1429;
+        #if defined(_DECAL_ENABLE_)
+          Decal_Q1429 = tex2D(_Decal_,fragInput.uv) * fragInput.extra1.w;
+        #else
+          Decal_Q1429 = half4(0,0,0,0);
+        #endif
+
+        // Mapped_Environment (#1413)
+        half4 Reflected_Color_Q1413;
+        half4 Indirect_Diffuse_Q1413;
+        #if defined(_ENV_ENABLE_)
+          Reflected_Color_Q1413 = texCUBE(_Reflection_Map_,Reflected_Q1408);
+          Indirect_Diffuse_Q1413 = texCUBE(_Indirect_Environment_,Reflected_Q1408);
+        #else
+          Reflected_Color_Q1413 = half4(0,0,0,1);
+          Indirect_Diffuse_Q1413 = half4(0,0,0,1);
+        #endif
+
+        // Sky_Environment (#1426)
+        half4 Reflected_Color_Q1426;
+        half4 Indirect_Color_Q1426;
+        #if defined(_SKY_ENABLED_)
+          Reflected_Color_Q1426 = SampleSky(Reflected_Q1408,_Sky_Color_,_Horizon_Color_,_Ground_Color_,_Horizon_Power_);
+          Indirect_Color_Q1426 = lerp(_Ground_Color_,_Sky_Color_,float4(NormalN_Q1414.y*0.5+0.5,NormalN_Q1414.y*0.5+0.5,NormalN_Q1414.y*0.5+0.5,NormalN_Q1414.y*0.5+0.5));
+        #else
+          Reflected_Color_Q1426 = half4(0,0,0,1);
+          Indirect_Color_Q1426 = half4(0,0,0,1);
+        #endif
+
+        // Normalize3 (#1427)
+        half3 TangentN_Q1427 = normalize(fragInput.tangent.xyz);
+
+        // Blend_Over (#1430)
+        half4 Decaled_Albedo_Q1430 = Decal_Q1429 + (1.0 - Decal_Q1429.a) * _Albedo_;
+
+        half Transmit_Q1409;
+        half Reflect_Q1409;
+        #if defined(_FRESNEL_ENABLED_)
+          Fast_Fresnel_B1409(_Front_Reflect_,_Edge_Reflect_,_Power_,NormalN_Q1414,Incident_Q1406,Transmit_Q1409,Reflect_Q1409);
+        #else
+          Transmit_Q1409 = 1;
+          Reflect_Q1409 = 0;
+        #endif
+
+        // Add_Colors (#1424)
+        half4 Reflections_Q1424 = Reflected_Color_Q1413 + Reflected_Color_Q1426;
+
+        // Add_Colors (#1423)
+        half4 Indirect_Q1423 = Indirect_Diffuse_Q1413 + Indirect_Color_Q1426;
+
+        half4 Iridescence_Q1428;
+        #if defined(_IRIDESCENCE_ENABLED_)
+          Iridescence_B1428(_Iridescence_Intensity_,_Iridescence_Texture_,Incident_Q1406,TangentN_Q1427,Iridescence_Q1428);
+        #else
+          Iridescence_Q1428 = half4(0,0,0,0);
+        #endif
+
+        half4 Result_Q1425;
+        Fragment_Main_B1425(_Sun_Intensity_,_Indirect_Diffuse_,NormalN_Q1414,Decaled_Albedo_Q1430,Reflect_Q1409,_Specular_,_Shininess_,_Sharpness_,_Subsurface_,Incident_Q1406,_Reflection_,Result_Q1407,Reflected_Q1408,fragInput.extra1,Reflections_Q1424,Indirect_Q1423,Iridescence_Q1428,Result_Q1425);
+
+        float4 Out_Color = Result_Q1425;
+        float Clip_Threshold = 0.001;
+        bool To_sRGB = false;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBeveledNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasBeveledNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: b629955ed709a4d42a8bae0f1c6ef603
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasFrontplateNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasFrontplateNonSrp.shader
@@ -1,0 +1,758 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Non-Canvas/Non-SRP/FrontplateNonSrp" {
+
+Properties {
+
+    [Header(Round Rect)]
+        _Radius_("Radius", Range(0,0.5)) = 0.01
+        _Line_Width_("Line Width", Range(0,1)) = 0.001
+        [Toggle] _Relative_To_Height_("Relative To Height", Float) = 0
+        _Filter_Width_("Filter Width", Range(0,4)) = 1.5
+        _Edge_Color_("Edge Color", Color) = (0.53,0.53,0.53,1)
+     
+    [Header(Fade)]
+        _Fade_Out_("Fade Out", Range(0,1)) = 1
+     
+    [Header(Antialiasing)]
+        [Toggle] _Smooth_Edges_("Smooth Edges", Float) = 1
+     
+    [Header(Blob)]
+        [Toggle] _Blob_Enable_("Blob Enable", Float) = 1
+        [PerRendererData] _Blob_Position_("Blob Position",Vector) = (0,0,0,1)
+        _Blob_Intensity_("Blob Intensity", Range(0,3)) = 0.5
+        _Blob_Near_Size_("Blob Near Size", Range(0,1)) = 0.032
+        _Blob_Far_Size_("Blob Far Size", Range(0,1)) = 0.048
+        _Blob_Near_Distance_("Blob Near Distance", Range(0,1)) = 0.008
+        _Blob_Far_Distance_("Blob Far Distance", Range(0,1)) = 0.064
+        _Blob_Fade_Length_("Blob Fade Length", Range(0,1)) = 0.04
+        _Blob_Inner_Fade_("Blob Inner Fade", Range(0.001,1)) = 0.01
+        [PerRendererData] _Blob_Pulse_("Blob Pulse",Range(0,1)) = 0
+        [PerRendererData] _Blob_Fade_("Blob Fade",Range(0,1)) = 1
+        _Blob_Pulse_Max_Size_("Blob Pulse Max Size", Range(0,1)) = 0.05
+     
+    [Header(Blob 2)]
+        [Toggle] _Blob_Enable_2_("Blob Enable 2", Float) = 1
+        [PerRendererData] _Blob_Position_2_("Blob Position 2",Vector) = (0,0,0,1)
+        _Blob_Near_Size_2_("Blob Near Size 2", Range(0,1)) = 0.008
+        _Blob_Inner_Fade_2_("Blob Inner Fade 2", Range(0,1)) = 0.1
+        [PerRendererData] _Blob_Pulse_2_("Blob Pulse 2",Range(0,1)) = 0
+        [PerRendererData] _Blob_Fade_2_("Blob Fade 2",Range(0,1)) = 1
+     
+    [Header(Gaze)]
+        _Gaze_Intensity_("Gaze Intensity", Range(0,1)) = 0.8
+        [PerRendererData] _Gaze_Focus_("Gaze Focus",Range(0,1)) = 0.0
+        [PerRendererData] _Pinched_("Pinched",Float) = 0.0
+     
+    [Header(Blob Texture)]
+        [NoScaleOffset] _Blob_Texture_("Blob Texture", 2D) = "" {}
+     
+    [Header(Selection)]
+        _Selection_Fuzz_("Selection Fuzz", Range(0,1)) = 0.5
+        _Selected_("Selected", Range(0,1)) = 0
+        _Selection_Fade_("Selection Fade", Range(0,1)) = 0.2
+        _Selection_Fade_Size_("Selection Fade Size", Range(0,1)) = 0.0
+        _Selected_Distance_("Selected Distance", Range(0,1)) = 0.08
+        _Selected_Fade_Length_("Selected Fade Length", Range(0,1)) = 0.08
+     
+    [Header(Proximity)]
+        _Proximity_Max_Intensity_("Proximity Max Intensity", Range(0,1)) = 0.45
+        _Proximity_Far_Distance_("Proximity Far Distance", Range(0,2)) = 0.16
+        _Proximity_Near_Radius_("Proximity Near Radius", Range(0,2)) = 0.016
+        _Proximity_Anisotropy_("Proximity Anisotropy", Range(0,1)) = 1
+     
+    [Header(Global)]
+        [PerRendererData] _Use_Global_Left_Index_("Use Global Left Index",Float) = 1
+        [PerRendererData] _Use_Global_Right_Index_("Use Global Right Index",Float) = 1
+     
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+}
+
+SubShader {
+    Tags { "RenderType" = "Transparent" "Queue" = "Transparent" }
+    Blend One One
+    Cull Off
+    ZWrite Off
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+
+    Pass
+
+    {
+
+    CGPROGRAM
+
+    #pragma vertex vert
+    #pragma fragment frag
+    #pragma multi_compile_instancing
+    #pragma target 4.0
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    float _Radius_;
+    float _Line_Width_;
+    int _Relative_To_Height_;
+    float _Filter_Width_;
+    half4 _Edge_Color_;
+    half _Fade_Out_;
+    int _Smooth_Edges_;
+    int _Blob_Enable_;
+    float3 _Blob_Position_;
+    float _Blob_Intensity_;
+    float _Blob_Near_Size_;
+    float _Blob_Far_Size_;
+    float _Blob_Near_Distance_;
+    float _Blob_Far_Distance_;
+    float _Blob_Fade_Length_;
+    float _Blob_Inner_Fade_;
+    float _Blob_Pulse_;
+    float _Blob_Fade_;
+    float _Blob_Pulse_Max_Size_;
+    int _Blob_Enable_2_;
+    float3 _Blob_Position_2_;
+    float _Blob_Near_Size_2_;
+    float _Blob_Inner_Fade_2_;
+    float _Blob_Pulse_2_;
+    float _Blob_Fade_2_;
+    float _Gaze_Intensity_;
+    float _Gaze_Focus_;
+    float _Pinched_;
+    sampler2D _Blob_Texture_;
+    float _Selection_Fuzz_;
+    float _Selected_;
+    float _Selection_Fade_;
+    float _Selection_Fade_Size_;
+    float _Selected_Distance_;
+    float _Selected_Fade_Length_;
+    half _Proximity_Max_Intensity_;
+    float _Proximity_Far_Distance_;
+    half _Proximity_Near_Radius_;
+    float _Proximity_Anisotropy_;
+    int _Use_Global_Left_Index_;
+    int _Use_Global_Right_Index_;
+
+
+
+    float4 Global_Left_Index_Tip_Position;
+    float4 Global_Right_Index_Tip_Position;
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        half3 normal : NORMAL;
+        float2 uv0 : TEXCOORD0;
+        float4 tangent : TANGENT;
+        float4 color : COLOR;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+        half4 normalWorld : TEXCOORD5;
+        float2 uv : TEXCOORD0;
+        float3 posWorld : TEXCOORD7;
+        float4 tangent : TANGENT;
+        float4 extra1 : TEXCOORD4;
+        float4 extra2 : TEXCOORD3;
+        float4 extra3 : TEXCOORD2;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    //BLOCK_BEGIN Blob_Vertex 1239
+
+    void Blob_Vertex_B1239(
+        float3 Position,
+        float3 Normal,
+        float3 Tangent,
+        float3 Bitangent,
+        float3 Blob_Position,
+        float Intensity,
+        float Blob_Near_Size,
+        float Blob_Far_Size,
+        float Blob_Near_Distance,
+        float Blob_Far_Distance,
+        float4 Vx_Color,
+        float2 UV,
+        float3 Face_Center,
+        float2 Face_Size,
+        float2 In_UV,
+        float Blob_Fade_Length,
+        float Selection_Fade,
+        float Selection_Fade_Size,
+        float Inner_Fade,
+        float Blob_Pulse,
+        float Blob_Fade,
+        float Blob_Enabled,
+        float DistanceOffset,
+        out float3 Out_Position,
+        out float2 Out_UV,
+        out float3 Blob_Info,
+        out float2 Blob_Relative_UV    )
+    {
+        
+        float blobSize, fadeIn;
+        float3 Hit_Position;
+        Blob_Info = float3(0.0,0.0,0.0);
+        
+        float Hit_Distance = dot(Blob_Position-Face_Center, Normal) + DistanceOffset*Blob_Far_Distance;
+        Hit_Position = Blob_Position - Hit_Distance * Normal;
+        
+        float absD = abs(Hit_Distance);
+        float lerpVal = clamp((absD-Blob_Near_Distance)/(Blob_Far_Distance-Blob_Near_Distance),0.0,1.0);
+        fadeIn = 1.0-clamp((absD-Blob_Far_Distance)/Blob_Fade_Length,0.0,1.0);
+        
+        float innerFade = 1.0-clamp(-Hit_Distance/Inner_Fade,0.0,1.0);
+        
+        //compute blob size
+        float farClip = saturate(1.0-step(Blob_Far_Distance+Blob_Fade_Length,absD));
+        float size = lerp(Blob_Near_Size,Blob_Far_Size,lerpVal)*farClip;
+        blobSize = lerp(size,Selection_Fade_Size,Selection_Fade)*innerFade*Blob_Enabled;
+        Blob_Info.x = lerpVal*0.5+0.5;
+            
+        Blob_Info.y = fadeIn*Intensity*(1.0-Selection_Fade)*Blob_Fade;
+        Blob_Info.x *= (1.0-Blob_Pulse);
+        
+        //compute blob position
+        float3 delta = Hit_Position - Face_Center;
+        float2 blobCenterXY = float2(dot(delta,Tangent),dot(delta,Bitangent));
+        
+        float2 quadUVin = 2.0*UV-1.0;  // remap to (-.5,.5)
+        float2 blobXY = blobCenterXY+quadUVin*blobSize;
+        
+        //keep the quad within the face
+        float2 blobClipped = clamp(blobXY,-Face_Size*0.5,Face_Size*0.5);
+        float2 blobUV = (blobClipped-blobCenterXY)/max(blobSize,0.0001)*2.0;
+        
+        float3 blobCorner = Face_Center + blobClipped.x*Tangent + blobClipped.y*Bitangent;
+        
+        //blend using VxColor.r=1 for blob quad, 0 otherwise
+        Out_Position = lerp(Position,blobCorner,Vx_Color.rrr);
+        Out_UV = lerp(In_UV,blobUV,Vx_Color.rr);
+        Blob_Relative_UV = blobClipped/Face_Size.y;
+    }
+    //BLOCK_END Blob_Vertex
+
+    //BLOCK_BEGIN Round_Rect_Vertex 1235
+
+    void Round_Rect_Vertex_B1235(
+        float2 UV,
+        float3 Tangent,
+        float3 Binormal,
+        float Radius,
+        float Anisotropy,
+        float2 Blob_Center_UV,
+        out float2 Rect_UV,
+        out float2 Scale_XY,
+        out float4 Rect_Parms    )
+    {
+        Scale_XY = float2(Anisotropy,1.0);
+        Rect_UV = (UV - float2(0.5,0.5)) * Scale_XY;
+        Rect_Parms.xy = Scale_XY*0.5-float2(Radius,Radius);
+        Rect_Parms.zw = Blob_Center_UV;
+    }
+    //BLOCK_END Round_Rect_Vertex
+
+    //BLOCK_BEGIN Proximity_Vertex 1232
+
+    float2 ProjectProximity(
+        float3 blobPosition,
+        float3 position,
+        float3 center,
+        float3 dir,
+        float3 xdir,
+        float3 ydir,
+        out float vdistance
+    )
+    {
+        float3 delta = blobPosition - position;
+        float2 xy = float2(dot(delta,xdir),dot(delta,ydir));
+        vdistance = abs(dot(delta,dir));
+        return xy;
+    }
+    
+    void Proximity_Vertex_B1232(
+        float3 Blob_Position,
+        float3 Blob_Position_2,
+        float3 Face_Center,
+        float3 Position,
+        float Proximity_Far_Distance,
+        float Relative_Scale,
+        float Proximity_Anisotropy,
+        float3 Normal,
+        float3 Tangent,
+        float3 Binormal,
+        out float4 Extra,
+        out float Distance_To_Face,
+        out float Distance_Fade1,
+        out float Distance_Fade2    )
+    {
+        //float3 Active_Face_Dir_X = normalize(cross(Active_Face_Dir,Up));
+        //float3 Active_Face_Dir_X = normalize(float3(Active_Face_Dir.y-Active_Face_Dir.z,Active_Face_Dir.z-Active_Face_Dir.x,Active_Face_Dir.x-Active_Face_Dir.y));
+        //float3 Active_Face_Dir_Y = cross(Active_Face_Dir,Active_Face_Dir_X);
+        
+        float distz1,distz2;
+        Extra.xy = ProjectProximity(Blob_Position,Position,Face_Center,Normal,Tangent*Proximity_Anisotropy,Binormal,distz1)/Relative_Scale;
+        Extra.zw = ProjectProximity(Blob_Position_2,Position,Face_Center,Normal,Tangent*Proximity_Anisotropy,Binormal,distz2)/Relative_Scale;
+        
+        Distance_To_Face = dot(Normal,Position-Face_Center);
+        Distance_Fade1 = 1.0 - saturate(distz1/Proximity_Far_Distance);
+        Distance_Fade2 = 1.0 - saturate(distz2/Proximity_Far_Distance);
+        
+    }
+    //BLOCK_END Proximity_Vertex
+
+    //BLOCK_BEGIN Object_To_World_Pos 1211
+
+    void Object_To_World_Pos_B1211(
+        float3 Pos_Object,
+        out float3 Pos_World    )
+    {
+        Pos_World=(mul(UNITY_MATRIX_M, float4(Pos_Object, 1)));
+        
+    }
+    //BLOCK_END Object_To_World_Pos
+
+    //BLOCK_BEGIN Choose_Blob 1226
+
+    void Choose_Blob_B1226(
+        float4 Vx_Color,
+        float3 Position1,
+        float3 Position2,
+        bool Blob_Enable_1,
+        bool Blob_Enable_2,
+        float Near_Size_1,
+        float Near_Size_2,
+        float Blob_Inner_Fade_1,
+        float Blob_Inner_Fade_2,
+        float Blob_Pulse_1,
+        float Blob_Pulse_2,
+        float Blob_Fade_1,
+        float Blob_Fade_2,
+        out float3 Position,
+        out float Near_Size,
+        out float Inner_Fade,
+        out float Blob_Enable,
+        out float Fade,
+        out float Pulse    )
+    {
+        Position = Position1*(1.0-Vx_Color.g)+Vx_Color.g*Position2;
+        
+        float b1 = Blob_Enable_1 ? 1.0 : 0.0;
+        float b2 = Blob_Enable_2 ? 1.0 : 0.0;
+        Blob_Enable = b1+(b2-b1)*Vx_Color.g;
+        
+        Pulse = Blob_Pulse_1*(1.0-Vx_Color.g)+Vx_Color.g*Blob_Pulse_2;
+        Fade = Blob_Fade_1*(1.0-Vx_Color.g)+Vx_Color.g*Blob_Fade_2;
+        Near_Size = Near_Size_1*(1.0-Vx_Color.g)+Vx_Color.g*Near_Size_2;
+        Inner_Fade = Blob_Inner_Fade_1*(1.0-Vx_Color.g)+Vx_Color.g*Blob_Inner_Fade_2;
+    }
+    //BLOCK_END Choose_Blob
+
+    //BLOCK_BEGIN Move_Verts 1231
+
+    void Move_Verts_B1231(
+        float2 UV,
+        float Radius,
+        float Anisotropy,
+        float Line_Width,
+        float Visible,
+        out float3 New_P,
+        out float2 New_UV    )
+    {
+        
+        float2 xy = 2 * UV - float2(0.5,0.5);
+        float2 center = saturate(xy);
+        
+        float2 delta = 2 * (xy - center);
+        float deltaLength = length(delta);
+        
+        float2 aniso = float2(1.0 / Anisotropy, 1.0);
+        center = (center-float2(0.5,0.5))*(1.0-2.0*Radius*aniso);
+        
+        New_UV = float2((2.0-2.0*deltaLength)*Visible,0.0);
+        
+        float deltaRadius =  (Radius - Line_Width * New_UV.x);
+        
+        New_P.xy = (center + deltaRadius / deltaLength *aniso * delta);
+        New_P.z = 0.0;
+        
+    }
+    //BLOCK_END Move_Verts
+
+    //BLOCK_BEGIN Object_To_World_Dir 1213
+
+    void Object_To_World_Dir_B1213(
+        float3 Dir_Object,
+        out float3 Binormal_World    )
+    {
+        Binormal_World = (mul((float3x3)UNITY_MATRIX_M, Dir_Object));
+        
+    }
+    //BLOCK_END Object_To_World_Dir
+
+    //BLOCK_BEGIN Proximity_Visibility 1254
+
+    void Proximity_Visibility_B1254(
+        float Selection,
+        float3 Proximity_Center,
+        float3 Proximity_Center_2,
+        float Proximity_Far_Distance,
+        float Proximity_Radius,
+        float3 Face_Center,
+        float3 Normal,
+        float2 Face_Size,
+        float Gaze,
+        out float Width    )
+    {
+        //make all edges invisible if no proximity or selection visible
+        float boxMaxSize = length(Face_Size)*0.5;
+        
+        float d1 = dot(Proximity_Center-Face_Center, Normal);
+        float3 blob1 = Proximity_Center - d1 * Normal;
+        
+        float d2 = dot(Proximity_Center_2-Face_Center, Normal);
+        float3 blob2 = Proximity_Center_2 - d2 * Normal;
+        
+        //float3 objectOriginInWorld = (mul(UNITY_MATRIX_M, float4(float3(0.0,0.0,0.0), 1)));
+        float3 delta1 = blob1 - Face_Center;
+        float3 delta2 = blob2 - Face_Center;
+        
+        float dist1 = dot(delta1,delta1);
+        float dist2 = dot(delta2,delta2);
+        
+        float nearestProxDist = sqrt(min(dist1,dist2));
+        
+        Width = (1.0 - step(boxMaxSize+Proximity_Radius,nearestProxDist))*(1.0-step(Proximity_Far_Distance,min(d1,d2))*(1.0-step(0.0001,Selection)));
+        Width = max(Gaze, Width);
+    }
+    //BLOCK_END Proximity_Visibility
+
+    //BLOCK_BEGIN Selection_Vertex 1230
+
+    float2 ramp2(float2 start, float2 end, float2 x)
+    {
+       return clamp((x-start)/(end-start),float2(0.0,0.0),float2(1.0,1.0));
+    }
+    
+    float computeSelection(
+        float3 blobPosition,
+        float3 normal,
+        float3 tangent,
+        float3 bitangent,
+        float3 faceCenter,
+        float2 faceSize,
+        float selectionFuzz,
+        float farDistance,
+        float fadeLength
+    )
+    {
+        float3 delta = blobPosition - faceCenter;
+        float absD = abs(dot(delta,normal));
+        float fadeIn = 1.0-clamp((absD-farDistance)/fadeLength,0.0,1.0);
+        
+        float2 blobCenterXY = float2(dot(delta,tangent),dot(delta,bitangent));
+    
+        float2 innerFace = faceSize * (1.0-selectionFuzz) * 0.5;
+        float2 selectPulse = ramp2(-faceSize*0.5,-innerFace,blobCenterXY)-ramp2(innerFace,faceSize*0.5,blobCenterXY);
+    
+        return selectPulse.x * selectPulse.y * fadeIn;
+    }
+    
+    void Selection_Vertex_B1230(
+        float3 Blob_Position,
+        float3 Blob_Position_2,
+        float3 Face_Center,
+        float2 Face_Size,
+        float3 Normal,
+        float3 Tangent,
+        float3 Bitangent,
+        float Selection_Fuzz,
+        float Selected,
+        float Far_Distance,
+        float Fade_Length,
+        float3 Active_Face_Dir,
+        out float Show_Selection    )
+    {
+        float select1 = computeSelection(Blob_Position,Normal,Tangent,Bitangent,Face_Center,Face_Size,Selection_Fuzz,Far_Distance,Fade_Length);
+        float select2 = computeSelection(Blob_Position_2,Normal,Tangent,Bitangent,Face_Center,Face_Size,Selection_Fuzz,Far_Distance,Fade_Length);
+        
+        Show_Selection = lerp(max(select1,select2),1.0,Selected);
+    }
+    //BLOCK_END Selection_Vertex
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        // Pack_For_Vertex (#1228)
+        float3 Vec3_Q1228 = float3(float2(0,0).x,float2(0,0).y,vertInput.color.r);
+
+        // Object_To_World_Dir (#1223)
+        float3 Nrm_World_Q1223;
+        Nrm_World_Q1223 = normalize((mul((float3x3)UNITY_MATRIX_M, vertInput.normal)));
+        
+        // Object_To_World_Pos (#1229)
+        float3 Face_Center_Q1229;
+        Face_Center_Q1229=(mul(UNITY_MATRIX_M, float4(float3(0,0,0), 1)));
+        
+        // Object_To_World_Dir (#1212)
+        float3 Tangent_World_Q1212;
+        Tangent_World_Q1212 = (mul((float3x3)UNITY_MATRIX_M, vertInput.tangent));
+        
+        float3 Binormal_World_Q1213;
+        Object_To_World_Dir_B1213((normalize(cross(vertInput.normal,vertInput.tangent))),Binormal_World_Q1213);
+
+        // Anisotropy (#1220)
+        float Anisotropy_Q1220=length(Tangent_World_Q1212)/length(Binormal_World_Q1213);
+
+        // Conditional (#1241)
+        float3 Result_Q1241;
+        Result_Q1241 = _Use_Global_Left_Index_ ? Global_Left_Index_Tip_Position.xyz : _Blob_Position_;
+        
+        // Conditional (#1242)
+        float3 Result_Q1242;
+        Result_Q1242 = _Use_Global_Right_Index_ ? Global_Right_Index_Tip_Position.xyz : _Blob_Position_2_;
+        
+        // Lerp (#1257)
+        float Value_At_T_Q1257=lerp(_Blob_Near_Size_,_Blob_Pulse_Max_Size_,_Blob_Pulse_);
+
+        // Lerp (#1258)
+        float Value_At_T_Q1258=lerp(_Blob_Near_Size_2_,_Blob_Pulse_Max_Size_,_Blob_Pulse_2_);
+
+        // Multiply (#1244)
+        float Product_Q1244 = _Gaze_Intensity_ * _Gaze_Focus_;
+
+        // Step (#1245)
+        float Step_Q1245 = step(0.0001, Product_Q1244);
+
+        // Normalize3 (#1214)
+        float3 Tangent_World_N_Q1214 = normalize(Tangent_World_Q1212);
+
+        // Normalize3 (#1215)
+        float3 Binormal_World_N_Q1215 = normalize(Binormal_World_Q1213);
+
+        float3 Position_Q1226;
+        float Near_Size_Q1226;
+        float Inner_Fade_Q1226;
+        float Blob_Enable_Q1226;
+        float Fade_Q1226;
+        float Pulse_Q1226;
+        Choose_Blob_B1226(vertInput.color,Result_Q1241,Result_Q1242,_Blob_Enable_,_Blob_Enable_2_,Value_At_T_Q1257,Value_At_T_Q1258,_Blob_Inner_Fade_,_Blob_Inner_Fade_2_,_Blob_Pulse_,_Blob_Pulse_2_,_Blob_Fade_,_Blob_Fade_2_,Position_Q1226,Near_Size_Q1226,Inner_Fade_Q1226,Blob_Enable_Q1226,Fade_Q1226,Pulse_Q1226);
+
+        // Face_Size (#1234)
+        float2 Face_Size_Q1234;
+        float ScaleY_Q1234;
+        Face_Size_Q1234 = float2(length(Tangent_World_Q1212),length(Binormal_World_Q1213));
+        ScaleY_Q1234 = Face_Size_Q1234.y;
+        
+        // Scale_Radius_And_Width (#1237)
+        float Out_Radius_Q1237;
+        float Out_Line_Width_Q1237;
+        Out_Radius_Q1237 = _Relative_To_Height_ ? _Radius_ : _Radius_ / ScaleY_Q1234;
+        Out_Line_Width_Q1237 = _Relative_To_Height_ ? _Line_Width_ : _Line_Width_ / ScaleY_Q1234;
+
+        float Show_Selection_Q1230;
+        Selection_Vertex_B1230(Result_Q1241,Result_Q1242,Face_Center_Q1229,Face_Size_Q1234,Nrm_World_Q1223,Tangent_World_N_Q1214,Binormal_World_N_Q1215,_Selection_Fuzz_,_Selected_,_Selected_Distance_,_Selected_Fade_Length_,float3(0,0,-1),Show_Selection_Q1230);
+
+        // Max (#1240)
+        float MaxAB_Q1240=max(Show_Selection_Q1230,Product_Q1244);
+
+        float Width_Q1254;
+        Proximity_Visibility_B1254(Show_Selection_Q1230,Result_Q1241,Result_Q1242,_Proximity_Far_Distance_,_Proximity_Near_Radius_,Face_Center_Q1229,Nrm_World_Q1223,Face_Size_Q1234,Step_Q1245,Width_Q1254);
+
+        float3 New_P_Q1231;
+        float2 New_UV_Q1231;
+        Move_Verts_B1231(vertInput.uv0,Out_Radius_Q1237,Anisotropy_Q1220,Out_Line_Width_Q1237,Width_Q1254,New_P_Q1231,New_UV_Q1231);
+
+        float3 Pos_World_Q1211;
+        Object_To_World_Pos_B1211(New_P_Q1231,Pos_World_Q1211);
+
+        float3 Out_Position_Q1239;
+        float2 Out_UV_Q1239;
+        float3 Blob_Info_Q1239;
+        float2 Blob_Relative_UV_Q1239;
+        Blob_Vertex_B1239(Pos_World_Q1211,Nrm_World_Q1223,Tangent_World_N_Q1214,Binormal_World_N_Q1215,Position_Q1226,_Blob_Intensity_,Near_Size_Q1226,_Blob_Far_Size_,_Blob_Near_Distance_,_Blob_Far_Distance_,vertInput.color,vertInput.uv0,Face_Center_Q1229,Face_Size_Q1234,New_UV_Q1231,_Blob_Fade_Length_,_Selection_Fade_,_Selection_Fade_Size_,Inner_Fade_Q1226,Pulse_Q1226,Fade_Q1226,Blob_Enable_Q1226,0.0,Out_Position_Q1239,Out_UV_Q1239,Blob_Info_Q1239,Blob_Relative_UV_Q1239);
+
+        float2 Rect_UV_Q1235;
+        float2 Scale_XY_Q1235;
+        float4 Rect_Parms_Q1235;
+        Round_Rect_Vertex_B1235(New_UV_Q1231,Tangent_World_Q1212,Binormal_World_Q1213,Out_Radius_Q1237,Anisotropy_Q1220,Blob_Relative_UV_Q1239,Rect_UV_Q1235,Scale_XY_Q1235,Rect_Parms_Q1235);
+
+        float4 Extra_Q1232;
+        float Distance_To_Face_Q1232;
+        float Distance_Fade1_Q1232;
+        float Distance_Fade2_Q1232;
+        Proximity_Vertex_B1232(Result_Q1241,Result_Q1242,Face_Center_Q1229,Pos_World_Q1211,_Proximity_Far_Distance_,1.0,_Proximity_Anisotropy_,Nrm_World_Q1223,Tangent_World_N_Q1214,Binormal_World_N_Q1215,Extra_Q1232,Distance_To_Face_Q1232,Distance_Fade1_Q1232,Distance_Fade2_Q1232);
+
+        // From_XYZW (#1236)
+        float4 Vec4_Q1236 = float4(MaxAB_Q1240, Distance_Fade1_Q1232, Distance_Fade2_Q1232, Out_Radius_Q1237);
+
+        float3 Position = Out_Position_Q1239;
+        float3 Normal = Vec3_Q1228;
+        float2 UV = Out_UV_Q1239;
+        float3 Tangent = Blob_Info_Q1239;
+        float3 Binormal = float3(0,0,0);
+        float4 Color = float4(1,1,1,1);
+        float4 Extra1 = Rect_Parms_Q1235;
+        float4 Extra2 = Extra_Q1232;
+        float4 Extra3 = Vec4_Q1236;
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
+        o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
+        o.uv = UV;
+        o.tangent.xyz = Tangent; o.tangent.w=1.0;
+        o.extra1=Extra1;
+        o.extra2=Extra2;
+        o.extra3=Extra3;
+
+        return o;
+    }
+
+    //BLOCK_BEGIN Scale_Color 1253
+
+    void Scale_Color_B1253(
+        half4 Color,
+        half Scalar,
+        out half4 Result    )
+    {
+        Result = Scalar * Color;
+    }
+    //BLOCK_END Scale_Color
+
+    //BLOCK_BEGIN Scale_RGB 1249
+
+    void Scale_RGB_B1249(
+        half4 Color,
+        half Scalar,
+        out half4 Result    )
+    {
+        Result = float4(Scalar,Scalar,Scalar,1) * Color;
+    }
+    //BLOCK_END Scale_RGB
+
+    //BLOCK_BEGIN Proximity_Fragment 1250
+
+    void Proximity_Fragment_B1250(
+        half Proximity_Max_Intensity,
+        half Proximity_Near_Radius,
+        half4 Deltas,
+        half Show_Selection,
+        half Distance_Fade1,
+        half Distance_Fade2,
+        half Strength,
+        out half Proximity    )
+    {
+        float proximity1 = (1.0-saturate(length(Deltas.xy)/Proximity_Near_Radius))*Distance_Fade1;
+        float proximity2 = (1.0-saturate(length(Deltas.zw)/Proximity_Near_Radius))*Distance_Fade2;
+        
+        Proximity = Strength * (Proximity_Max_Intensity * max(proximity1, proximity2) *(1.0-Show_Selection)+Show_Selection);
+        
+    }
+    //BLOCK_END Proximity_Fragment
+
+    //BLOCK_BEGIN Blob_Fragment 1255
+
+    void Blob_Fragment_B1255(
+        float2 UV,
+        float3 Blob_Info,
+        sampler2D Blob_Texture,
+        out half4 Blob_Color    )
+    {
+        float k = dot(UV,UV);
+        Blob_Color = Blob_Info.y * tex2D(Blob_Texture,float2(float2(sqrt(k),Blob_Info.x).x,1.0-float2(sqrt(k),Blob_Info.x).y))*(1.0-saturate(k));
+    }
+    //BLOCK_END Blob_Fragment
+
+    //BLOCK_BEGIN Round_Rect_Fragment 1260
+
+    void Round_Rect_Fragment_B1260(
+        half Radius,
+        half4 Line_Color,
+        half Filter_Width,
+        half Line_Visibility,
+        half4 Fill_Color,
+        bool Smooth_Edges,
+        half4 Rect_Parms,
+        out half Inside_Rect    )
+    {
+        half d = length(max(abs(Rect_Parms.zw)-Rect_Parms.xy,0.0));
+        half dx = max(fwidth(d)*Filter_Width,0.00001);
+        
+        Inside_Rect = Smooth_Edges ? saturate((Radius-d)/dx) : 1.0-step(Radius,d);
+        
+    }
+    //BLOCK_END Round_Rect_Fragment
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+        half4 result;
+
+        // Is_Quad (#1252)
+        half Is_Quad_Q1252;
+        Is_Quad_Q1252=fragInput.normalWorld.xyz.z;
+        
+        half4 Blob_Color_Q1255;
+        Blob_Fragment_B1255(fragInput.uv,fragInput.tangent.xyz,_Blob_Texture_,Blob_Color_Q1255);
+
+        // To_XYZW (#1251)
+        half X_Q1251;
+        half Y_Q1251;
+        half Z_Q1251;
+        half W_Q1251;
+        X_Q1251=fragInput.extra3.x;
+        Y_Q1251=fragInput.extra3.y;
+        Z_Q1251=fragInput.extra3.z;
+        W_Q1251=fragInput.extra3.w;
+
+        half Proximity_Q1250;
+        Proximity_Fragment_B1250(_Proximity_Max_Intensity_,_Proximity_Near_Radius_,fragInput.extra2,X_Q1251,Y_Q1251,Z_Q1251,1.0,Proximity_Q1250);
+
+        half Inside_Rect_Q1260;
+        Round_Rect_Fragment_B1260(W_Q1251,half4(1,1,1,1),_Filter_Width_,1,half4(0,0,0,0),_Smooth_Edges_,fragInput.extra1,Inside_Rect_Q1260);
+
+        half4 Result_Q1249;
+        Scale_RGB_B1249(_Edge_Color_,Proximity_Q1250,Result_Q1249);
+
+        // Scale_Color (#1246)
+        half4 Result_Q1246 = Inside_Rect_Q1260 * Blob_Color_Q1255;
+
+        // Mix_Colors (#1247)
+        half4 Color_At_T_Q1247 = lerp(Result_Q1249, Result_Q1246,float4( Is_Quad_Q1252, Is_Quad_Q1252, Is_Quad_Q1252, Is_Quad_Q1252));
+
+        half4 Result_Q1253;
+        Scale_Color_B1253(Color_At_T_Q1247,_Fade_Out_,Result_Q1253);
+
+        float4 Out_Color = Result_Q1253;
+        float Clip_Threshold = 0.001;
+        bool To_sRGB = false;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasFrontplateNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasFrontplateNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d2b13fce7d724c14ebf4b51bc8ba5ee9
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasGlowNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasGlowNonSrp.shader
@@ -1,0 +1,242 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Non-Canvas/Non-SRP/GlowNonSrp" {
+
+Properties {
+
+    [Header(Rounded Rectangle)]
+        _Bevel_Radius_("Bevel Radius", Range(0,1)) = 0.014
+        _Line_Width_("Line Width", Range(0,1)) = 0.008
+        [Toggle] _Absolute_Sizes_("Absolute Sizes", Float) = 1
+     
+    [Header(Animation)]
+        _Tuning_Motion_("Tuning Motion", Range(0,1)) = 0
+        [PerRendererData] _Motion_("Motion",Range(0,1)) = 0
+        _Max_Intensity_("Max Intensity", Range(0,1)) = 0.7
+        _Intensity_Fade_In_Exponent_("Intensity Fade In Exponent", Range(0,5)) = 2
+        _Outer_Fuzz_Start_("Outer Fuzz Start", Range(0,1)) = 0.004
+        _Outer_Fuzz_End_("Outer Fuzz End", Range(0,1)) = 0.001
+     
+    [Header(Color)]
+        _Color_("Color", Color) = (0.682353,0.698039,1,1)
+        _Inner_Color_("Inner Color", Color) = (0.356863,0.392157,0.796078,1)
+        _Blend_Exponent_("Blend Exponent", Range(0,9)) = 1.5
+     
+    [Header(Inner Transition)]
+        _Falloff_("Falloff", Range(0,5)) = 2
+        _Bias_("Bias", Range(0,1)) = 0.5
+     
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+}
+
+SubShader {
+    Tags { "RenderType" = "Transparent" "Queue" = "Transparent" }
+    Blend One One
+    ZWrite Off
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+
+    Pass
+
+    {
+
+    CGPROGRAM
+
+    #pragma vertex vert
+    #pragma fragment frag
+    #pragma multi_compile_instancing
+    #pragma target 4.0
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    float _Bevel_Radius_;
+    half _Line_Width_;
+    int _Absolute_Sizes_;
+    half _Tuning_Motion_;
+    half _Motion_;
+    half _Max_Intensity_;
+    half _Intensity_Fade_In_Exponent_;
+    half _Outer_Fuzz_Start_;
+    half _Outer_Fuzz_End_;
+    half4 _Color_;
+    half4 _Inner_Color_;
+    half _Blend_Exponent_;
+    half _Falloff_;
+    half _Bias_;
+
+
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        half3 normal : NORMAL;
+        float2 uv0 : TEXCOORD0;
+        float4 tangent : TANGENT;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+        half4 normalWorld : TEXCOORD5;
+        float2 uv : TEXCOORD0;
+        float3 posWorld : TEXCOORD7;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        // Object_To_World_Dir (#196)
+        float3 Dir_World_Q196=(mul((float3x3)UNITY_MATRIX_M, vertInput.tangent));
+
+        // Object_To_World_Dir (#195)
+        float3 Dir_World_Q195=(mul((float3x3)UNITY_MATRIX_M, (normalize(cross(vertInput.normal,vertInput.tangent)))));
+
+        // Max (#179)
+        half MaxAB_Q179=max(_Tuning_Motion_,_Motion_);
+
+        // Length3 (#171)
+        float Length_Q171 = length(Dir_World_Q196);
+
+        // Length3 (#172)
+        float Length_Q172 = length(Dir_World_Q195);
+
+        // Greater_Than (#192)
+        bool Greater_Than_Q192 = MaxAB_Q179 > 0;
+
+        // ScaleUVs (#190)
+        float3 Sizes_Q190;
+        float2 XY_Q190;
+        Sizes_Q190 = (_Absolute_Sizes_ ? float3(Length_Q171,Length_Q172,0) : float3(Length_Q171/Length_Q172,1,0));
+        XY_Q190 = (vertInput.uv0 - float2(0.5,0.5))*Sizes_Q190.xy;
+
+        // Conditional_Vec3 (#193)
+        float3 Result_Q193 = Greater_Than_Q192 ? vertInput.vertex.xyz : float3(0,0,0);
+
+        // Object_To_World_Pos (#194)
+        float3 Pos_World_Q194=(mul(UNITY_MATRIX_M, float4(Result_Q193, 1)));
+
+        float3 Position = Pos_World_Q194;
+        float3 Normal = Sizes_Q190;
+        float2 UV = XY_Q190;
+        float3 Tangent = float3(0,0,0);
+        float3 Binormal = float3(0,0,0);
+        float4 Color = float4(1,1,1,1);
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
+        o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
+        o.uv = UV;
+
+        return o;
+    }
+
+    //BLOCK_BEGIN Ease_Transition 200
+
+    float BiasFunc(float b, float v) {
+      return pow(v,log(clamp(b,0.001,0.999))/log(0.5));
+    }
+    //BLOCK_END Ease_Transition
+
+    //BLOCK_BEGIN Fuzzy_Round_Rect 188
+
+    void Fuzzy_Round_Rect_B188(
+        float Size_X,
+        float Size_Y,
+        float Radius_X,
+        float Radius_Y,
+        half Line_Width,
+        float2 UV,
+        half Outer_Fuzz,
+        half Max_Outer_Fuzz,
+        out half Rect_Distance,
+        out half Inner_Distance    )
+    {
+        float2 halfSize = float2(Size_X,Size_Y)*0.5;
+        float2 r = max(min(float2(Radius_X,Radius_Y),halfSize),float2(0.001,0.001));
+        float radius = min(r.x,r.y)-Max_Outer_Fuzz;
+        float2 v = abs(UV);
+        float2 nearestp = min(v,halfSize-r);
+        half d = distance(nearestp,v);
+        Inner_Distance = saturate(1.0-(radius-d)/Line_Width);
+        Rect_Distance = saturate(1.0-(d-radius)/Outer_Fuzz)*Inner_Distance;
+    }
+    //BLOCK_END Fuzzy_Round_Rect
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+        half4 result;
+
+        // To_XY (#197)
+        float X_Q197;
+        float Y_Q197;
+        X_Q197=fragInput.normalWorld.xyz.x;
+        Y_Q197=fragInput.normalWorld.xyz.y;
+
+        // Max (#179)
+        half MaxAB_Q179=max(_Tuning_Motion_,_Motion_);
+
+        // Sqrt (#182)
+        half Sqrt_F_Q182 = sqrt(MaxAB_Q179);
+
+        // Power (#198)
+        half Power_Q198 = pow(MaxAB_Q179, _Intensity_Fade_In_Exponent_);
+
+        // Lerp (#181)
+        half Value_At_T_Q181=lerp(_Outer_Fuzz_Start_,_Outer_Fuzz_End_,Sqrt_F_Q182);
+
+        // Multiply (#178)
+        half Product_Q178 = _Max_Intensity_ * Power_Q198;
+
+        half Rect_Distance_Q188;
+        half Inner_Distance_Q188;
+        Fuzzy_Round_Rect_B188(X_Q197,Y_Q197,_Bevel_Radius_,_Bevel_Radius_,_Line_Width_,fragInput.uv,Value_At_T_Q181,_Outer_Fuzz_Start_,Rect_Distance_Q188,Inner_Distance_Q188);
+
+        // Power (#199)
+        half Power_Q199 = pow(Inner_Distance_Q188, _Blend_Exponent_);
+
+        // Ease_Transition (#200)
+        half Result_Q200 = pow(BiasFunc(_Bias_,Rect_Distance_Q188),_Falloff_);
+
+        // Mix_Colors (#180)
+        half4 Color_At_T_Q180 = lerp(_Inner_Color_, _Color_,float4( Power_Q199, Power_Q199, Power_Q199, Power_Q199));
+
+        // Multiply (#177)
+        half Product_Q177 = Result_Q200 * Product_Q178;
+
+        // Scale_Color (#183)
+        half4 Result_Q183 = Product_Q177 * Color_At_T_Q180;
+
+        half4 Out_Color = Result_Q183;
+        half Clip_Threshold = 0;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasGlowNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasGlowNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: b7e915878d5eb8d428515df315708f3b
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasQuadGlowNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasQuadGlowNonSrp.shader
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Non-Canvas/Non-SRP/Quad GlowNonSrp" {
+
+Properties {
+
+    [Header(Color)]
+        _Color_("Color", Color) = (1,1,1,1)
+     
+    [Header(Shape)]
+        _Radius_("Radius", Range(0,0.5)) = 0.5
+        [Toggle] _Fixed_Radius_("Fixed Radius", Float) = 0
+        _Filter_Width_("Filter Width", Range(0,4)) = 2
+     
+    [Header(Glow)]
+        _Glow_Fraction_("Glow Fraction", Range(0.01,0.99)) = 0.5
+        _Glow_Max_("Glow Max", Range(0,1)) = 0.5
+        _Glow_Falloff_("Glow Falloff", Range(0,5)) = 2
+     
+
+    [Header(Stencil)]
+        _StencilReference("Stencil Reference", Range(0, 255)) = 0
+        [Enum(UnityEngine.Rendering.CompareFunction)]_StencilComparison("Stencil Comparison", Int) = 0
+        [Enum(UnityEngine.Rendering.StencilOp)]_StencilOperation("Stencil Operation", Int) = 0
+
+    [Header(Blend)]
+    [Enum(UnityEngine.Rendering.CompareFunction)] _ZTest("Depth Test", Float) = 4
+    [Enum(Microsoft.MixedReality.GraphicsTools.Editor.DepthWrite)] _ZWrite("Depth Write", Float) = 0
+}
+
+SubShader {
+    Tags{ "RenderType" = "AlphaTest" "Queue" = "AlphaTest"}
+    Blend One OneMinusSrcAlpha
+    Tags {"DisableBatching" = "True"}
+    Stencil
+    {
+        Ref[_StencilReference]
+        Comp[_StencilComparison]
+        Pass[_StencilOperation]
+    }
+
+    LOD 100
+
+
+    Pass
+
+    {
+
+    ZWrite[_ZWrite]
+    ZTest[_ZTest]
+
+    CGPROGRAM
+
+    #pragma vertex vert
+    #pragma fragment frag
+    #pragma multi_compile_instancing
+    #pragma target 4.0
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    half4 _Color_;
+    float _Radius_;
+    int _Fixed_Radius_;
+    half _Filter_Width_;
+    half _Glow_Fraction_;
+    half _Glow_Max_;
+    half _Glow_Falloff_;
+
+
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        half3 normal : NORMAL;
+        float2 uv0 : TEXCOORD0;
+        float4 tangent : TANGENT;
+        float4 color : COLOR;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+        float2 uv : TEXCOORD0;
+        float3 posWorld : TEXCOORD7;
+        float4 tangent : TANGENT;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        // Object_To_World_Pos (#1371)
+        float3 Pos_World_Q1371;
+        Pos_World_Q1371=(mul(UNITY_MATRIX_M, float4(vertInput.vertex.xyz, 1)));
+        
+        // Object_To_World_Dir (#1372)
+        float3 Dir_World_Q1372;
+        Dir_World_Q1372=(mul((float3x3)UNITY_MATRIX_M, vertInput.tangent));
+        
+        // Object_To_World_Dir (#1373)
+        float3 Dir_World_Q1373;
+        Dir_World_Q1373=(mul((float3x3)UNITY_MATRIX_M, (normalize(cross(vertInput.normal,vertInput.tangent)))));
+        
+        // Length3 (#1362)
+        float Length_Q1362 = length(Dir_World_Q1372);
+
+        // Length3 (#1363)
+        float Length_Q1363 = length(Dir_World_Q1373);
+
+        // Divide (#1366)
+        float Quotient_Q1366 = Length_Q1362 / Length_Q1363;
+
+        // Divide (#1377)
+        float Quotient_Q1377 = _Radius_ / Length_Q1363;
+
+        // TransformUVs (#1375)
+        float2 Result_Q1375;
+        Result_Q1375 = float2((vertInput.uv0.x-0.5)*Length_Q1362/Length_Q1363,(vertInput.uv0.y-0.5));
+        
+        // Conditional_Float (#1380)
+        float Result_Q1380 = _Fixed_Radius_ ? Quotient_Q1377 : _Radius_;
+
+        // From_XYZ (#1365)
+        float3 Vec3_Q1365 = float3(Quotient_Q1366,Result_Q1380,0);
+
+        float3 Position = Pos_World_Q1371;
+        float3 Normal = float3(0,0,0);
+        float2 UV = Result_Q1375;
+        float3 Tangent = Vec3_Q1365;
+        float3 Binormal = float3(0,0,0);
+        float4 Color = vertInput.color;
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
+        o.uv = UV;
+        o.tangent.xyz = Tangent; o.tangent.w=1.0;
+
+        return o;
+    }
+
+    //BLOCK_BEGIN Round_Rect 1376
+
+    half FilterStep_Bid1376(half edge, half x, half filterWidth)
+    {
+       half dx = max(1.0E-5,fwidth(x)*filterWidth);
+       return max((x+dx*0.5 - max(edge,x-dx*0.5))/dx,0.0);
+    }
+    void Round_Rect_B1376(
+        half Size_X,
+        half Size_Y,
+        half Radius,
+        half4 Rect_Color,
+        half Filter_Width,
+        half2 UV,
+        half Glow_Fraction,
+        half Glow_Max,
+        half Glow_Falloff,
+        out half4 Color    )
+    {
+        half2 halfSize = half2(Size_X,Size_Y)*0.5;
+        half2 r = max(min(half2(Radius,Radius),halfSize),half2(0.01,0.01));
+        
+        half2 v = abs(UV);
+        
+        half2 nearestp = min(v,halfSize-r);
+        half2 delta = (v-nearestp)/max(half2(0.01,0.01),r);
+        half Distance = length(delta);
+        
+        half insideRect = 1.0 - FilterStep_Bid1376(1.0-Glow_Fraction,Distance,Filter_Width);
+        
+        half glow = saturate((1.0-Distance)/Glow_Fraction);
+        glow = pow(glow, Glow_Falloff);
+        Color = Rect_Color * max(insideRect, glow*Glow_Max);
+    }
+    //BLOCK_END Round_Rect
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+        half4 result;
+
+        // To_XYZ (#1374)
+        half X_Q1374;
+        half Y_Q1374;
+        half Z_Q1374;
+        X_Q1374=fragInput.tangent.xyz.x;
+        Y_Q1374=fragInput.tangent.xyz.y;
+        Z_Q1374=fragInput.tangent.xyz.z;
+        
+        half4 Color_Q1376;
+        Round_Rect_B1376(X_Q1374,1.0,Y_Q1374,_Color_,_Filter_Width_,fragInput.uv,_Glow_Fraction_,_Glow_Max_,_Glow_Falloff_,Color_Q1376);
+
+        float4 Out_Color = Color_Q1376;
+        float Clip_Threshold = 0;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasQuadGlowNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasQuadGlowNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d59c89fa52789d84a9c29fc0d7776182
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasSlateProximityNonSrp.shader
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasSlateProximityNonSrp.shader
@@ -1,0 +1,359 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+Shader "Graphics Tools/Non-Canvas/Non-SRP/Slate ProximityNonSrp" {
+
+Properties {
+
+    [Header(Shape)]
+        [Toggle(_ROUNDED_)] _Rounded_("Rounded", Float) = 1
+        _Radius_("Radius", Range(0,1)) = 0.01
+     
+    [Header(Blob)]
+        [PerRendererData] _Blob_Position_("Blob Position",Vector) = (0,0,0,1)
+        _Blob_Intensity_("Blob Intensity", Range(0,3)) = 1
+        _Blob_Near_Size_("Blob Near Size", Range(0,1)) = 0.02
+        _Blob_Far_Size_("Blob Far Size", Range(0,1)) = 0.05
+        _Blob_Near_Distance_("Blob Near Distance", Range(0,1)) = 0.0
+        _Blob_Far_Distance_("Blob Far Distance", Range(0,1)) = 0.08
+        _Blob_Fade_Length_("Blob Fade Length", Range(0,1)) = 0.08
+        _Blob_Inner_Fade_("Blob Inner Fade", Range(0.01,1)) = 0.1
+        [PerRendererData] _Blob_Pulse_("Blob Pulse",Range(0,1)) = 0
+        [PerRendererData] _Blob_Fade_("Blob Fade",Range(0,1)) = 1
+     
+    [Header(Blob Texture)]
+        [NoScaleOffset] _Blob_Texture_("Blob Texture", 2D) = "" {}
+     
+    [Header(Blob 2)]
+        [PerRendererData] _Blob_Position_2_("Blob Position 2",Vector) = (0,0,0,1)
+        _Blob_Near_Size_2_("Blob Near Size 2", Float) = 0.02
+        _Blob_Inner_Fade_2_("Blob Inner Fade 2", Range(0,1)) = 0.1
+        [PerRendererData] _Blob_Pulse_2_("Blob Pulse 2",Range(0,1)) = 0
+        [PerRendererData] _Blob_Fade_2_("Blob Fade 2",Range(0,1)) = 1
+     
+    [Header(Global)]
+        [PerRendererData] _Use_Global_Left_Index_("Use Global Left Index",Float) = 1
+        [PerRendererData] _Use_Global_Right_Index_("Use Global Right Index",Float) = 1
+     
+
+}
+
+SubShader {
+    Tags{ "RenderType" = "AlphaTest" "Queue" = "AlphaTest"}
+    Blend One OneMinusSrcAlpha
+    Cull Off
+    ZWrite Off
+    Tags {"DisableBatching" = "True"}
+
+    LOD 100
+
+
+    Pass
+
+    {
+
+    CGPROGRAM
+
+    #pragma vertex vert
+    #pragma fragment frag
+    #pragma multi_compile_instancing
+    #pragma target 4.0
+    #pragma multi_compile_local _ _ROUNDED_
+    #pragma multi_compile_local _ _CLIPPING_PLANE _CLIPPING_SPHERE _CLIPPING_BOX
+
+    #include "UnityCG.cginc"
+    #include "GraphicsToolsCommon.hlsl"
+
+
+    //bool _Rounded_;
+    float _Radius_;
+    float3 _Blob_Position_;
+    float _Blob_Intensity_;
+    float _Blob_Near_Size_;
+    float _Blob_Far_Size_;
+    float _Blob_Near_Distance_;
+    float _Blob_Far_Distance_;
+    float _Blob_Fade_Length_;
+    float _Blob_Inner_Fade_;
+    float _Blob_Pulse_;
+    float _Blob_Fade_;
+    sampler2D _Blob_Texture_;
+    float3 _Blob_Position_2_;
+    float _Blob_Near_Size_2_;
+    float _Blob_Inner_Fade_2_;
+    float _Blob_Pulse_2_;
+    float _Blob_Fade_2_;
+    int _Use_Global_Left_Index_;
+    int _Use_Global_Right_Index_;
+
+
+
+    float4 Global_Left_Index_Tip_Position;
+    float4 Global_Right_Index_Tip_Position;
+
+    struct VertexInput {
+        float4 vertex : POSITION;
+        half3 normal : NORMAL;
+        float2 uv0 : TEXCOORD0;
+        float4 tangent : TANGENT;
+        float4 color : COLOR;
+        UNITY_VERTEX_INPUT_INSTANCE_ID
+    };
+
+    struct VertexOutput {
+        float4 pos : SV_POSITION;
+        float3 posWorld : TEXCOORD7;
+        half4 normalWorld : TEXCOORD5;
+        float2 uv : TEXCOORD0;
+        float4 extra1 : TEXCOORD4;
+      UNITY_VERTEX_OUTPUT_STEREO
+    };
+
+    //BLOCK_BEGIN Blob_Vertex 985
+
+    void Blob_Vertex_B985(
+        float3 Face_Center,
+        float3 Normal,
+        float3 Tangent,
+        float3 Bitangent,
+        float Intensity,
+        float Blob_Far_Size,
+        float Blob_Near_Distance,
+        float Blob_Far_Distance,
+        float Blob_Fade_Length,
+        float4 Vx_Color,
+        float2 UV,
+        float3 Blob_Position,
+        float Blob_Near_Size,
+        float Inner_Fade,
+        float Blob_Enabled,
+        float Fade,
+        float Pulse,
+        float2 Face_Size,
+        float Radius,
+        out float3 Out_Position,
+        out float2 Out_UV,
+        out float3 Blob_Info,
+        out float4 Clip_Info    )
+    {
+        
+        float Hit_Distance = dot(Blob_Position-Face_Center, Normal);
+        float3 Hit_Position = Blob_Position - Hit_Distance * Normal;
+        
+        float absD = (Hit_Distance);
+        float lerpVal = clamp((absD-Blob_Near_Distance)/(Blob_Far_Distance-Blob_Near_Distance),0.0,1.0);
+        float fadeIn = 1.0-clamp((absD-Blob_Far_Distance)/Blob_Fade_Length,0.0,1.0);
+        
+        //compute blob position & uv
+        float3 delta = Hit_Position - Face_Center;
+        float2 blobCenterXY = float2(dot(delta,Tangent),dot(delta,Bitangent));
+        
+        float innerFade = 1.0-clamp(-Hit_Distance/Inner_Fade,0.0,1.0);
+        
+        float size = lerp(Blob_Near_Size,Blob_Far_Size,lerpVal)*Blob_Enabled*step(0.001,fadeIn);
+        
+        float2 quadUVin = UV-0.5; // remap to (-.5,.5)
+        float2 blobXY = blobCenterXY+quadUVin*size;
+        //keep the quad within the face
+        float2 blobClipped = clamp(blobXY,-Face_Size*0.5,Face_Size*0.5);
+        float2 blobUV = (blobClipped-blobCenterXY)/max(size,0.0001)*2.0;
+        
+        float3 blobCorner = Face_Center + blobClipped.x*Tangent + blobClipped.y*Bitangent;
+        
+        Out_Position = blobCorner;
+        Out_UV = blobUV;
+        Blob_Info = float3((lerpVal*0.5+0.5)*(1.0-Pulse),Intensity*fadeIn*Fade*innerFade,0.0);
+        Clip_Info = float4(blobClipped.x,blobClipped.y,Face_Size.x*0.5-Radius,Face_Size.y*0.5-Radius);
+    }
+    //BLOCK_END Blob_Vertex
+
+    //BLOCK_BEGIN Object_To_World_Pos 964
+
+    void Object_To_World_Pos_B964(
+        float3 Pos_Object,
+        out float3 Pos_World    )
+    {
+        Pos_World=(mul(UNITY_MATRIX_M, float4(Pos_Object, 1)));
+        
+    }
+    //BLOCK_END Object_To_World_Pos
+
+    //BLOCK_BEGIN Choose_Blob 986
+
+    void Choose_Blob_B986(
+        float4 Vx_Color,
+        float3 Position1,
+        float3 Position2,
+        float Near_Size_1,
+        float Near_Size_2,
+        float Blob_Inner_Fade_1,
+        float Blob_Inner_Fade_2,
+        float Blob_Pulse_1,
+        float Blob_Pulse_2,
+        float Blob_Fade_1,
+        float Blob_Fade_2,
+        out float3 Position,
+        out float Near_Size,
+        out float Inner_Fade,
+        out float Fade,
+        out float Pulse    )
+    {
+        Position = Position1*(1.0-Vx_Color.g)+Vx_Color.g*Position2;
+        Pulse = Blob_Pulse_1*(1.0-Vx_Color.g)+Vx_Color.g*Blob_Pulse_2;
+        Fade = Blob_Fade_1*(1.0-Vx_Color.g)+Vx_Color.g*Blob_Fade_2;
+        Near_Size = Near_Size_1*(1.0-Vx_Color.g)+Vx_Color.g*Near_Size_2;
+        Inner_Fade = Blob_Inner_Fade_1*(1.0-Vx_Color.g)+Vx_Color.g*Blob_Inner_Fade_2;
+    }
+    //BLOCK_END Choose_Blob
+
+    //BLOCK_BEGIN Object_To_World_Dir 977
+
+    void Object_To_World_Dir_B977(
+        float3 Nrm_Object,
+        out float3 Nrm_World    )
+    {
+        Nrm_World=(mul((float3x3)UNITY_MATRIX_M, Nrm_Object));
+    }
+    //BLOCK_END Object_To_World_Dir
+
+    //BLOCK_BEGIN Object_To_World_Dir 968
+
+    void Object_To_World_Dir_B968(
+        float3 Dir_Object,
+        out float3 Dir_World    )
+    {
+        Dir_World=(mul((float3x3)UNITY_MATRIX_M, Dir_Object));
+    }
+    //BLOCK_END Object_To_World_Dir
+
+
+    VertexOutput vert(VertexInput vertInput)
+    {
+        UNITY_SETUP_INSTANCE_ID(vertInput);
+        VertexOutput o;
+        UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+
+        float3 Pos_World_Q964;
+        Object_To_World_Pos_B964(float3(0,0,0),Pos_World_Q964);
+
+        float3 Nrm_World_Q977;
+        Object_To_World_Dir_B977(vertInput.normal,Nrm_World_Q977);
+
+        float3 Dir_World_Q968;
+        Object_To_World_Dir_B968(vertInput.tangent,Dir_World_Q968);
+
+        float3 Dir_World_Q969;
+        Object_To_World_Dir_B968((normalize(cross(vertInput.normal,vertInput.tangent))),Dir_World_Q969);
+
+        // Conditional (#978)
+        float3 Result_Q978;
+        Result_Q978 = _Use_Global_Left_Index_ ? Global_Left_Index_Tip_Position.xyz : _Blob_Position_;
+        
+        // Conditional (#980)
+        float3 Result_Q980;
+        Result_Q980 = _Use_Global_Right_Index_ ? Global_Right_Index_Tip_Position.xyz : _Blob_Position_2_;
+        
+        // Length3 (#974)
+        float Length_Q974 = length(Dir_World_Q968);
+
+        // Length3 (#973)
+        float Length_Q973 = length(Dir_World_Q969);
+
+        // Normalize3 (#963)
+        float3 Normalized_Q963 = normalize(Nrm_World_Q977);
+
+        // Normalize3 (#961)
+        float3 Normalized_Q961 = normalize(Dir_World_Q968);
+
+        // Normalize3 (#962)
+        float3 Normalized_Q962 = normalize(Dir_World_Q969);
+
+        float3 Position_Q986;
+        float Near_Size_Q986;
+        float Inner_Fade_Q986;
+        float Fade_Q986;
+        float Pulse_Q986;
+        Choose_Blob_B986(vertInput.color,Result_Q978,Result_Q980,_Blob_Near_Size_,_Blob_Near_Size_2_,_Blob_Inner_Fade_,_Blob_Inner_Fade_2_,_Blob_Pulse_,_Blob_Pulse_2_,_Blob_Fade_,_Blob_Fade_2_,Position_Q986,Near_Size_Q986,Inner_Fade_Q986,Fade_Q986,Pulse_Q986);
+
+        // From_XY (#975)
+        float2 Vec2_Q975 = float2(Length_Q974,Length_Q973);
+
+        float3 Out_Position_Q985;
+        float2 Out_UV_Q985;
+        float3 Blob_Info_Q985;
+        float4 Clip_Info_Q985;
+        Blob_Vertex_B985(Pos_World_Q964,Normalized_Q963,Normalized_Q961,Normalized_Q962,_Blob_Intensity_,_Blob_Far_Size_,_Blob_Near_Distance_,_Blob_Far_Distance_,_Blob_Fade_Length_,vertInput.color,vertInput.uv0,Position_Q986,Near_Size_Q986,Inner_Fade_Q986,1.0,Fade_Q986,Pulse_Q986,Vec2_Q975,_Radius_,Out_Position_Q985,Out_UV_Q985,Blob_Info_Q985,Clip_Info_Q985);
+
+        float3 Position = Out_Position_Q985;
+        float2 UV = Out_UV_Q985;
+        float3 Normal = Blob_Info_Q985;
+        float3 Tangent = float3(0,0,0);
+        float3 Binormal = float3(0,0,0);
+        float4 Color = float4(1,1,1,1);
+        float4 Extra1 = Clip_Info_Q985;
+
+        o.pos = mul(UNITY_MATRIX_VP, float4(Position,1));
+        o.posWorld = Position;
+        o.normalWorld.xyz = Normal; o.normalWorld.w=1.0;
+        o.uv = UV;
+        o.extra1=Extra1;
+
+        return o;
+    }
+
+    //BLOCK_BEGIN Blob_Fragment 982
+
+    void Blob_Fragment_B982(
+        sampler2D Blob_Texture,
+        float3 Blob_Info,
+        float2 UV,
+        float Clip,
+        out float4 Blob_Color    )
+    {
+        float k = dot(UV,UV);
+        Blob_Color = (Clip * Blob_Info.y) * tex2D(Blob_Texture,float2(float2(sqrt(k),Blob_Info.x).x,1.0-float2(sqrt(k),Blob_Info.x).y))*(1.0-saturate(k));
+    }
+    //BLOCK_END Blob_Fragment
+
+    //BLOCK_BEGIN ClipToRoundedRect 984
+
+    void ClipToRoundedRect_B984(
+        float4 ClipInfo,
+        half Radius,
+        out half Result    )
+    {
+        half d = length(max(abs(ClipInfo.xy)-ClipInfo.zw,0));
+        half fw = max(fwidth(d),0.0001);
+        Result = 1.0-saturate((d-Radius)/fw);
+    }
+    //BLOCK_END ClipToRoundedRect
+
+
+    half4 frag(VertexOutput fragInput) : SV_Target
+    {
+        ClipAgainstPrimitive(fragInput.posWorld);
+
+        half4 result;
+
+        half Result_Q984;
+        #if defined(_ROUNDED_)
+          ClipToRoundedRect_B984(fragInput.extra1,_Radius_,Result_Q984);
+        #else
+          Result_Q984 = 1.0;
+        #endif
+
+        float4 Blob_Color_Q982;
+        Blob_Fragment_B982(_Blob_Texture_,fragInput.normalWorld.xyz,fragInput.uv,Result_Q984,Blob_Color_Q982);
+
+        float4 Out_Color = Blob_Color_Q982;
+        float Clip_Threshold = 0;
+        bool To_sRGB = false;
+
+        result = Out_Color;
+        return result;
+    }
+
+    ENDCG
+  }
+ }
+}

--- a/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasSlateProximityNonSrp.shader.meta
+++ b/com.microsoft.mrtk.graphicstools.unity/Runtime/Shaders/Non-CanvasSlateProximityNonSrp.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 5931f2bcf4a9d86498868baa4c535b12
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Overview
This PR provides developers an option to use non-SRP versions of any shader in cases where GPU instancing is more advantageous over SRP batcher (e.g. many instances of an object with same material).
As Unity concludes SRP compatibility on per-shader basis instead of per-shader-variant, the only way to expose this option is to keep a copy of a compatible shader, but break SRP compatibility in its source code. 
The PR has an AssetPostprocessor script for automatcally generating and updating the non-SRP variants of .shader scripts.
Refer to #234 for more details, that led to this decision. 

## Changes
- Add `NonSrpShaderAssetGenerator` script deriving from AssetPostprocessor, that removes CBUFFER statements from shader code and creates new shader script 
- Wrap CBUFFER statements in `GraphicsToolsStandardInput.hlsl`  in `#ifndef _NON_SRP`  for the shaders including it. Shaders themselves get patched with the define by the `NonSrpShaderAssetGenerator`
- Generate non SRP option script for all relevant shaders

## Usage
All the generated `*NonSrp.shader` files are already included in PR, but if you want to verify the `NonSrpShaderAssetGenerator` script, you can delete them and reimport the original SRP shaders. This will regenerate the NonSrp versions but with different  GUIDs in their .meta files. 
It's enough to edit original shaders with Unity opened. The script will automatically propagate the changes to the NonSrp shader files and the meta file's guid will remain unchanged.
 
`NonSrpShaderAssetGenerator` script can be disabled by commenting out the define at the top. 

Note: This repo's included Unity example project surprisingly shows its shipped shaders to be not SRP compatible when opened with Unity 2021.3.39f. The project's shaders show up correctly as SRP compatible when opening it with Unity 2022.3.36f.

# RenderDoc examples
So far we have discovered two classic scenarios, where the usage of SRP enabled shaders brings performance drop and non-SRP is preferred. Below are examples from our project with short analysis of RenderDoc captures.  
 
## 500 houses
Consider an example scene with 500 simple houses objects' instances. 4 different models and 1 material employed.  
<img width="881" height="500" alt="image" src="https://github.com/user-attachments/assets/5bd3c69b-c2f0-44c1-884a-53a80ba94c8c" />

With the SRP compatible `GraphicsToolsStandard.shader`  each house requires an individual `DrawIndexedInstanced(nIndexes, nInstances)` call. And although shader resources are being set once at the start of the batch, each call brings buffer setting calls. 
<img width="916" height="703" alt="image" src="https://github.com/user-attachments/assets/8a9f1d23-9657-4f74-a5d8-eaca1c1fa33f" />


With the generated SRP incompatible `GraphicsToolsStandardNonSrp.shader`  all the houses are rendered in just 5 `DrawIndexedInstanced(nIndexes, nInstances)` calls. This results in significant reduction of draw calls and considerable improvement of performance in FPS. 
<img width="573" height="208" alt="image" src="https://github.com/user-attachments/assets/9b931cff-42b3-474d-8538-829adf7bb471" />


# #TextMeshPro rendering

<img width="648" height="390" alt="image" src="https://github.com/user-attachments/assets/f7115f97-5c62-4d2e-a5f8-7a15cb41cf52" />

Using non-SRP TextmeshPro shader brings back dynamic batching of TextMeshPro objects with different strings of text.
Here half of the text labels are rendered in one go. 
<img width="1027" height="623" alt="image" src="https://github.com/user-attachments/assets/bcb4249d-5d0c-4b94-8289-a58d44d4fdf4" />

Whereas the normal 'GraphicsTools/TextMeshPro.shader' results in the exact number of draw calls, as the number of TMP objects. These make up x1.5 API calls compared to non-SRP 

<img width="857" height="339" alt="image" src="https://github.com/user-attachments/assets/a5ee9846-844c-4cfa-b7f2-eaf2a494a720" />

  
 